### PR TITLE
Fix remaining PR #20 review comments

### DIFF
--- a/include/cbor_tags/cbor.h
+++ b/include/cbor_tags/cbor.h
@@ -175,7 +175,9 @@ template <typename Iterator, typename Value> struct cast_view_iterator {
     friend bool operator==(const cast_view_iterator &lhs, const cast_view_iterator &rhs) { return lhs.it == rhs.it; }
 };
 
-template <std::ranges::input_range R> struct bstr_view : std::ranges::view_interface<bstr_view<R>> {
+template <std::ranges::input_range R>
+    requires std::ranges::common_range<R>
+struct bstr_view : std::ranges::view_interface<bstr_view<R>> {
     using value_type   = std::byte;
     using element_type = const std::byte;
     using iterator     = cast_view_iterator<std::ranges::iterator_t<const R>, value_type>;
@@ -195,7 +197,9 @@ template <std::ranges::input_range R> struct bstr_view : std::ranges::view_inter
     constexpr auto view() const { return std::ranges::subrange(begin(), end()); }
 };
 
-template <std::ranges::input_range R> struct tstr_view : std::ranges::view_interface<tstr_view<R>> {
+template <std::ranges::input_range R>
+    requires std::ranges::common_range<R>
+struct tstr_view : std::ranges::view_interface<tstr_view<R>> {
     using value_type   = char;
     using element_type = const char;
     using iterator     = cast_view_iterator<std::ranges::iterator_t<const R>, value_type>;

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -12,6 +12,7 @@
 #include <fmt/ranges.h>
 #include <functional>
 #include <iterator>
+#include <memory>
 #include <memory_resource>
 #include <nameof.hpp>
 #include <optional>
@@ -155,7 +156,11 @@ struct CDDLContext {
         return false;
     }
 
-    void clear() { definitions.clear(); }
+    void clear() {
+        std::destroy_at(std::addressof(definitions));
+        memory_resource.release();
+        std::construct_at(std::addressof(definitions), &memory_resource);
+    }
 
     template <typename T, typename Context> void register_type(CDDLOptions options, Context context) {
         (void)context;

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -27,6 +27,7 @@
 #include <map>
 #include <nameof.hpp>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <string_view>
@@ -38,6 +39,12 @@
 #include <variant>
 #include <vector>
 using namespace cbor::tags;
+
+template <typename R>
+concept CanInstantiateTextView = requires { typename tstr_view<R>; };
+
+template <typename R>
+concept CanInstantiateBinaryView = requires { typename bstr_view<R>; };
 
 TEST_CASE("CMake std reflection option enables native reflection") {
 #if CBOR_TAGS_USE_STD_REFLECTION == 1
@@ -62,11 +69,16 @@ TEST_CASE("Test IsSigned concept") {
 }
 
 TEST_CASE("Test IsTextString concept") {
+    using non_common_char_range = std::ranges::istream_view<char>;
+
     static_assert(IsTextString<std::string>);
     static_assert(IsTextString<std::string_view>);
     static_assert(IsTextString<std::basic_string_view<char>>);
     static_assert(IsConstTextView<tstr_view<std::deque<uint8_t>>>);
     static_assert(IsTextString<tstr_view<std::deque<std::byte>>>);
+    static_assert(std::ranges::input_range<non_common_char_range>);
+    static_assert(!std::ranges::common_range<non_common_char_range>);
+    static_assert(!CanInstantiateTextView<non_common_char_range>);
     static_assert(!IsTextString<std::basic_string_view<std::byte>>);
     static_assert(!IsTextString<std::vector<char>>);
     static_assert(!IsTextString<std::span<char>>);
@@ -74,6 +86,8 @@ TEST_CASE("Test IsTextString concept") {
 }
 
 TEST_CASE("Test IsBinaryString concept") {
+    using non_common_char_range = std::ranges::istream_view<char>;
+
     static_assert(IsBinaryString<std::basic_string<std::byte>>);
     static_assert(IsBinaryString<std::basic_string_view<std::byte>>);
     static_assert(IsBinaryString<std::vector<std::byte>>);
@@ -82,6 +96,7 @@ TEST_CASE("Test IsBinaryString concept") {
     static_assert(IsBinaryString<std::span<std::byte>>);
     static_assert(IsConstBinaryView<bstr_view<std::list<char>>>);
     static_assert(IsBinaryString<bstr_view<std::vector<char>>>);
+    static_assert(!CanInstantiateBinaryView<non_common_char_range>);
     static_assert(!IsBinaryString<std::vector<uint8_t>>);
     static_assert(!IsBinaryString<std::span<const uint8_t>>);
     static_assert(!IsBinaryString<std::basic_string_view<uint8_t>>);

--- a/test/test_visualization_coverage.cpp
+++ b/test/test_visualization_coverage.cpp
@@ -98,6 +98,10 @@ TEST_CASE("cddl context handles duplicate registration, copy, and clear") {
 
     context.clear();
     CHECK(context.definitions.empty());
+
+    context.register_type<VisualizationTagged>({}, std::ref(context));
+    CHECK(context.contains(nameof::nameof_type<VisualizationTagged>()));
+    CHECK_EQ(context.definitions.size(), 1);
 }
 
 TEST_CASE("buffer annotation handles empty input, text chunks, arrays, maps, and tags") {


### PR DESCRIPTION
Follow-up after #20 squash merge.

Changes:
- Constrain `bstr_view`/`tstr_view` to common input ranges, matching current iterator/end implementation.
- Release and rebuild the CDDL PMR definition arena in `CDDLContext::clear()`.
- Add regression coverage for both cases.

Validation:
- `cmake --build build-gcc --target tests --parallel`
- `ctest --test-dir build-gcc --output-on-failure`
- `scripts/format-cxx.sh --check`
- `scripts/lint-cxx.sh`
- benchmark compile with GCC 15 (`CBOR_TAGS_BUILD_BENCHMARKS=ON`)
