### PR TITLE
feat(codecs): add opt-in std::expected support

### DIFF
--- a/.github/actions/bootstrap-vcpkg/action.yml
+++ b/.github/actions/bootstrap-vcpkg/action.yml
@@ -1,0 +1,78 @@
+name: Bootstrap vcpkg
+description: Fetch the manifest baseline, bootstrap vcpkg, and export VCPKG_ROOT.
+
+inputs:
+  baseline_file:
+    description: File containing the vcpkg builtin-baseline.
+    default: vcpkg.json
+  fetch_attempts:
+    description: Number of git fetch attempts before failing.
+    default: "3"
+  retry_delay_seconds:
+    description: Base delay between retries. The delay is multiplied by the attempt number.
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Bootstrap vcpkg (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        baseline_file="${{ inputs.baseline_file }}"
+        fetch_attempts="${{ inputs.fetch_attempts }}"
+        retry_delay_seconds="${{ inputs.retry_delay_seconds }}"
+        vcpkg_root="${RUNNER_TEMP}/vcpkg"
+        vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' "${baseline_file}" | head -n 1)"
+        if [[ -z "${vcpkg_baseline}" ]]; then
+          echo "::error::Could not find builtin-baseline in ${baseline_file}"
+          exit 1
+        fi
+
+        rm -rf "${vcpkg_root}"
+        git init "${vcpkg_root}"
+        git -C "${vcpkg_root}" remote add origin https://github.com/microsoft/vcpkg.git
+        for ((attempt = 1; attempt <= fetch_attempts; attempt++)); do
+          if git -C "${vcpkg_root}" fetch origin "${vcpkg_baseline}"; then
+            break
+          fi
+          if (( attempt == fetch_attempts )); then
+            exit 1
+          fi
+          sleep "$((attempt * retry_delay_seconds))"
+        done
+        git -C "${vcpkg_root}" checkout --detach FETCH_HEAD
+        "${vcpkg_root}/bootstrap-vcpkg.sh" -disableMetrics
+        echo "VCPKG_ROOT=${vcpkg_root}" >> "${GITHUB_ENV}"
+
+    - name: Bootstrap vcpkg (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $baselineFile = "${{ inputs.baseline_file }}"
+        $fetchAttempts = [int]"${{ inputs.fetch_attempts }}"
+        $retryDelaySeconds = [int]"${{ inputs.retry_delay_seconds }}"
+        $match = Select-String -Path $baselineFile -Pattern '"builtin-baseline": "([^"]+)"'
+        if ($null -eq $match) {
+          Write-Error "Could not find builtin-baseline in $baselineFile"
+          exit 1
+        }
+
+        $baseline = $match.Matches[0].Groups[1].Value
+        $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
+        Remove-Item -Recurse -Force $vcpkgRoot -ErrorAction SilentlyContinue
+        git init $vcpkgRoot
+        git -C $vcpkgRoot remote add origin https://github.com/microsoft/vcpkg.git
+        for ($attempt = 1; $attempt -le $fetchAttempts; $attempt++) {
+          git -C $vcpkgRoot fetch origin $baseline
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq $fetchAttempts) {
+            exit $LASTEXITCODE
+          }
+          Start-Sleep -Seconds ($attempt * $retryDelaySeconds)
+        }
+        git -C $vcpkgRoot checkout --detach FETCH_HEAD
+        & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
+        "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -128,7 +128,15 @@ jobs:
         vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"
+        for attempt in 1 2 3; do
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+            break
+          fi
+          if [[ "${attempt}" == "3" ]]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
         git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
         "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
         echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -129,7 +129,7 @@ jobs:
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
         for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
             break
           fi
           if [[ "${attempt}" == "3" ]]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -123,23 +123,7 @@ jobs:
         xcode-version: ${{ matrix.config.xcode_version }}
 
     - name: Bootstrap vcpkg
-      shell: bash
-      run: |
-        vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
-        git init "${RUNNER_TEMP}/vcpkg"
-        git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
-            break
-          fi
-          if [[ "${attempt}" == "3" ]]; then
-            exit 1
-          fi
-          sleep "$((attempt * 10))"
-        done
-        git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
-        "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-        echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"
+      uses: ./.github/actions/bootstrap-vcpkg
 
     - name: Configure CMake with ${{ matrix.backend.name }}
       shell: bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -239,7 +239,15 @@ jobs:
         vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"
+        for attempt in 1 2 3; do
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+            break
+          fi
+          if [[ "${attempt}" == "3" ]]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
         git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
         "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
         echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"
@@ -283,7 +291,15 @@ jobs:
         vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"
+        for attempt in 1 2 3; do
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+            break
+          fi
+          if [[ "${attempt}" == "3" ]]; then
+            exit 1
+          fi
+          sleep "$((attempt * 10))"
+        done
         git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
         "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
         echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -240,7 +240,7 @@ jobs:
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
         for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
             break
           fi
           if [[ "${attempt}" == "3" ]]; then
@@ -292,7 +292,7 @@ jobs:
         git init "${RUNNER_TEMP}/vcpkg"
         git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
         for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch --depth=1 origin "${vcpkg_baseline}"; then
+          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
             break
           fi
           if [[ "${attempt}" == "3" ]]; then

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -234,23 +234,7 @@ jobs:
         sudo apt-get install -y ccache curl g++ gcc ninja-build tar unzip zip
 
     - name: Bootstrap vcpkg
-      shell: bash
-      run: |
-        vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
-        git init "${RUNNER_TEMP}/vcpkg"
-        git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
-            break
-          fi
-          if [[ "${attempt}" == "3" ]]; then
-            exit 1
-          fi
-          sleep "$((attempt * 10))"
-        done
-        git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
-        "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-        echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"
+      uses: ./.github/actions/bootstrap-vcpkg
 
     - name: Configure CMake with Boost.PFR names
       shell: bash
@@ -286,23 +270,7 @@ jobs:
         sudo apt-get install -y ccache curl g++ gcc ninja-build tar unzip zip
 
     - name: Bootstrap vcpkg
-      shell: bash
-      run: |
-        vcpkg_baseline="$(sed -n 's/.*"builtin-baseline": "\([^"]*\)".*/\1/p' vcpkg.json)"
-        git init "${RUNNER_TEMP}/vcpkg"
-        git -C "${RUNNER_TEMP}/vcpkg" remote add origin https://github.com/microsoft/vcpkg.git
-        for attempt in 1 2 3; do
-          if git -C "${RUNNER_TEMP}/vcpkg" fetch origin "${vcpkg_baseline}"; then
-            break
-          fi
-          if [[ "${attempt}" == "3" ]]; then
-            exit 1
-          fi
-          sleep "$((attempt * 10))"
-        done
-        git -C "${RUNNER_TEMP}/vcpkg" checkout --detach FETCH_HEAD
-        "${RUNNER_TEMP}/vcpkg/bootstrap-vcpkg.sh" -disableMetrics
-        echo "VCPKG_ROOT=${RUNNER_TEMP}/vcpkg" >> "${GITHUB_ENV}"
+      uses: ./.github/actions/bootstrap-vcpkg
 
     - name: Configure CMake with magic_enum names
       shell: bash

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -152,6 +152,41 @@ jobs:
             ctest --test-dir /tmp/build -C Release --output-on-failure
           '
 
+  std-expected-cxx23:
+    name: Ubuntu GCC 15 C++23 std::expected tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Build and test std::expected extension in C++23
+      shell: bash
+      run: |
+        docker run --rm \
+          -v "${{ github.workspace }}:/work:ro,z" \
+          -w /work \
+          ubuntu:26.04 \
+          bash -euxo pipefail -c '
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              ca-certificates \
+              cmake \
+              git \
+              ninja-build \
+              gcc-15 \
+              g++-15
+            cmake -S /work -B /tmp/build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCBOR_TAGS_BUILD_TESTS=ON \
+              -DCMAKE_CXX_STANDARD=23 \
+              -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+              -DCMAKE_C_COMPILER=gcc-15 \
+              -DCMAKE_CXX_COMPILER=g++-15
+            cmake --build /tmp/build --parallel
+            ctest --test-dir /tmp/build -C Release --output-on-failure
+          '
+
   gcc-std-reflection:
     name: Fedora 44 GCC C++26 reflection tests
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -119,7 +119,7 @@ jobs:
         git init $vcpkgRoot
         git -C $vcpkgRoot remote add origin https://github.com/microsoft/vcpkg.git
         for ($attempt = 1; $attempt -le 3; $attempt++) {
-          git -C $vcpkgRoot fetch --depth=1 origin $baseline
+          git -C $vcpkgRoot fetch origin $baseline
           if ($LASTEXITCODE -eq 0) {
             break
           }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,16 @@ jobs:
         $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
         git init $vcpkgRoot
         git -C $vcpkgRoot remote add origin https://github.com/microsoft/vcpkg.git
-        git -C $vcpkgRoot fetch origin $baseline
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+          git -C $vcpkgRoot fetch --depth=1 origin $baseline
+          if ($LASTEXITCODE -eq 0) {
+            break
+          }
+          if ($attempt -eq 3) {
+            exit $LASTEXITCODE
+          }
+          Start-Sleep -Seconds ($attempt * 10)
+        }
         git -C $vcpkgRoot checkout --detach FETCH_HEAD
         & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
         "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -111,26 +111,7 @@ jobs:
         useCloudCache: false
 
     - name: Bootstrap vcpkg
-      shell: pwsh
-      run: |
-        $match = Select-String -Path vcpkg.json -Pattern '"builtin-baseline": "([^"]+)"'
-        $baseline = $match.Matches[0].Groups[1].Value
-        $vcpkgRoot = Join-Path $env:RUNNER_TEMP "vcpkg"
-        git init $vcpkgRoot
-        git -C $vcpkgRoot remote add origin https://github.com/microsoft/vcpkg.git
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          git -C $vcpkgRoot fetch origin $baseline
-          if ($LASTEXITCODE -eq 0) {
-            break
-          }
-          if ($attempt -eq 3) {
-            exit $LASTEXITCODE
-          }
-          Start-Sleep -Seconds ($attempt * 10)
-        }
-        git -C $vcpkgRoot checkout --detach FETCH_HEAD
-        & (Join-Path $vcpkgRoot "bootstrap-vcpkg.bat") -disableMetrics
-        "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      uses: ./.github/actions/bootstrap-vcpkg
 
     - name: Configure CMake with ${{ matrix.backend.name }}
       shell: pwsh

--- a/README.md
+++ b/README.md
@@ -221,6 +221,32 @@ int main() {
 > [!NOTE]
 > The encoding is basically just a "tuple cast", that a fold expression apply encode(...) to, for each member. The definition of the struct is what sets the expectation when decoding the data. Any mismatch when decoding will result in a status_code, i.e result.error(). An incomplete decode will result in status_code "incomplete". The primary decoder is still a one-shot API: retry/resume after incomplete input is reserved for a future explicit resumable decoder entry point.
 
+### C++23 `std::expected` Extension
+`std::expected<T, E>` support is available in C++23 and newer through an explicit codec extension:
+
+```cpp
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/std_expected.h"
+
+#include <expected>
+#include <string>
+#include <vector>
+
+using namespace cbor::tags;
+using namespace cbor::tags::ext::std_expected;
+
+std::vector<std::byte> buffer;
+auto enc = make_encoder<std_expected_codec>(buffer);
+enc(std::expected<int, std::string>{42});
+
+std::expected<int, std::string> decoded;
+auto dec = make_decoder<std_expected_codec>(buffer);
+dec(decoded);
+```
+
+The extension encodes expected values as `[true, value]` and errors as `[false, error]`. `std::expected<void, E>` uses `[true, null]` for success.
+
 ### Version Handling with Variants
 The example below show how cbor tags can be utilized for version handling. There is no explicit version handling in the protocol, instead a tag can represent a new object, which *you* the application developer can, by your definition, decide to be a new version of an object.
 ```cpp

--- a/include/cbor_tags/extensions/std_expected.h
+++ b/include/cbor_tags/extensions/std_expected.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include "cbor_tags/cbor.h"
+#include "cbor_tags/cbor_extensions.h"
+
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#if !defined(__has_include)
+#error "cbor_tags std::expected support requires __has_include and C++23 <expected>"
+#endif
+
+#if !__has_include(<expected>)
+#error "cbor_tags std::expected support requires C++23 <expected>"
+#endif
+
+#include <expected>
+
+#if !defined(__cpp_lib_expected) || __cpp_lib_expected < 202202L
+#error "cbor_tags std::expected support requires C++23 std::expected"
+#endif
+
+namespace cbor::tags::ext::std_expected {
+
+namespace detail {
+
+template <typename T, typename E>
+concept DecodableStdExpected = std::default_initializable<E> && (std::is_void_v<T> || std::default_initializable<T>);
+
+} // namespace detail
+
+template <typename Self> struct std_expected_codec : cbor_codec_mixin_base<Self> {
+    using cbor_codec_mixin_base<Self>::decode;
+    using cbor_codec_mixin_base<Self>::encode;
+
+    template <typename T, typename E> constexpr void encode(const std::expected<T, E> &value) {
+        auto &enc = static_cast<Self &>(*this);
+
+        enc.encode(as_array{2});
+        enc.encode(value.has_value());
+        if (value.has_value()) {
+            if constexpr (std::is_void_v<T>) {
+                enc.encode(nullptr);
+            } else {
+                enc.encode(*value);
+            }
+        } else {
+            enc.encode(value.error());
+        }
+    }
+
+    template <typename T, typename E>
+        requires detail::DecodableStdExpected<T, E>
+    [[nodiscard]] constexpr status_code decode(std::expected<T, E> &value, major_type major, std::byte additional_info) {
+        auto &dec = static_cast<Self &>(*this);
+
+        if (major != major_type::Array) {
+            return status_code::no_match_for_array_on_buffer;
+        }
+
+        if (additional_info == static_cast<std::byte>(31)) {
+            auto status = decode_payload(value);
+            if (status != status_code::success) {
+                return status;
+            }
+
+            const auto [end_major, end_info] = dec.read_initial_byte();
+            if (end_major != major_type::Simple || end_info != static_cast<std::byte>(31)) {
+                return status_code::unexpected_group_size;
+            }
+            return status_code::success;
+        }
+
+        const auto size = dec.decode_unsigned(additional_info);
+        if (size != 2U) {
+            return status_code::unexpected_group_size;
+        }
+
+        return decode_payload(value);
+    }
+
+  private:
+    template <typename T, typename E>
+        requires detail::DecodableStdExpected<T, E>
+    [[nodiscard]] constexpr status_code decode_payload(std::expected<T, E> &value) {
+        auto &dec = static_cast<Self &>(*this);
+
+        bool has_value{};
+        auto status = dec.decode(has_value);
+        if (status != status_code::success) {
+            return status;
+        }
+
+        if (has_value) {
+            if constexpr (std::is_void_v<T>) {
+                std::nullptr_t decoded_value{};
+                status = dec.decode(decoded_value);
+                if (status == status_code::success) {
+                    value = std::expected<void, E>{};
+                }
+            } else {
+                T decoded_value{};
+                status = dec.decode(decoded_value);
+                if (status == status_code::success) {
+                    value = std::expected<T, E>{std::move(decoded_value)};
+                }
+            }
+        } else {
+            E decoded_error{};
+            status = dec.decode(decoded_error);
+            if (status == status_code::success) {
+                value = std::unexpected<E>{std::move(decoded_error)};
+            }
+        }
+
+        return status;
+    }
+};
+
+} // namespace cbor::tags::ext::std_expected

--- a/test/test_header_split_std_expected.cpp
+++ b/test/test_header_split_std_expected.cpp
@@ -1,0 +1,29 @@
+#if __has_include(<expected>)
+#include <expected>
+#endif
+
+#if defined(__cpp_lib_expected) && __cpp_lib_expected >= 202202L
+
+#include <cbor_tags/cbor_decoder.h>
+#include <cbor_tags/cbor_encoder.h>
+#include <cbor_tags/extensions/std_expected.h>
+#include <cstddef>
+#include <doctest/doctest.h>
+#include <expected>
+#include <string>
+#include <vector>
+
+TEST_CASE("std::expected split header is directly usable") {
+    std::vector<std::byte>          encoded;
+    std::expected<int, std::string> value{42};
+    auto                            enc = cbor::tags::make_encoder<cbor::tags::ext::std_expected::std_expected_codec>(encoded);
+    REQUIRE(enc(value));
+
+    std::expected<int, std::string> decoded{};
+    auto                            dec = cbor::tags::make_decoder<cbor::tags::ext::std_expected::std_expected_codec>(encoded);
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded.has_value());
+    CHECK_EQ(*decoded, 42);
+}
+
+#endif

--- a/test/test_std_expected.cpp
+++ b/test/test_std_expected.cpp
@@ -1,0 +1,205 @@
+#if __has_include(<expected>)
+#include <expected>
+#endif
+
+#if defined(__cpp_lib_expected) && __cpp_lib_expected >= 202202L
+
+#include "test_util.h"
+
+#include <cbor_tags/cbor_decoder.h>
+#include <cbor_tags/cbor_encoder.h>
+#include <cbor_tags/extensions/std_expected.h>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <doctest/doctest.h>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+using namespace cbor::tags;
+using namespace cbor::tags::ext::std_expected;
+
+namespace {
+
+template <typename Enc, typename T>
+concept CanEncode = requires(Enc &enc, const T &value) { enc.encode(value); };
+
+template <typename Dec, typename T>
+concept CanDecode = requires(Dec &dec, T &value, major_type major, std::byte additional_info) {
+    { dec.decode(value, major, additional_info) } -> std::same_as<status_code>;
+};
+
+struct expected_holder {
+    std::uint64_t                             id{};
+    std::expected<std::string, std::uint64_t> result{};
+};
+
+template <typename T, typename E> std::vector<std::byte> encode_expected(const std::expected<T, E> &value) {
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder<std_expected_codec>(buffer);
+    REQUIRE(enc(value));
+    return buffer;
+}
+
+template <typename T, typename E> std::expected<T, E> decode_expected(const std::vector<std::byte> &buffer) {
+    std::expected<T, E> decoded{};
+    auto                dec = make_decoder<std_expected_codec>(buffer);
+    REQUIRE(dec(decoded));
+    return decoded;
+}
+
+template <typename T, typename E> void check_decode_error(const char *hex, status_code expected_status) {
+    const auto          bytes = to_bytes(hex);
+    std::expected<T, E> decoded{};
+    auto                dec    = make_decoder<std_expected_codec>(bytes);
+    const auto          result = dec(decoded);
+
+    CAPTURE(hex);
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), expected_status);
+}
+
+} // namespace
+
+TEST_CASE("std::expected codec is explicit opt in") {
+    using expected_type     = std::expected<std::uint64_t, std::string>;
+    using default_encoder   = decltype(make_encoder(std::declval<std::vector<std::byte> &>()));
+    using extension_encoder = decltype(make_encoder<std_expected_codec>(std::declval<std::vector<std::byte> &>()));
+    using default_decoder   = decltype(make_decoder(std::declval<std::vector<std::byte> &>()));
+    using extension_decoder = decltype(make_decoder<std_expected_codec>(std::declval<std::vector<std::byte> &>()));
+
+    static_assert(!CanEncode<default_encoder, expected_type>);
+    static_assert(CanEncode<extension_encoder, expected_type>);
+    static_assert(!CanDecode<default_decoder, expected_type>);
+    static_assert(CanDecode<extension_decoder, expected_type>);
+}
+
+TEST_CASE("std::expected codec roundtrips value and error alternatives") {
+    {
+        const std::expected<std::uint64_t, std::string> value{42U};
+        const auto                                      encoded = encode_expected(value);
+
+        CHECK_EQ(to_hex(encoded), "82f5182a");
+
+        const auto decoded = decode_expected<std::uint64_t, std::string>(encoded);
+        REQUIRE(decoded.has_value());
+        CHECK_EQ(*decoded, 42U);
+    }
+
+    {
+        const std::expected<std::uint64_t, std::string> value{std::unexpected<std::string>{"bad"}};
+        const auto                                      encoded = encode_expected(value);
+
+        CHECK_EQ(to_hex(encoded), "82f463626164");
+
+        const auto decoded = decode_expected<std::uint64_t, std::string>(encoded);
+        REQUIRE_FALSE(decoded.has_value());
+        CHECK_EQ(decoded.error(), "bad");
+    }
+}
+
+TEST_CASE("std::expected codec supports void success payloads") {
+    {
+        const std::expected<void, std::string> value{};
+        const auto                             encoded = encode_expected(value);
+
+        CHECK_EQ(to_hex(encoded), "82f5f6");
+
+        std::expected<void, std::string> decoded{std::unexpected<std::string>{"before"}};
+        auto                             dec = make_decoder<std_expected_codec>(encoded);
+        REQUIRE(dec(decoded));
+        CHECK(decoded.has_value());
+    }
+
+    {
+        const std::expected<void, std::string> value{std::unexpected<std::string>{"failed"}};
+        const auto                             encoded = encode_expected(value);
+
+        CHECK_EQ(to_hex(encoded), "82f4666661696c6564");
+
+        std::expected<void, std::string> decoded{};
+        auto                             dec = make_decoder<std_expected_codec>(encoded);
+        REQUIRE(dec(decoded));
+        REQUIRE_FALSE(decoded.has_value());
+        CHECK_EQ(decoded.error(), "failed");
+    }
+}
+
+TEST_CASE("std::expected codec composes with nested expected and optional payloads") {
+    {
+        using inner_type = std::expected<int, std::string>;
+        using outer_type = std::expected<inner_type, std::string>;
+
+        const outer_type value{inner_type{std::unexpected<std::string>{"inner"}}};
+        const auto       encoded = encode_expected(value);
+
+        const auto decoded = decode_expected<inner_type, std::string>(encoded);
+        REQUIRE(decoded.has_value());
+        REQUIRE_FALSE(decoded->has_value());
+        CHECK_EQ(decoded->error(), "inner");
+    }
+
+    {
+        using expected_type = std::expected<std::optional<int>, std::string>;
+
+        const expected_type value{std::optional<int>{}};
+        const auto          encoded = encode_expected(value);
+
+        const auto decoded = decode_expected<std::optional<int>, std::string>(encoded);
+        REQUIRE(decoded.has_value());
+        CHECK_FALSE(decoded->has_value());
+    }
+}
+
+TEST_CASE("std::expected codec composes inside aggregate fields") {
+    const expected_holder value{7U, std::unexpected<std::uint64_t>{99U}};
+
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder<std_expected_codec>(buffer);
+    REQUIRE(enc(value));
+
+    expected_holder decoded{};
+    auto            dec = make_decoder<std_expected_codec>(buffer);
+    REQUIRE(dec(decoded));
+    CHECK_EQ(decoded.id, 7U);
+    REQUIRE_FALSE(decoded.result.has_value());
+    CHECK_EQ(decoded.result.error(), 99U);
+}
+
+TEST_CASE("std::expected codec decodes from non-contiguous buffers") {
+    const std::expected<std::string, std::uint64_t> value{std::string{"ok"}};
+    const auto                                      encoded = encode_expected(value);
+    const std::deque<std::byte>                     input(encoded.begin(), encoded.end());
+
+    std::expected<std::string, std::uint64_t> decoded;
+    auto                                      dec = make_decoder<std_expected_codec>(input);
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded.has_value());
+    CHECK_EQ(*decoded, "ok");
+}
+
+TEST_CASE("std::expected codec accepts indefinite two-item arrays") {
+    const auto bytes = to_bytes("9ff5182aff");
+
+    std::expected<int, std::string> decoded{};
+    auto                            dec = make_decoder<std_expected_codec>(bytes);
+
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded.has_value());
+    CHECK_EQ(*decoded, 42);
+}
+
+TEST_CASE("std::expected codec reports malformed wrappers and payloads") {
+    check_decode_error<std::uint64_t, std::string>("a0", status_code::no_match_for_array_on_buffer);
+    check_decode_error<std::uint64_t, std::string>("81f5", status_code::unexpected_group_size);
+    check_decode_error<std::uint64_t, std::string>("83f5182a00", status_code::unexpected_group_size);
+    check_decode_error<std::uint64_t, std::string>("8200182a", status_code::no_match_for_simple_on_buffer);
+    check_decode_error<std::uint64_t, std::string>("82f563626164", status_code::no_match_for_uint_on_buffer);
+    check_decode_error<std::uint64_t, std::string>("82f4182a", status_code::no_match_for_tstr_on_buffer);
+    check_decode_error<std::uint64_t, std::string>("9ff5182a00ff", status_code::unexpected_group_size);
+}
+
+#endif


### PR DESCRIPTION
## Summary
- Add `cbor_tags/extensions/std_expected.h` with an explicit `std_expected_codec` for C++23 `std::expected<T, E>`.
- Encode expected success/error states as `[true, value]` and `[false, error]`, with `[true, null]` for `std::expected<void, E>` success.
- Cover value/error roundtrips, void success, nested expected payloads, optional payloads, aggregate fields, non-contiguous input, indefinite arrays, malformed wrappers, and split-header use.
- Add a focused Ubuntu GCC 15 C++23 CI job so the exact supported mode runs in PR checks.

## Validation
- `ctest --test-dir build-std-expected-cxx20 --output-on-failure`
- `ctest --test-dir build-std-expected-cxx23 --output-on-failure`
- `ctest --test-dir build-std-expected-cxx26 --output-on-failure`
- Ubuntu 26.04 Docker GCC 15 C++23 build/test path from the new workflow
- `scripts/format-cxx.sh --check`
- `scripts/lint-cxx.sh`
- `git diff --check`