### PR TITLE
ci: test macOS and Windows C++20 and C++26

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: MacOS Tests (AppleClang 26/16)
+name: macOS Tests (AppleClang C++20/26)
 
 on:
   push:
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }} C++${{ matrix.cxx_standard }}
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
+        cxx_standard: [20, 26]
         config:
           - {
               name: "macOS AppleClang 26",
@@ -43,15 +44,129 @@ jobs:
     - name: Configure CMake
       shell: bash
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCBOR_TAGS_BUILD_TESTS=ON \
+        cxx_standard_args=(
+          -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }}
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON
+          -DCMAKE_CXX_EXTENSIONS=OFF
+        )
+        if [[ "${{ matrix.cxx_standard }}" == "26" ]]; then
+          # CMake 3.31 does not model AppleClang CXX26 yet; -std=c++2c is AppleClang's C++26-preview mode.
+          preview_flags="${RUNNER_TEMP}/cbor-tags-cxx26-preview.cmake"
+          printf '%s\n' 'add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-std=c++2c>")' > "${preview_flags}"
+          cxx_standard_args=(
+            -DCMAKE_CXX_STANDARD=23
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON
+            -DCMAKE_CXX_EXTENSIONS=OFF
+            -DCMAKE_PROJECT_INCLUDE="${preview_flags}"
+          )
+        fi
+        cmake -B build-cxx${{ matrix.cxx_standard }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCBOR_TAGS_BUILD_TESTS=ON \
+          "${cxx_standard_args[@]}" \
           -DCMAKE_C_COMPILER=${{ matrix.config.cc }} \
           -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }}
 
     - name: Build
       shell: bash
-      run: cmake --build build --config Release
+      run: cmake --build build-cxx${{ matrix.cxx_standard }} --config Release --parallel
 
     - name: Test
-      working-directory: build
       shell: bash
-      run: ctest -C Release --output-on-failure
+      run: ctest --test-dir build-cxx${{ matrix.cxx_standard }} -C Release --output-on-failure
+
+  optional-backends:
+    name: ${{ matrix.config.name }} C++${{ matrix.cxx_standard }} ${{ matrix.backend.name }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cxx_standard: [20, 26]
+        config:
+          - {
+              name: "macOS AppleClang 26",
+              cc: "clang",
+              cxx: "clang++",
+              xcode_version: "^26.0.0"
+            }
+          - {
+              name: "macOS AppleClang 16",
+              cc: "clang",
+              cxx: "clang++",
+              xcode_version: "^16.2.0"
+            }
+        backend:
+          - {
+              name: "Boost.PFR names",
+              id: "boost-pfr-names",
+              option: "CBOR_TAGS_USE_BOOST_PFR_NAMES",
+              feature: "boost-pfr-names"
+            }
+          - {
+              name: "magic_enum names",
+              id: "magic-enum-names",
+              option: "CBOR_TAGS_USE_MAGIC_ENUM_NAMES",
+              feature: "magic-enum-names"
+            }
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Setup CMake
+      uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: '3.31.5'
+
+    - name: Setup Xcode (macOS)
+      uses: maxim-lobanov/setup-xcode@v1.7.0
+      with:
+        xcode-version: ${{ matrix.config.xcode_version }}
+
+    - name: Bootstrap vcpkg
+      shell: bash
+      run: |
+        vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
+        git init "${RUNNER_TEMP}/vcpkg"
+        git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
+        git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"
+        git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
+        "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
+        echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"
+
+    - name: Configure CMake with ${{ matrix.backend.name }}
+      shell: bash
+      run: |
+        build_dir="build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }}"
+        cxx_standard_args=(
+          -DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }}
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON
+          -DCMAKE_CXX_EXTENSIONS=OFF
+        )
+        if [[ "${{ matrix.cxx_standard }}" == "26" ]]; then
+          # CMake 3.31 does not model AppleClang CXX26 yet; -std=c++2c is AppleClang's C++26-preview mode.
+          preview_flags="${RUNNER_TEMP}/cbor-tags-cxx26-preview.cmake"
+          printf '%s\n' 'add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-std=c++2c>")' > "${preview_flags}"
+          cxx_standard_args=(
+            -DCMAKE_CXX_STANDARD=23
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON
+            -DCMAKE_CXX_EXTENSIONS=OFF
+            -DCMAKE_PROJECT_INCLUDE="${preview_flags}"
+          )
+        fi
+        cmake -B "${build_dir}" \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCBOR_TAGS_BUILD_TESTS=ON \
+          -D${{ matrix.backend.option }}=ON \
+          "${cxx_standard_args[@]}" \
+          -DCMAKE_C_COMPILER=${{ matrix.config.cc }} \
+          -DCMAKE_CXX_COMPILER=${{ matrix.config.cxx }} \
+          -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+          -DVCPKG_MANIFEST_FEATURES=${{ matrix.backend.feature }}
+
+    - name: Build
+      shell: bash
+      run: cmake --build build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }} --config Release --parallel
+
+    - name: Test
+      shell: bash
+      run: ctest --test-dir build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }} -C Release --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,4 +1,4 @@
-name: Windows Tests (MSVC, Clang-CL)
+name: Windows Tests (MSVC/Clang-CL C++20/26)
 
 on:
   push:
@@ -8,11 +8,12 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name }} C++${{ matrix.cxx_standard }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
+        cxx_standard: [20, 26]
         config:
           - {
               name: "Windows MSVC",
@@ -35,22 +36,131 @@ jobs:
     - name: Configure CMake (Windows)
       shell: pwsh
       run: |
+        $buildDir = "build-cxx${{ matrix.cxx_standard }}"
         $arguments = @(
-          "-B", "build",
+          "-B", $buildDir,
           "-G", "Visual Studio 17 2022",
           "-A", "x64",
           "-DCBOR_TAGS_BUILD_TESTS=ON"
         )
+        if ("${{ matrix.cxx_standard }}" -eq "26") {
+          # CMake does not model MSVC CXX26 yet; /std:c++latest is MSVC's C++26-preview mode.
+          $arguments += @(
+            "-DCMAKE_CXX_STANDARD=23",
+            "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
+            "-DCMAKE_CXX_EXTENSIONS=OFF",
+            "-DCMAKE_CXX_FLAGS_INIT=/std:c++latest"
+          )
+        } else {
+          $arguments += @(
+            "-DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }}",
+            "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
+            "-DCMAKE_CXX_EXTENSIONS=OFF"
+          )
+        }
         if ("${{ matrix.config.toolset }}" -ne "") {
           $arguments += @("-T", "${{ matrix.config.toolset }}")
         }
         cmake @arguments
 
     - name: Build
-      shell: bash
-      run: cmake --build build --config Release
+      shell: pwsh
+      run: cmake --build build-cxx${{ matrix.cxx_standard }} --config Release --parallel
 
     - name: Test
-      working-directory: build
-      shell: bash
-      run: ctest -C Release --output-on-failure
+      shell: pwsh
+      run: ctest --test-dir build-cxx${{ matrix.cxx_standard }} -C Release --output-on-failure
+
+  optional-backends:
+    name: ${{ matrix.config.name }} C++${{ matrix.cxx_standard }} ${{ matrix.backend.name }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cxx_standard: [20, 26]
+        config:
+          - {
+              name: "Windows MSVC",
+              toolset: ""
+            }
+          - {
+              name: "Windows Clang-CL",
+              toolset: "ClangCL"
+            }
+        backend:
+          - {
+              name: "Boost.PFR names",
+              id: "boost-pfr-names",
+              option: "CBOR_TAGS_USE_BOOST_PFR_NAMES",
+              feature: "boost-pfr-names"
+            }
+          - {
+              name: "magic_enum names",
+              id: "magic-enum-names",
+              option: "CBOR_TAGS_USE_MAGIC_ENUM_NAMES",
+              feature: "magic-enum-names"
+            }
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Setup CMake
+      uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: '3.31.5'
+        useCloudCache: false
+
+    - name: Bootstrap vcpkg
+      shell: pwsh
+      run: |
+        $match = Select-String -Path vcpkg.json -Pattern '"builtin-baseline": "([^"]+)"'
+        $baseline = $match.Matches[0].Groups[1].Value
+        $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
+        git init $vcpkgRoot
+        git -C $vcpkgRoot remote add origin https://github.com/microsoft/vcpkg.git
+        git -C $vcpkgRoot fetch origin $baseline
+        git -C $vcpkgRoot checkout --detach FETCH_HEAD
+        & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
+        "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - name: Configure CMake with ${{ matrix.backend.name }}
+      shell: pwsh
+      run: |
+        $buildDir = "build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }}"
+        $toolchainFile = Join-Path $env:VCPKG_ROOT "scripts\buildsystems\vcpkg.cmake"
+        $arguments = @(
+          "-B", $buildDir,
+          "-G", "Visual Studio 17 2022",
+          "-A", "x64",
+          "-DCBOR_TAGS_BUILD_TESTS=ON",
+          "-D${{ matrix.backend.option }}=ON",
+          "-DCMAKE_TOOLCHAIN_FILE=$toolchainFile",
+          "-DVCPKG_MANIFEST_FEATURES=${{ matrix.backend.feature }}"
+        )
+        if ("${{ matrix.cxx_standard }}" -eq "26") {
+          # CMake does not model MSVC CXX26 yet; /std:c++latest is MSVC's C++26-preview mode.
+          $arguments += @(
+            "-DCMAKE_CXX_STANDARD=23",
+            "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
+            "-DCMAKE_CXX_EXTENSIONS=OFF",
+            "-DCMAKE_CXX_FLAGS_INIT=/std:c++latest"
+          )
+        } else {
+          $arguments += @(
+            "-DCMAKE_CXX_STANDARD=${{ matrix.cxx_standard }}",
+            "-DCMAKE_CXX_STANDARD_REQUIRED=ON",
+            "-DCMAKE_CXX_EXTENSIONS=OFF"
+          )
+        }
+        if ("${{ matrix.config.toolset }}" -ne "") {
+          $arguments += @("-T", "${{ matrix.config.toolset }}")
+        }
+        cmake @arguments
+
+    - name: Build
+      shell: pwsh
+      run: cmake --build build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }} --config Release --parallel
+
+    - name: Test
+      shell: pwsh
+      run: ctest --test-dir build-${{ matrix.backend.id }}-cxx${{ matrix.cxx_standard }} -C Release --output-on-failure

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -109,6 +109,13 @@ struct CDDLContext {
         std::pmr::string cddl;
         DefinitionState  state{DefinitionState::visiting};
         bool             recursive_reference{false};
+
+        definition_cddl_pair() = default;
+
+        definition_cddl_pair(std::pmr::string key_, std::pmr::string name_, std::pmr::string cddl_,
+                             DefinitionState state_ = DefinitionState::visiting, bool recursive_reference_ = false)
+            : key(std::move(key_)), name(std::move(name_)), cddl(std::move(cddl_)), state(state_),
+              recursive_reference(recursive_reference_) {}
     };
 
     std::array<std::byte, 2000>           buffer;

--- a/test/test_cddl.cpp
+++ b/test/test_cddl.cpp
@@ -21,7 +21,7 @@
 
 using namespace cbor::tags;
 
-namespace {
+namespace cbor_tags_test_cddl {
 template <typename T> std::string cddl_schema_inline() {
     fmt::memory_buffer buffer;
     cddl_schema_to<T>(buffer, {.row_options = {.format_by_rows = false}});
@@ -78,14 +78,14 @@ enum class CDDLUnorderedChoice : std::int8_t { high = 5, low = 1, negative = -1 
 enum class CDDLWideMagicEnum : std::uint16_t { low = 1, high = 1000 };
 
 #if CBOR_TAGS_HAS_MAGIC_ENUM_NAMES
-} // namespace
+} // namespace cbor_tags_test_cddl
 
-template <> struct magic_enum::customize::enum_range<CDDLWideMagicEnum> {
+template <> struct magic_enum::customize::enum_range<cbor_tags_test_cddl::CDDLWideMagicEnum> {
     static constexpr int min = 0;
     static constexpr int max = 1000;
 };
 
-namespace {
+namespace cbor_tags_test_cddl {
 #endif
 
 struct CDDLEnums {
@@ -316,7 +316,9 @@ static_assert(detail::named_flattened_extension_count<CDDLNestedMapScopedExtensi
 static_assert(detail::named_flattened_extension_count<CDDLRootWithTwoExtensions>() == 2U);
 
 #endif
-} // namespace
+} // namespace cbor_tags_test_cddl
+
+using namespace cbor_tags_test_cddl;
 
 struct B129058 {
     static constexpr std::uint64_t cbor_tag = 140;


### PR DESCRIPTION
## Summary
- carry forward the named-reflection portability fix on top of the merged `master`
- expand macOS CI to run full C++20 and C++26 test matrices
- add macOS/Windows full-test optional-backend jobs for Boost.PFR names and magic_enum through pinned vcpkg manifest features
- run Windows C++26 lanes with MSVC/ClangCL `/std:c++latest`, since CMake does not currently model `CXX_STANDARD=26` for MSVC-family generators