### PR TITLE
feat(variant): support explicit variant traits

### DIFF
--- a/doc/variant_handling.md
+++ b/doc/variant_handling.md
@@ -23,6 +23,50 @@ Alternative shapes must still be unambiguous. A variant with two alternatives
 that both match the same tag or the same catch-all shape is rejected at compile
 time where the type system exposes that collision.
 
+## Non-Std Variants
+
+Only `std::variant` is recognized automatically. Other union types must opt in
+with `cbor::tags::variant_traits`; structural `index()`/`visit()` lookalikes are
+not treated as variants by default. Without the specialization, normal overload
+resolution applies, so an aggregate wrapper may encode as an aggregate.
+
+```cpp
+template <class... Ts> struct my_variant {
+    std::variant<Ts...> storage;
+};
+
+template <class... Ts>
+struct cbor::tags::variant_traits<my_variant<Ts...>> {
+    static constexpr std::size_t size = sizeof...(Ts);
+
+    template <std::size_t I>
+    using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+    static std::size_t index(my_variant<Ts...> const& v) {
+        return v.storage.index();
+    }
+
+    template <std::size_t I, class V>
+    static decltype(auto) get(V&& v) {
+        return std::get<I>(std::forward<V>(v).storage);
+    }
+
+    template <class Visitor, class... Vs>
+    static decltype(auto) visit(Visitor&& visitor, Vs&&... vs) {
+        return std::visit(std::forward<Visitor>(visitor),
+                          std::forward<Vs>(vs).storage...);
+    }
+
+    template <std::size_t I, class U>
+    static void assign(my_variant<Ts...>& v, U&& value) {
+        v.storage.template emplace<I>(std::forward<U>(value));
+    }
+};
+```
+
+`visit` must support both single-variant and multi-variant calls because
+encoding uses the former and comparison helpers use the latter.
+
 ## Compile-Time Dispatch
 
 Below is "pseudo code" that can be investigated with [godbolt](https://godbolt.org/). The code shows how you can optimize away unused code paths with `if constexpr`; in this case the code paths are constrained by the variant type.

--- a/doc/variant_handling.md
+++ b/doc/variant_handling.md
@@ -31,41 +31,47 @@ not treated as variants by default. Without the specialization, normal overload
 resolution applies, so an aggregate wrapper may encode as an aggregate.
 
 ```cpp
-template <class... Ts> struct my_variant {
-    std::variant<Ts...> storage;
-};
+#include <boost/variant2/variant.hpp>
 
 template <class... Ts>
-struct cbor::tags::variant_traits<my_variant<Ts...>> {
-    static constexpr std::size_t size = sizeof...(Ts);
+struct cbor::tags::variant_traits<boost::variant2::variant<Ts...>> {
+    using variant_type = boost::variant2::variant<Ts...>;
+
+    static constexpr std::size_t size =
+        boost::variant2::variant_size_v<variant_type>;
 
     template <std::size_t I>
-    using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
+    using alternative =
+        boost::variant2::variant_alternative_t<I, variant_type>;
 
-    static std::size_t index(my_variant<Ts...> const& v) {
-        return v.storage.index();
+    static std::size_t index(variant_type const& value) {
+        return value.index();
     }
 
     template <std::size_t I, class V>
-    static decltype(auto) get(V&& v) {
-        return std::get<I>(std::forward<V>(v).storage);
+    static decltype(auto) get(V&& value) {
+        return boost::variant2::get<I>(std::forward<V>(value));
     }
 
     template <class Visitor, class... Vs>
-    static decltype(auto) visit(Visitor&& visitor, Vs&&... vs) {
-        return std::visit(std::forward<Visitor>(visitor),
-                          std::forward<Vs>(vs).storage...);
+    static decltype(auto) visit(Visitor&& visitor, Vs&&... values) {
+        return boost::variant2::visit(std::forward<Visitor>(visitor),
+                                      std::forward<Vs>(values)...);
     }
 
     template <std::size_t I, class U>
-    static void assign(my_variant<Ts...>& v, U&& value) {
-        v.storage.template emplace<I>(std::forward<U>(value));
+    static void assign(variant_type& value, U&& decoded) {
+        value.template emplace<I>(std::forward<U>(decoded));
     }
 };
 ```
 
 `visit` must support both single-variant and multi-variant calls because
 encoding uses the former and comparison helpers use the latter.
+
+For raw `union` storage with a domain-specific discriminator, prefer an ADL
+`encode`/`decode` overload unless the type can honestly expose the same
+`index`/`get`/`visit`/`assign` operations as a variant.
 
 ## Compile-Time Dispatch
 

--- a/doc/variant_handling.md
+++ b/doc/variant_handling.md
@@ -44,7 +44,7 @@ struct cbor::tags::variant_traits<boost::variant2::variant<Ts...>> {
     using alternative =
         boost::variant2::variant_alternative_t<I, variant_type>;
 
-    static std::size_t index(variant_type const& value) {
+    static std::size_t index(variant_type const& value) noexcept {
         return value.index();
     }
 
@@ -65,6 +65,10 @@ struct cbor::tags::variant_traits<boost::variant2::variant<Ts...>> {
     }
 };
 ```
+
+`index` must be declared `noexcept`. It only reads the active-alternative
+discriminator; types that can fail while determining their active member should
+use an ordinary `encode`/`decode` overload instead of `variant_traits`.
 
 `visit` must support both single-variant and multi-variant calls because
 encoding uses the former and comparison helpers use the latter.

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "cbor_tags/cbor_variant_traits.h"
 #include "cbor_tags/detail/cbor_range_concepts.h"
+#include "cbor_tags/detail/cbor_variant_traits.h"
 
 #include <array>
 #include <concepts>

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -579,7 +579,7 @@ template <typename T> struct unwrap_type<std::optional<T>> {
     using type = typename unwrap_type<T>::type;
 };
 
-// Specialization for variant-like types. The first alternative is used as the representative type.
+// Specialization for trait-backed variant types. The first alternative is used as the representative type.
 template <typename T>
     requires IsVariant<T>
 struct unwrap_type<T> {

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cbor_tags/cbor_variant_traits.h"
 #include "cbor_tags/detail/cbor_range_concepts.h"
 
 #include <array>
@@ -563,6 +564,11 @@ concept IsOptional = requires(T t) {
     T{};                    // Must be default constructible (nullopt)
 };
 
+template <typename T> struct is_variant : std::bool_constant<detail::VariantLike<std::remove_cvref_t<T>>> {};
+
+template <typename T>
+concept IsVariant = is_variant<std::remove_cvref_t<T>>::value;
+
 // Type trait to unwrap nested types
 template <typename T> struct unwrap_type {
     using type = T;
@@ -573,10 +579,11 @@ template <typename T> struct unwrap_type<std::optional<T>> {
     using type = typename unwrap_type<T>::type;
 };
 
-// Specialization for std::variant
-template <typename... Ts> struct unwrap_type<std::variant<Ts...>> {
-    // Get the first type's unwrapped version
-    using type = typename unwrap_type<std::tuple_element_t<0, std::tuple<Ts...>>>::type;
+// Specialization for variant-like types. The first alternative is used as the representative type.
+template <typename T>
+    requires IsVariant<T>
+struct unwrap_type<T> {
+    using type = typename unwrap_type<detail::variant_alternative_t<0, T>>::type;
 };
 
 // Helper alias
@@ -586,20 +593,29 @@ template <typename... T> constexpr bool contains_signed_integer = (... || IsSign
 template <typename... T> constexpr bool contains_unsigned       = (... || IsUnsigned<unwrap_type_t<T>>);
 template <typename... T> constexpr bool contains_negative       = (... || IsNegative<unwrap_type_t<T>>);
 
-template <typename T> struct is_variant : std::false_type {};
+namespace detail {
 
-template <typename... Args> struct is_variant<std::variant<Args...>> : std::true_type {};
+template <typename Variant, std::size_t... Is> consteval bool variant_contains_signed_integer_impl(std::index_sequence<Is...>) {
+    return contains_signed_integer<variant_alternative_t<Is, Variant>...>;
+}
 
-template <typename T>
-concept IsVariant = is_variant<std::remove_cvref_t<T>>::value;
+template <typename Variant, std::size_t... Is> consteval bool variant_contains_unsigned_or_negative_impl(std::index_sequence<Is...>) {
+    return contains_unsigned<variant_alternative_t<Is, Variant>...> || contains_negative<variant_alternative_t<Is, Variant>...>;
+}
+
+} // namespace detail
 
 template <typename T> struct variant_contains_integer : std::false_type {};
-template <template <typename...> typename V, typename... T>
-struct variant_contains_integer<V<T...>> : std::bool_constant<contains_signed_integer<T...>> {};
+template <typename T>
+    requires IsVariant<T>
+struct variant_contains_integer<T>
+    : std::bool_constant<detail::variant_contains_signed_integer_impl<T>(std::make_index_sequence<detail::variant_size_v<T>>{})> {};
 
 template <typename T> struct variant_contains_unsigned_or_negative : std::false_type {};
-template <template <typename...> typename V, typename... T>
-struct variant_contains_unsigned_or_negative<V<T...>> : std::bool_constant<contains_unsigned<T...> || contains_negative<T...>> {};
+template <typename T>
+    requires IsVariant<T>
+struct variant_contains_unsigned_or_negative<T>
+    : std::bool_constant<detail::variant_contains_unsigned_or_negative_impl<T>(std::make_index_sequence<detail::variant_size_v<T>>{})> {};
 
 template <typename T>
 concept IsVariantWithSignedInteger = IsVariant<T> && variant_contains_integer<T>::value;
@@ -647,8 +663,18 @@ concept IsCborMajor = IsAnyHeader<T> || IsUnsigned<T> || IsNegative<T> || IsSign
                       (IsVariant<T> && AllTypesAreCborMajorConcept<T>) || (IsOptional<T> && ContainsCborMajorConcept<T>) ||
                       IsNamedMapWrapper<T> || IsEnum<T> || (IsClassWithTagOverload<T>);
 
-template <typename... Ts> struct AllTypesAreCborMajor<std::variant<Ts...>> {
-    static constexpr bool value = (IsCborMajor<Ts> && ...);
+namespace detail {
+
+template <typename Variant, std::size_t... Is> consteval bool all_variant_alternatives_are_cbor_major(std::index_sequence<Is...>) {
+    return (IsCborMajor<variant_alternative_t<Is, Variant>> && ...);
+}
+
+} // namespace detail
+
+template <typename T>
+    requires IsVariant<T>
+struct AllTypesAreCborMajor<T> {
+    static constexpr bool value = detail::all_variant_alternatives_are_cbor_major<T>(std::make_index_sequence<detail::variant_size_v<T>>{});
 };
 
 // Helper for container like types, e.g optional

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -644,7 +644,7 @@ concept IsClassWithDecodingOverload = std::is_class_v<C> && (HasTranscodeMethod<
                                                              HasTranscodeFreeFunction<T, C> || HasDecodeFreeFunction<T, C>);
 
 template <typename T>
-concept IsAggregate = std::is_aggregate_v<T> && !IsFixedArray<T> && !IsAnyHeader<T> && !IsString<T> && !IsNamedWrapper<T>;
+concept IsAggregate = std::is_aggregate_v<T> && !IsVariant<T> && !IsFixedArray<T> && !IsAnyHeader<T> && !IsString<T> && !IsNamedWrapper<T>;
 
 // Helper to check if all types in a variant satisfy IsCborMajor
 template <typename T> struct AllTypesAreCborMajor;

--- a/include/cbor_tags/cbor_concepts_checking.h
+++ b/include/cbor_tags/cbor_concepts_checking.h
@@ -124,17 +124,36 @@ template <typename T> inline constexpr bool is_dynamic_tagged_tuple_v = is_dynam
 
 template <typename Variant, auto... Concepts> struct ValidConceptMapping;
 
-template <template <typename...> typename Variant, typename... Ts, auto... Concepts>
-struct ValidConceptMapping<Variant<Ts...>, Concepts...> {
+template <typename Variant, auto... Concepts>
+    requires IsVariant<Variant>
+struct ValidConceptMapping<Variant, Concepts...> {
+  private:
+    using variant_type = std::remove_cvref_t<Variant>;
 
-    static constexpr auto counts_fn_inner = [](std::array<uint64_t, detail::MaxBucketsForVariantChecking> &result,
-                                               std::vector<uint64_t>                                      &tags,
-                                               std::vector<SimpleType> &simples) { (getMatchCount<Ts>(result, tags, simples), ...); };
+    template <std::size_t... Is>
+    static constexpr void counts_fn_inner_impl(std::array<uint64_t, detail::MaxBucketsForVariantChecking> &result,
+                                               std::vector<uint64_t> &tags, std::vector<SimpleType> &simples, std::index_sequence<Is...>) {
+        (getMatchCount<detail::variant_alternative_t<Is, variant_type>>(result, tags, simples), ...);
+    }
 
-    static constexpr auto tags_fn_inner = [](std::array<uint64_t, detail::MaxTagsForVariantChecking> &result, std::vector<uint64_t> &tags,
-                                             std::vector<SimpleType> &simples) { (getTagsCounts<Ts>(result, tags, simples), ...); };
+    template <std::size_t... Is>
+    static constexpr void tags_fn_inner_impl(std::array<uint64_t, detail::MaxTagsForVariantChecking> &result, std::vector<uint64_t> &tags,
+                                             std::vector<SimpleType> &simples, std::index_sequence<Is...>) {
+        (getTagsCounts<detail::variant_alternative_t<Is, variant_type>>(result, tags, simples), ...);
+    }
 
-    static constexpr auto counts_fn_outer = []() {
+  public:
+    static constexpr void counts_fn_inner(std::array<uint64_t, detail::MaxBucketsForVariantChecking> &result, std::vector<uint64_t> &tags,
+                                          std::vector<SimpleType> &simples) {
+        counts_fn_inner_impl(result, tags, simples, std::make_index_sequence<detail::variant_size_v<variant_type>>{});
+    }
+
+    static constexpr void tags_fn_inner(std::array<uint64_t, detail::MaxTagsForVariantChecking> &result, std::vector<uint64_t> &tags,
+                                        std::vector<SimpleType> &simples) {
+        tags_fn_inner_impl(result, tags, simples, std::make_index_sequence<detail::variant_size_v<variant_type>>{});
+    }
+
+    static constexpr auto counts_fn_outer() {
         using namespace detail;
         std::array<uint64_t, detail::MaxBucketsForVariantChecking> result{};
         std::vector<uint64_t>                                      tags;
@@ -158,9 +177,9 @@ struct ValidConceptMapping<Variant<Ts...>, Concepts...> {
             result[MajorIndex::SimpleValued] = std::count(simples.begin(), simples.end(), SimpleType::Simple);
         }
         return result;
-    };
+    }
 
-    static constexpr auto tags_fn_outer = []() mutable {
+    static constexpr auto tags_fn_outer() {
         using namespace detail;
         std::array<uint64_t, detail::MaxTagsForVariantChecking> result{};
         std::vector<uint64_t>                                   tags;
@@ -172,21 +191,21 @@ struct ValidConceptMapping<Variant<Ts...>, Concepts...> {
         }
 
         return result;
-    };
+    }
 
-    static constexpr auto tags_size_outer = []() {
+    static constexpr auto tags_size_outer() {
         using namespace detail;
         std::array<uint64_t, detail::MaxTagsForVariantChecking> result{};
         std::vector<uint64_t>                                   tags;
         std::vector<SimpleType>                                 simples;
         tags_fn_inner(result, tags, simples);
         return tags.size();
-    };
+    }
 
-    static constexpr auto majors_and_subtypes_counts = (counts_fn_outer());
-    static constexpr auto tags                       = (tags_fn_outer());
+    static constexpr auto majors_and_subtypes_counts = counts_fn_outer();
+    static constexpr auto tags                       = tags_fn_outer();
 
-    static constexpr uint64_t number_of_tags = (tags_size_outer());
+    static constexpr uint64_t number_of_tags = tags_size_outer();
     static constexpr bool     too_many_tags  = (number_of_tags >= detail::MaxTagsForVariantChecking); // Use a runtime map instead
 
     static constexpr bool no_dynamic_tags    = (majors_and_subtypes_counts[detail::MajorIndex::DynamicTag] == 0);

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1337,7 +1337,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             } else if (result == status_code::incomplete) {
                 saw_incomplete = true;
                 return false;
-            } else if (!detail::is_variant_alternative_mismatch(result)) {
+            } else if (!detail::is_retriable_variant_mismatch(result)) {
                 hard_error = result;
                 return false;
             } else {
@@ -1426,7 +1426,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             } else if (result == status_code::incomplete) {
                 saw_incomplete = true;
                 return false;
-            } else if (!detail::is_variant_alternative_mismatch(result)) {
+            } else if (!detail::is_retriable_variant_mismatch(result)) {
                 hard_error = result;
                 return false;
             } else {

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1281,6 +1281,92 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     reader_type        reader_;
 
   private:
+    // Keep std::variant on the original pack-based fast path; generic variant-like dispatch is slower here.
+    template <typename... T>
+    constexpr status_code decode_variant(std::variant<T...> &value, major_type major, byte additionalInfo,
+                                         std::optional<std::uint64_t> &tag) {
+        using namespace detail;
+        static_assert((IsCborMajor<T> && ...),
+                      "All types must be CBOR major types, most likely you have a struct or class without a \"cbor_tag\" in the variant.");
+
+        // TODO: Remove this requirement
+        static_assert((std::is_default_constructible_v<T> && ...), "All types must be default constructible. Because in order to "
+                                                                   "decode into the type, it must be default constructed first.");
+
+        // Check ambiguous types in the variant.
+        using Variant = std::variant<T...>;
+        require_unambiguous_variant_dispatch<Variant>();
+        // TODO: Revisit variant validity as a separate check from dispatch ambiguity.
+        // Do not restore this as an unmatched-only guard; it misses invalid nested containers
+        // and can drift from IsCborMajor/decoder overload truth.
+        // static_assert(matching_major_types[MajorIndex::Unmatched] == 0, "Unmatched major types in variant");
+
+        bool        saw_incomplete = false;
+        status_code hard_error     = status_code::success;
+
+        auto try_decode = [this, major, additionalInfo, &value, &tag, &saw_incomplete,
+                           &hard_error]<bool CatchAllPass, typename U>() -> bool {
+            using raw_type = std::remove_cvref_t<U>;
+            if (hard_error != status_code::success) {
+                return false;
+            }
+            if (!matches_major_dispatch<raw_type>(major)) {
+                return false;
+            }
+
+            if (major == major_type::Simple && !detail::matches_simple_dispatch<CatchAllPass, raw_type>(additionalInfo)) {
+                return false;
+            }
+
+            raw_type    decoded_value;
+            status_code result;
+            if constexpr (IsVariant<raw_type>) {
+                result = this->decode_variant(decoded_value, major, additionalInfo, tag);
+            } else if constexpr (IsTag<raw_type>) {
+                if (!tag) {
+                    tag = decode_unsigned(additionalInfo);
+                }
+                result = this->decode(decoded_value, *tag);
+            } else {
+                result = this->decode(decoded_value, major, additionalInfo);
+            }
+
+            if (result == status_code::success) {
+                value = std::move(decoded_value);
+                return true;
+            } else if (result == status_code::incomplete) {
+                saw_incomplete = true;
+                return false;
+            } else if (major == major_type::Tag && result != status_code::no_match_for_tag &&
+                       result != status_code::no_match_for_tag_on_buffer && result != status_code::no_match_in_variant_on_buffer) {
+                hard_error = result;
+                return false;
+            } else {
+                return false;
+            }
+        };
+
+        bool found = false;
+        if (major == major_type::Simple) {
+            found = (try_decode.template operator()<false, T>() || ...);
+            if (!found) {
+                found = (try_decode.template operator()<true, T>() || ...);
+            }
+        } else {
+            found = (try_decode.template operator()<false, T>() || ...);
+        }
+        if (!found) {
+            if (hard_error != status_code::success) {
+                return hard_error;
+            }
+            if (saw_incomplete) {
+                return status_code::incomplete;
+            }
+            return status_code::no_match_in_variant_on_buffer;
+        }
+        return status_code::success;
+    }
+
     template <IsVariant Variant>
     constexpr status_code decode_variant(Variant &value, major_type major, byte additionalInfo, std::optional<std::uint64_t> &tag) {
         using namespace detail;

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1337,8 +1337,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             } else if (result == status_code::incomplete) {
                 saw_incomplete = true;
                 return false;
-            } else if (major == major_type::Tag && result != status_code::no_match_for_tag &&
-                       result != status_code::no_match_for_tag_on_buffer && result != status_code::no_match_in_variant_on_buffer) {
+            } else if (!detail::is_variant_alternative_mismatch(result)) {
                 hard_error = result;
                 return false;
             } else {
@@ -1427,8 +1426,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             } else if (result == status_code::incomplete) {
                 saw_incomplete = true;
                 return false;
-            } else if (major == major_type::Tag && result != status_code::no_match_for_tag &&
-                       result != status_code::no_match_for_tag_on_buffer && result != status_code::no_match_in_variant_on_buffer) {
+            } else if (!detail::is_variant_alternative_mismatch(result)) {
                 hard_error = result;
                 return false;
             } else {

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -709,7 +709,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 #endif
     }
 
-    template <typename... T> constexpr status_code decode(std::variant<T...> &value, major_type major, byte additionalInfo) {
+    template <IsVariant Variant> constexpr status_code decode(Variant &value, major_type major, byte additionalInfo) {
         std::optional<std::uint64_t> tag;
         return decode_variant(value, major, additionalInfo, tag);
     }
@@ -1281,20 +1281,25 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     reader_type        reader_;
 
   private:
-    template <typename... T>
-    constexpr status_code decode_variant(std::variant<T...> &value, major_type major, byte additionalInfo,
-                                         std::optional<std::uint64_t> &tag) {
+    template <IsVariant Variant>
+    constexpr status_code decode_variant(Variant &value, major_type major, byte additionalInfo, std::optional<std::uint64_t> &tag) {
         using namespace detail;
-        static_assert((IsCborMajor<T> && ...),
-                      "All types must be CBOR major types, most likely you have a struct or class without a \"cbor_tag\" in the variant.");
+        using variant_type = std::remove_cvref_t<Variant>;
+
+        static_assert(
+            detail::with_variant_alternatives<variant_type>([]<typename... Alternatives>() { return (IsCborMajor<Alternatives> && ...); }),
+            "All variant alternatives must be CBOR major types, most likely you have a struct or class without a \"cbor_tag\" in the "
+            "variant.");
 
         // TODO: Remove this requirement
-        static_assert((std::is_default_constructible_v<T> && ...), "All types must be default constructible. Because in order to "
-                                                                   "decode into the type, it must be default constructed first.");
+        static_assert(
+            detail::with_variant_alternatives<variant_type>(
+                []<typename... Alternatives>() { return (std::is_default_constructible_v<Alternatives> && ...); }),
+            "All variant alternatives must be default constructible. Because in order to decode into the type, each alternative must be "
+            "default constructed first.");
 
         // Check ambiguous types in the variant.
-        using Variant = std::variant<T...>;
-        require_unambiguous_variant_dispatch<Variant>();
+        require_unambiguous_variant_dispatch<variant_type>();
         // TODO: Revisit variant validity as a separate check from dispatch ambiguity.
         // Do not restore this as an unmatched-only guard; it misses invalid nested containers
         // and can drift from IsCborMajor/decoder overload truth.
@@ -1304,8 +1309,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         status_code hard_error     = status_code::success;
 
         auto try_decode = [this, major, additionalInfo, &value, &tag, &saw_incomplete,
-                           &hard_error]<bool CatchAllPass, typename U>() -> bool {
-            using raw_type = std::remove_cvref_t<U>;
+                           &hard_error]<bool CatchAllPass, std::size_t I>() -> bool {
+            using raw_type = detail::variant_alternative_t<I, variant_type>;
             if (hard_error != status_code::success) {
                 return false;
             }
@@ -1331,7 +1336,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
 
             if (result == status_code::success) {
-                value = std::move(decoded_value);
+                detail::variant_assign<I>(value, std::move(decoded_value));
                 return true;
             } else if (result == status_code::incomplete) {
                 saw_incomplete = true;
@@ -1345,14 +1350,18 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         };
 
+        auto try_decode_alternatives = [&]<bool CatchAllPass, std::size_t... Is>(std::index_sequence<Is...>) {
+            return (try_decode.template operator()<CatchAllPass, Is>() || ...);
+        };
+
         bool found = false;
         if (major == major_type::Simple) {
-            found = (try_decode.template operator()<false, T>() || ...);
+            found = try_decode_alternatives.template operator()<false>(std::make_index_sequence<detail::variant_size_v<variant_type>>{});
             if (!found) {
-                found = (try_decode.template operator()<true, T>() || ...);
+                found = try_decode_alternatives.template operator()<true>(std::make_index_sequence<detail::variant_size_v<variant_type>>{});
             }
         } else {
-            found = (try_decode.template operator()<false, T>() || ...);
+            found = try_decode_alternatives.template operator()<false>(std::make_index_sequence<detail::variant_size_v<variant_type>>{});
         }
         if (!found) {
             if (hard_error != status_code::success) {

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1281,7 +1281,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     reader_type        reader_;
 
   private:
-    // Keep std::variant on the original pack-based fast path; generic variant-like dispatch is slower here.
+    // Keep std::variant on the original pack-based fast path; generic trait-backed variant dispatch is slower here.
     template <typename... T>
     constexpr status_code decode_variant(std::variant<T...> &value, major_type major, byte additionalInfo,
                                          std::optional<std::uint64_t> &tag) {

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -262,9 +262,9 @@ template <typename T> struct cbor_indefinite_encoder {
 };
 
 template <typename T> struct cbor_variant_encoder {
-    template <typename... Ts> constexpr void encode(const std::variant<Ts...> &value) {
+    template <IsVariant Variant> constexpr void encode(const Variant &value) {
         // encoding a variant is less strict than decoding
-        std::visit([this](const auto &v) { detail::underlying<T>(this).encode(v); }, value);
+        detail::variant_visit([this](const auto &v) { detail::underlying<T>(this).encode(v); }, value);
     }
 };
 

--- a/include/cbor_tags/cbor_operators.h
+++ b/include/cbor_tags/cbor_operators.h
@@ -80,19 +80,21 @@ template <typename Compare> struct cbor_variant_visitor {
 };
 
 template <typename Compare = std::less<>> struct variant_comparator {
-    template <typename Variant> bool operator()(const Variant &lhs, const Variant &rhs) const {
-        if (lhs.index() != rhs.index()) {
-            return Compare{}(lhs.index(), rhs.index());
+    template <IsVariant Variant> bool operator()(const Variant &lhs, const Variant &rhs) const {
+        const auto lhs_index = detail::variant_index(lhs);
+        const auto rhs_index = detail::variant_index(rhs);
+        if (lhs_index != rhs_index) {
+            return Compare{}(lhs_index, rhs_index);
         }
 
-        return std::visit(cbor_variant_visitor<Compare>{}, lhs, rhs);
+        return detail::variant_visit(cbor_variant_visitor<Compare>{}, lhs, rhs);
     }
 };
 
 struct variant_hasher {
     template <IsVariant Variant> size_t operator()(const Variant &v) const noexcept {
         // Start with the index hash
-        size_t seed = std::hash<size_t>{}(v.index());
+        size_t seed = std::hash<size_t>{}(detail::variant_index(v));
         seed ^= hash_variant_value(v);
         seed *= fnv_prime;
         return seed;
@@ -134,11 +136,11 @@ struct variant_hasher {
     template <std::size_t I, IsVariant Variant> static size_t hash_variant_value_impl(const Variant &v) noexcept {
         using variant_type = std::remove_cvref_t<Variant>;
 
-        if constexpr (I == std::variant_size_v<variant_type>) {
+        if constexpr (I == detail::variant_size_v<variant_type>) {
             std::terminate();
         } else {
-            if (v.index() == I) {
-                return hash_cbor_value(std::get<I>(v));
+            if (detail::variant_index(v) == I) {
+                return hash_cbor_value(detail::variant_get<I>(v));
             }
             return hash_variant_value_impl<I + 1>(v);
         }

--- a/include/cbor_tags/cbor_operators.h
+++ b/include/cbor_tags/cbor_operators.h
@@ -94,7 +94,7 @@ template <typename Compare = std::less<>> struct variant_comparator {
 struct variant_hasher {
     template <IsVariant Variant> size_t operator()(const Variant &v) const noexcept {
         // Start with the index hash
-        size_t seed = std::hash<size_t>{}(detail::variant_index(v));
+        size_t seed = std::hash<size_t>{}(v.index());
         seed ^= hash_variant_value(v);
         seed *= fnv_prime;
         return seed;
@@ -136,11 +136,11 @@ struct variant_hasher {
     template <std::size_t I, IsVariant Variant> static size_t hash_variant_value_impl(const Variant &v) noexcept {
         using variant_type = std::remove_cvref_t<Variant>;
 
-        if constexpr (I == detail::variant_size_v<variant_type>) {
+        if constexpr (I == std::variant_size_v<variant_type>) {
             std::terminate();
         } else {
-            if (detail::variant_index(v) == I) {
-                return hash_cbor_value(detail::variant_get<I>(v));
+            if (v.index() == I) {
+                return hash_cbor_value(std::get<I>(v));
             }
             return hash_variant_value_impl<I + 1>(v);
         }

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -9,11 +9,21 @@
 
 namespace cbor::tags {
 
+// Customize this trait for variant-like types that cannot be detected
+// structurally. A usable specialization must provide:
+// - static constexpr std::size_t size
+// - template <std::size_t I> using alternative = ...
+// - static std::size_t index(const T&)
+// - static get<I>(T&&), visit(visitor, variants...), and assign<I>(T&, value)
 template <typename T> struct variant_traits;
 
 namespace detail {
 
 template <typename T> struct variant_dependent_false : std::false_type {};
+
+struct variant_probe_visitor {
+    template <typename... Args> constexpr void operator()(Args &&...) const noexcept {}
+};
 
 template <typename T>
 concept VariantTemplateIndexable = requires(const T &value) {
@@ -22,21 +32,69 @@ concept VariantTemplateIndexable = requires(const T &value) {
     { value.which() } -> std::convertible_to<int>;
 };
 
-template <typename T, typename = void> struct is_variant_like : std::false_type {};
+template <typename Visitor, typename... Variants>
+concept HasVariantVisit =
+    requires(Visitor &&visitor, Variants &&...variants) { visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); };
 
-template <typename T>
-struct is_variant_like<T, std::void_t<decltype(variant_traits<std::remove_cvref_t<T>>::size)>>
-    : std::bool_constant<(variant_traits<std::remove_cvref_t<T>>::size > 0U)> {};
+template <typename Visitor, typename... Variants>
+concept HasVariantApplyVisitor = requires(Visitor &&visitor, Variants &&...variants) {
+    apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
+};
 
-template <typename T>
-concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
+template <typename Variant>
+concept VariantTemplateVisitable =
+    HasVariantVisit<variant_probe_visitor, const Variant &> || HasVariantApplyVisitor<variant_probe_visitor, const Variant &>;
+
+template <std::size_t I, typename Variant>
+concept VariantIndexedGettable = requires(Variant &&value) { get<I>(std::forward<Variant>(value)); };
+
+template <typename Alternative, typename Variant>
+concept VariantTypedGettable = requires(Variant &&value) { get<Alternative>(std::forward<Variant>(value)); };
+
+template <std::size_t I, typename Alternative, typename Variant> consteval bool variant_alternative_gettable() {
+    if constexpr (VariantIndexedGettable<I, Variant>) {
+        return true;
+    } else {
+        return VariantTypedGettable<Alternative, Variant>;
+    }
+}
+
+template <typename Variant, typename... Ts, std::size_t... Is> consteval bool variant_template_gettable_impl(std::index_sequence<Is...>) {
+    return (variant_alternative_gettable<Is, Ts, Variant &>() && ...) && (variant_alternative_gettable<Is, Ts, const Variant &>() && ...);
+}
+
+template <typename Variant, typename... Ts>
+concept VariantTemplateGettable = (sizeof...(Ts) > 0U) && variant_template_gettable_impl<Variant, Ts...>(std::index_sequence_for<Ts...>{});
+
+template <std::size_t I, typename Alternative, typename Variant> consteval bool variant_alternative_assignable() {
+    if constexpr (requires(Variant &value, Alternative alternative) { value.template emplace<I>(std::move(alternative)); }) {
+        return true;
+    } else {
+        return std::assignable_from<Variant &, Alternative>;
+    }
+}
+
+template <typename Variant, typename... Ts, std::size_t... Is> consteval bool variant_template_assignable_impl(std::index_sequence<Is...>) {
+    return (variant_alternative_assignable<Is, Ts, Variant>() && ...);
+}
+
+template <typename Variant, typename... Ts>
+concept VariantTemplateAssignable =
+    (sizeof...(Ts) > 0U) && variant_template_assignable_impl<Variant, Ts...>(std::index_sequence_for<Ts...>{});
+
+template <typename Variant, typename... Ts>
+concept VariantTemplateLike = VariantTemplateIndexable<Variant> && VariantTemplateVisitable<Variant> &&
+                              VariantTemplateGettable<Variant, Ts...> && VariantTemplateAssignable<Variant, Ts...>;
 
 template <typename Visitor, typename... Variants> constexpr decltype(auto) variant_adl_visit(Visitor &&visitor, Variants &&...variants) {
     using std::visit;
     if constexpr (requires { visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); }) {
         return visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
-    } else {
+    } else if constexpr (requires { apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); }) {
         return apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
+    } else {
+        static_assert(variant_dependent_false<std::remove_cvref_t<Visitor>>::value,
+                      "variant-like types require visit(visitor, variant...) or apply_visitor(visitor, variant...)");
     }
 }
 
@@ -54,7 +112,7 @@ template <std::size_t I, typename Variant> constexpr decltype(auto) variant_adl_
 } // namespace detail
 
 template <template <typename...> typename Variant, typename... Ts>
-    requires detail::VariantTemplateIndexable<Variant<Ts...>>
+    requires detail::VariantTemplateLike<Variant<Ts...>, Ts...>
 struct variant_traits<Variant<Ts...>> {
     using variant_type = Variant<Ts...>;
 
@@ -91,6 +149,54 @@ struct variant_traits<Variant<Ts...>> {
 };
 
 namespace detail {
+
+template <typename T>
+concept VariantTraitsAvailable =
+    requires { typename std::integral_constant<std::size_t, static_cast<std::size_t>(variant_traits<std::remove_cvref_t<T>>::size)>; };
+
+template <typename T>
+inline constexpr std::size_t variant_traits_declared_size_v = static_cast<std::size_t>(variant_traits<std::remove_cvref_t<T>>::size);
+
+template <typename Variant, std::size_t I>
+concept VariantTraitReadableAlternative = requires(Variant &value, const Variant &const_value, variant_probe_visitor visitor) {
+    typename variant_traits<Variant>::template alternative<I>;
+    { variant_traits<Variant>::index(const_value) } -> std::convertible_to<std::size_t>;
+    variant_traits<Variant>::template get<I>(value);
+    variant_traits<Variant>::template get<I>(const_value);
+    variant_traits<Variant>::visit(visitor, const_value);
+};
+
+template <typename Variant, std::size_t I>
+concept VariantTraitAssignableAlternative =
+    requires(Variant &value, typename variant_traits<Variant>::template alternative<I> alternative) {
+        variant_traits<Variant>::template assign<I>(value, std::move(alternative));
+    };
+
+template <typename Variant, std::size_t... Is> consteval bool variant_traits_are_usable_impl(std::index_sequence<Is...>) {
+    return (VariantTraitReadableAlternative<Variant, Is> && ...) && (VariantTraitAssignableAlternative<Variant, Is> && ...);
+}
+
+template <typename T> consteval bool variant_traits_are_usable() {
+    using variant_type = std::remove_cvref_t<T>;
+    if constexpr (VariantTraitsAvailable<variant_type>) {
+        if constexpr (variant_traits_declared_size_v<variant_type> == 0U) {
+            return false;
+        }
+        return variant_traits_are_usable_impl<variant_type>(std::make_index_sequence<variant_traits_declared_size_v<variant_type>>{});
+    }
+    return false;
+}
+
+template <typename T>
+concept VariantTraitsUsable = variant_traits_are_usable<T>();
+
+template <typename T> struct is_variant_like : std::bool_constant<VariantTraitsUsable<std::remove_cvref_t<T>>> {
+    static_assert(!VariantTraitsAvailable<std::remove_cvref_t<T>> || VariantTraitsUsable<std::remove_cvref_t<T>>,
+                  "variant_traits<T> must provide size, alternative<I>, index, get<I>, visit, and assign<I>");
+};
+
+template <typename T>
+concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
 
 template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits<std::remove_cvref_t<Variant>>::size;
 

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace cbor::tags {
+
+template <typename T> struct variant_traits;
+
+namespace detail {
+
+template <typename T> struct variant_dependent_false : std::false_type {};
+
+template <typename T>
+concept VariantTemplateIndexable = requires(const T &value) {
+    { value.index() } -> std::convertible_to<std::size_t>;
+} || requires(const T &value) {
+    { value.which() } -> std::convertible_to<int>;
+};
+
+template <typename T, typename = void> struct is_variant_like : std::false_type {};
+
+template <typename T>
+struct is_variant_like<T, std::void_t<decltype(variant_traits<std::remove_cvref_t<T>>::size)>>
+    : std::bool_constant<(variant_traits<std::remove_cvref_t<T>>::size > 0U)> {};
+
+template <typename T>
+concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
+
+template <typename Visitor, typename... Variants> constexpr decltype(auto) variant_adl_visit(Visitor &&visitor, Variants &&...variants) {
+    using std::visit;
+    if constexpr (requires { visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); }) {
+        return visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
+    } else {
+        return apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
+    }
+}
+
+template <std::size_t I, typename Variant> constexpr decltype(auto) variant_adl_get(Variant &&value) {
+    using std::get;
+    if constexpr (requires { get<I>(std::forward<Variant>(value)); }) {
+        return get<I>(std::forward<Variant>(value));
+    } else {
+        using variant_type     = std::remove_cvref_t<Variant>;
+        using alternative_type = typename variant_traits<variant_type>::template alternative<I>;
+        return get<alternative_type>(std::forward<Variant>(value));
+    }
+}
+
+} // namespace detail
+
+template <template <typename...> typename Variant, typename... Ts>
+    requires detail::VariantTemplateIndexable<Variant<Ts...>>
+struct variant_traits<Variant<Ts...>> {
+    using variant_type = Variant<Ts...>;
+
+    static constexpr std::size_t size = sizeof...(Ts);
+
+    template <std::size_t I> using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+    [[nodiscard]] static constexpr std::size_t index(const variant_type &value) noexcept {
+        if constexpr (requires { value.index(); }) {
+            return static_cast<std::size_t>(value.index());
+        } else {
+            return static_cast<std::size_t>(value.which());
+        }
+    }
+
+    template <std::size_t I, typename VariantRef> static constexpr decltype(auto) get(VariantRef &&value) {
+        return detail::variant_adl_get<I>(std::forward<VariantRef>(value));
+    }
+
+    template <typename Visitor, typename... VariantRefs> static constexpr decltype(auto) visit(Visitor &&visitor, VariantRefs &&...values) {
+        return detail::variant_adl_visit(std::forward<Visitor>(visitor), std::forward<VariantRefs>(values)...);
+    }
+
+    template <std::size_t I, typename U> static constexpr void assign(variant_type &value, U &&decoded_value) {
+        if constexpr (requires { value.template emplace<I>(std::forward<U>(decoded_value)); }) {
+            value.template emplace<I>(std::forward<U>(decoded_value));
+        } else if constexpr (std::assignable_from<variant_type &, U>) {
+            value = std::forward<U>(decoded_value);
+        } else {
+            static_assert(detail::variant_dependent_false<U>::value,
+                          "variant-like decode requires emplace<I>(value) or assignment from the decoded alternative");
+        }
+    }
+};
+
+namespace detail {
+
+template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits<std::remove_cvref_t<Variant>>::size;
+
+template <std::size_t I, typename Variant>
+using variant_alternative_t = typename variant_traits<std::remove_cvref_t<Variant>>::template alternative<I>;
+
+template <typename Variant> [[nodiscard]] constexpr std::size_t variant_index(const Variant &value) noexcept {
+    return variant_traits<std::remove_cvref_t<Variant>>::index(value);
+}
+
+template <std::size_t I, typename Variant> constexpr decltype(auto) variant_get(Variant &&value) {
+    return variant_traits<std::remove_cvref_t<Variant>>::template get<I>(std::forward<Variant>(value));
+}
+
+template <typename Visitor, typename Variant, typename... Variants>
+constexpr decltype(auto) variant_visit(Visitor &&visitor, Variant &&value, Variants &&...values) {
+    return variant_traits<std::remove_cvref_t<Variant>>::visit(std::forward<Visitor>(visitor), std::forward<Variant>(value),
+                                                               std::forward<Variants>(values)...);
+}
+
+template <std::size_t I, typename Variant, typename U> constexpr void variant_assign(Variant &value, U &&decoded_value) {
+    variant_traits<std::remove_cvref_t<Variant>>::template assign<I>(value, std::forward<U>(decoded_value));
+}
+
+template <typename Variant, typename Fn, std::size_t... Is>
+constexpr decltype(auto) with_variant_alternatives_impl(Fn &&fn, std::index_sequence<Is...>) {
+    return std::forward<Fn>(fn).template operator()<variant_alternative_t<Is, Variant>...>();
+}
+
+template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternatives(Fn &&fn) {
+    return with_variant_alternatives_impl<std::remove_cvref_t<Variant>>(
+        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
+}
+
+template <typename Variant, typename Fn, std::size_t... Is>
+constexpr decltype(auto) with_variant_alternative_indices_impl(Fn &&fn, std::index_sequence<Is...>) {
+    return std::forward<Fn>(fn).template operator()<Is...>();
+}
+
+template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternative_indices(Fn &&fn) {
+    return with_variant_alternative_indices_impl<std::remove_cvref_t<Variant>>(
+        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
+}
+
+} // namespace detail
+
+} // namespace cbor::tags

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -9,8 +9,8 @@
 
 namespace cbor::tags {
 
-// Customize this trait for variant-like types that cannot be detected
-// structurally. A usable specialization must provide:
+// Customize this trait for variant-like types that cannot be detected structurally.
+// A usable specialization must provide:
 // - static constexpr std::size_t size
 // - template <std::size_t I> using alternative = ...
 // - static std::size_t index(const T&)
@@ -150,50 +150,11 @@ struct variant_traits<Variant<Ts...>> {
 
 namespace detail {
 
-template <typename T>
-concept VariantTraitsAvailable =
-    requires { typename std::integral_constant<std::size_t, static_cast<std::size_t>(variant_traits<std::remove_cvref_t<T>>::size)>; };
+template <typename T, typename = void> struct is_variant_like : std::false_type {};
 
 template <typename T>
-inline constexpr std::size_t variant_traits_declared_size_v = static_cast<std::size_t>(variant_traits<std::remove_cvref_t<T>>::size);
-
-template <typename Variant, std::size_t I>
-concept VariantTraitReadableAlternative = requires(Variant &value, const Variant &const_value, variant_probe_visitor visitor) {
-    typename variant_traits<Variant>::template alternative<I>;
-    { variant_traits<Variant>::index(const_value) } -> std::convertible_to<std::size_t>;
-    variant_traits<Variant>::template get<I>(value);
-    variant_traits<Variant>::template get<I>(const_value);
-    variant_traits<Variant>::visit(visitor, const_value);
-};
-
-template <typename Variant, std::size_t I>
-concept VariantTraitAssignableAlternative =
-    requires(Variant &value, typename variant_traits<Variant>::template alternative<I> alternative) {
-        variant_traits<Variant>::template assign<I>(value, std::move(alternative));
-    };
-
-template <typename Variant, std::size_t... Is> consteval bool variant_traits_are_usable_impl(std::index_sequence<Is...>) {
-    return (VariantTraitReadableAlternative<Variant, Is> && ...) && (VariantTraitAssignableAlternative<Variant, Is> && ...);
-}
-
-template <typename T> consteval bool variant_traits_are_usable() {
-    using variant_type = std::remove_cvref_t<T>;
-    if constexpr (VariantTraitsAvailable<variant_type>) {
-        if constexpr (variant_traits_declared_size_v<variant_type> == 0U) {
-            return false;
-        }
-        return variant_traits_are_usable_impl<variant_type>(std::make_index_sequence<variant_traits_declared_size_v<variant_type>>{});
-    }
-    return false;
-}
-
-template <typename T>
-concept VariantTraitsUsable = variant_traits_are_usable<T>();
-
-template <typename T> struct is_variant_like : std::bool_constant<VariantTraitsUsable<std::remove_cvref_t<T>>> {
-    static_assert(!VariantTraitsAvailable<std::remove_cvref_t<T>> || VariantTraitsUsable<std::remove_cvref_t<T>>,
-                  "variant_traits<T> must provide size, alternative<I>, index, get<I>, visit, and assign<I>");
-};
+struct is_variant_like<T, std::void_t<decltype(variant_traits<std::remove_cvref_t<T>>::size)>>
+    : std::bool_constant<(variant_traits<std::remove_cvref_t<T>>::size > 0U)> {};
 
 template <typename T>
 concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -17,6 +17,8 @@ namespace cbor::tags {
 // - static get<I>(T&) and get<I>(const T&)
 // - static visit(visitor, variant) and visit(visitor, variant, variant)
 // - static assign<I>(T&, value)
+// Recognition checks the type-level shape plus index(). The remaining hooks are
+// instantiated by encoder, decoder, and operator call sites.
 template <typename T> struct variant_traits;
 
 template <typename... Ts> struct variant_traits<std::variant<Ts...>> {
@@ -49,10 +51,6 @@ template <typename T> struct is_std_variant : std::false_type {};
 
 template <typename... Ts> struct is_std_variant<std::variant<Ts...>> : std::true_type {};
 
-struct variant_probe_visitor {
-    template <typename... Args> constexpr void operator()(Args &&...) const noexcept {}
-};
-
 template <typename T, typename = void> struct variant_traits_size : std::integral_constant<std::size_t, 0U> {
     static constexpr bool valid = false;
 };
@@ -63,20 +61,18 @@ struct variant_traits_size<T, std::void_t<decltype(std::integral_constant<std::s
     static constexpr bool valid = true;
 };
 
+template <typename T, std::size_t I> using variant_trait_alternative_probe_t = typename variant_traits_t<T>::template alternative<I>;
+
 template <typename T, std::size_t I>
-concept CompleteVariantTraitAlternative = requires(T &value, const T &const_value, variant_probe_visitor visitor,
-                                                   typename variant_traits_t<T>::template alternative<I> alternative) {
-    typename variant_traits_t<T>::template alternative<I>;
+concept VariantTraitAlternative = requires { typename variant_trait_alternative_probe_t<T, I>; };
+
+template <typename T>
+concept VariantTraitIndexable = requires(const T &const_value) {
     { variant_traits_t<T>::index(const_value) } -> std::convertible_to<std::size_t>;
-    variant_traits_t<T>::template get<I>(value);
-    variant_traits_t<T>::template get<I>(const_value);
-    variant_traits_t<T>::visit(visitor, const_value);
-    variant_traits_t<T>::visit(visitor, const_value, const_value);
-    variant_traits_t<T>::template assign<I>(value, std::move(alternative));
 };
 
 template <typename T, std::size_t... Is> consteval bool variant_traits_complete_impl(std::index_sequence<Is...>) {
-    return (CompleteVariantTraitAlternative<std::remove_cvref_t<T>, Is> && ...);
+    return VariantTraitIndexable<std::remove_cvref_t<T>> && (VariantTraitAlternative<std::remove_cvref_t<T>, Is> && ...);
 }
 
 template <typename T> consteval bool variant_traits_complete() {

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -45,6 +45,10 @@ namespace detail {
 
 template <typename T> using variant_traits_t = variant_traits<std::remove_cvref_t<T>>;
 
+template <typename T> struct is_std_variant : std::false_type {};
+
+template <typename... Ts> struct is_std_variant<std::variant<Ts...>> : std::true_type {};
+
 struct variant_probe_visitor {
     template <typename... Args> constexpr void operator()(Args &&...) const noexcept {}
 };
@@ -85,7 +89,11 @@ template <typename T> consteval bool variant_traits_complete() {
 
 template <typename T, typename = void> struct is_variant_like : std::false_type {};
 
-template <typename T> struct is_variant_like<T, std::enable_if_t<variant_traits_complete<T>()>> : std::true_type {};
+template <typename T> struct is_variant_like<T, std::enable_if_t<is_std_variant<std::remove_cvref_t<T>>::value>> : std::true_type {};
+
+template <typename T>
+struct is_variant_like<T, std::enable_if_t<!is_std_variant<std::remove_cvref_t<T>>::value && variant_traits_complete<T>()>>
+    : std::true_type {};
 
 template <typename T>
 concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include <concepts>
 #include <cstddef>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -42,101 +40,5 @@ template <typename... Ts> struct variant_traits<std::variant<Ts...>> {
         value.template emplace<I>(std::forward<U>(decoded_value));
     }
 };
-
-namespace detail {
-
-template <typename T> using variant_traits_t = variant_traits<std::remove_cvref_t<T>>;
-
-template <typename T> struct is_std_variant : std::false_type {};
-
-template <typename... Ts> struct is_std_variant<std::variant<Ts...>> : std::true_type {};
-
-template <typename T, typename = void> struct variant_traits_size : std::integral_constant<std::size_t, 0U> {
-    static constexpr bool valid = false;
-};
-
-template <typename T>
-struct variant_traits_size<T, std::void_t<decltype(std::integral_constant<std::size_t, variant_traits_t<T>::size>{})>>
-    : std::integral_constant<std::size_t, variant_traits_t<T>::size> {
-    static constexpr bool valid = true;
-};
-
-template <typename T, std::size_t I> using variant_trait_alternative_probe_t = typename variant_traits_t<T>::template alternative<I>;
-
-template <typename T, std::size_t I>
-concept VariantTraitAlternative = requires { typename variant_trait_alternative_probe_t<T, I>; };
-
-template <typename T>
-concept VariantTraitIndexable = requires(const T &const_value) {
-    { variant_traits_t<T>::index(const_value) } -> std::convertible_to<std::size_t>;
-};
-
-template <typename T, std::size_t... Is> consteval bool variant_traits_complete_impl(std::index_sequence<Is...>) {
-    return VariantTraitIndexable<std::remove_cvref_t<T>> && (VariantTraitAlternative<std::remove_cvref_t<T>, Is> && ...);
-}
-
-template <typename T> consteval bool variant_traits_complete() {
-    if constexpr (!variant_traits_size<T>::valid || variant_traits_size<T>::value == 0U) {
-        return false;
-    } else {
-        return variant_traits_complete_impl<T>(std::make_index_sequence<variant_traits_size<T>::value>{});
-    }
-}
-
-template <typename T, typename = void> struct is_variant_like : std::false_type {};
-
-template <typename T> struct is_variant_like<T, std::enable_if_t<is_std_variant<std::remove_cvref_t<T>>::value>> : std::true_type {};
-
-template <typename T>
-struct is_variant_like<T, std::enable_if_t<!is_std_variant<std::remove_cvref_t<T>>::value && variant_traits_complete<T>()>>
-    : std::true_type {};
-
-template <typename T>
-concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
-
-template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits_t<Variant>::size;
-
-template <std::size_t I, typename Variant> using variant_alternative_t = typename variant_traits_t<Variant>::template alternative<I>;
-
-template <typename Variant> [[nodiscard]] constexpr std::size_t variant_index(const Variant &value) noexcept {
-    static_assert(noexcept(variant_traits_t<Variant>::index(value)), "variant_traits::index must be declared noexcept");
-    return variant_traits_t<Variant>::index(value);
-}
-
-template <std::size_t I, typename Variant> constexpr decltype(auto) variant_get(Variant &&value) {
-    return variant_traits_t<Variant>::template get<I>(std::forward<Variant>(value));
-}
-
-template <typename Visitor, typename Variant, typename... Variants>
-constexpr decltype(auto) variant_visit(Visitor &&visitor, Variant &&value, Variants &&...values) {
-    return variant_traits_t<Variant>::visit(std::forward<Visitor>(visitor), std::forward<Variant>(value),
-                                            std::forward<Variants>(values)...);
-}
-
-template <std::size_t I, typename Variant, typename U> constexpr void variant_assign(Variant &value, U &&decoded_value) {
-    variant_traits_t<Variant>::template assign<I>(value, std::forward<U>(decoded_value));
-}
-
-template <typename Variant, typename Fn, std::size_t... Is>
-constexpr decltype(auto) with_variant_alternatives_impl(Fn &&fn, std::index_sequence<Is...>) {
-    return std::forward<Fn>(fn).template operator()<variant_alternative_t<Is, Variant>...>();
-}
-
-template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternatives(Fn &&fn) {
-    return with_variant_alternatives_impl<std::remove_cvref_t<Variant>>(
-        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
-}
-
-template <typename Variant, typename Fn, std::size_t... Is>
-constexpr decltype(auto) with_variant_alternative_indices_impl(Fn &&fn, std::index_sequence<Is...>) {
-    return std::forward<Fn>(fn).template operator()<Is...>();
-}
-
-template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternative_indices(Fn &&fn) {
-    return with_variant_alternative_indices_impl<std::remove_cvref_t<Variant>>(
-        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
-}
-
-} // namespace detail
 
 } // namespace cbor::tags

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -13,7 +13,7 @@ namespace cbor::tags {
 // A usable specialization must provide:
 // - static constexpr std::size_t size
 // - template <std::size_t I> using alternative = ...
-// - static std::size_t index(const T&)
+// - static std::size_t index(const T&) noexcept
 // - static get<I>(T&) and get<I>(const T&)
 // - static visit(visitor, variant) and visit(visitor, variant, variant)
 // - static assign<I>(T&, value)
@@ -99,6 +99,7 @@ template <typename Variant> inline constexpr std::size_t variant_size_v = varian
 template <std::size_t I, typename Variant> using variant_alternative_t = typename variant_traits_t<Variant>::template alternative<I>;
 
 template <typename Variant> [[nodiscard]] constexpr std::size_t variant_index(const Variant &value) noexcept {
+    static_assert(noexcept(variant_traits_t<Variant>::index(value)), "variant_traits::index must be declared noexcept");
     return variant_traits_t<Variant>::index(value);
 }
 

--- a/include/cbor_tags/cbor_variant_traits.h
+++ b/include/cbor_tags/cbor_variant_traits.h
@@ -9,177 +9,107 @@
 
 namespace cbor::tags {
 
-// Customize this trait for variant-like types that cannot be detected structurally.
+// Specialize this trait to opt non-std variant types into cbor_tags variant dispatch.
 // A usable specialization must provide:
 // - static constexpr std::size_t size
 // - template <std::size_t I> using alternative = ...
 // - static std::size_t index(const T&)
-// - static get<I>(T&&), visit(visitor, variants...), and assign<I>(T&, value)
+// - static get<I>(T&) and get<I>(const T&)
+// - static visit(visitor, variant) and visit(visitor, variant, variant)
+// - static assign<I>(T&, value)
 template <typename T> struct variant_traits;
 
-namespace detail {
-
-template <typename T> struct variant_dependent_false : std::false_type {};
-
-struct variant_probe_visitor {
-    template <typename... Args> constexpr void operator()(Args &&...) const noexcept {}
-};
-
-template <typename T>
-concept VariantTemplateIndexable = requires(const T &value) {
-    { value.index() } -> std::convertible_to<std::size_t>;
-} || requires(const T &value) {
-    { value.which() } -> std::convertible_to<int>;
-};
-
-template <typename Visitor, typename... Variants>
-concept HasVariantVisit =
-    requires(Visitor &&visitor, Variants &&...variants) { visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); };
-
-template <typename Visitor, typename... Variants>
-concept HasVariantApplyVisitor = requires(Visitor &&visitor, Variants &&...variants) {
-    apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
-};
-
-template <typename Variant>
-concept VariantTemplateVisitable =
-    HasVariantVisit<variant_probe_visitor, const Variant &> || HasVariantApplyVisitor<variant_probe_visitor, const Variant &>;
-
-template <std::size_t I, typename Variant>
-concept VariantIndexedGettable = requires(Variant &&value) { get<I>(std::forward<Variant>(value)); };
-
-template <typename Alternative, typename Variant>
-concept VariantTypedGettable = requires(Variant &&value) { get<Alternative>(std::forward<Variant>(value)); };
-
-template <std::size_t I, typename Alternative, typename Variant> consteval bool variant_alternative_gettable() {
-    if constexpr (VariantIndexedGettable<I, Variant>) {
-        return true;
-    } else {
-        return VariantTypedGettable<Alternative, Variant>;
-    }
-}
-
-template <typename Variant, typename... Ts, std::size_t... Is> consteval bool variant_template_gettable_impl(std::index_sequence<Is...>) {
-    return (variant_alternative_gettable<Is, Ts, Variant &>() && ...) && (variant_alternative_gettable<Is, Ts, const Variant &>() && ...);
-}
-
-template <typename Variant, typename... Ts>
-concept VariantTemplateGettable = (sizeof...(Ts) > 0U) && variant_template_gettable_impl<Variant, Ts...>(std::index_sequence_for<Ts...>{});
-
-template <std::size_t I, typename Alternative, typename Variant> consteval bool variant_alternative_assignable() {
-    if constexpr (requires(Variant &value, Alternative alternative) { value.template emplace<I>(std::move(alternative)); }) {
-        return true;
-    } else {
-        return std::assignable_from<Variant &, Alternative>;
-    }
-}
-
-template <typename Variant, typename... Ts, std::size_t... Is> consteval bool variant_template_assignable_impl(std::index_sequence<Is...>) {
-    return (variant_alternative_assignable<Is, Ts, Variant>() && ...);
-}
-
-template <typename Variant, typename... Ts>
-concept VariantTemplateAssignable =
-    (sizeof...(Ts) > 0U) && variant_template_assignable_impl<Variant, Ts...>(std::index_sequence_for<Ts...>{});
-
-template <typename Variant, typename... Ts>
-concept VariantTemplateLike = VariantTemplateIndexable<Variant> && VariantTemplateVisitable<Variant> &&
-                              VariantTemplateGettable<Variant, Ts...> && VariantTemplateAssignable<Variant, Ts...>;
-
-template <typename Visitor, typename... Variants> constexpr decltype(auto) variant_adl_visit(Visitor &&visitor, Variants &&...variants) {
-    using std::visit;
-    if constexpr (requires { visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); }) {
-        return visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
-    } else if constexpr (requires { apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...); }) {
-        return apply_visitor(std::forward<Visitor>(visitor), std::forward<Variants>(variants)...);
-    } else {
-        static_assert(variant_dependent_false<std::remove_cvref_t<Visitor>>::value,
-                      "variant-like types require visit(visitor, variant...) or apply_visitor(visitor, variant...)");
-    }
-}
-
-template <std::size_t I, typename Variant> constexpr decltype(auto) variant_adl_get(Variant &&value) {
-    using std::get;
-    if constexpr (requires { get<I>(std::forward<Variant>(value)); }) {
-        return get<I>(std::forward<Variant>(value));
-    } else {
-        using variant_type     = std::remove_cvref_t<Variant>;
-        using alternative_type = typename variant_traits<variant_type>::template alternative<I>;
-        return get<alternative_type>(std::forward<Variant>(value));
-    }
-}
-
-} // namespace detail
-
-template <template <typename...> typename Variant, typename... Ts>
-    requires detail::VariantTemplateLike<Variant<Ts...>, Ts...>
-struct variant_traits<Variant<Ts...>> {
-    using variant_type = Variant<Ts...>;
+template <typename... Ts> struct variant_traits<std::variant<Ts...>> {
+    using variant_type = std::variant<Ts...>;
 
     static constexpr std::size_t size = sizeof...(Ts);
 
     template <std::size_t I> using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
 
-    [[nodiscard]] static constexpr std::size_t index(const variant_type &value) noexcept {
-        if constexpr (requires { value.index(); }) {
-            return static_cast<std::size_t>(value.index());
-        } else {
-            return static_cast<std::size_t>(value.which());
-        }
-    }
+    [[nodiscard]] static constexpr std::size_t index(const variant_type &value) noexcept { return value.index(); }
 
     template <std::size_t I, typename VariantRef> static constexpr decltype(auto) get(VariantRef &&value) {
-        return detail::variant_adl_get<I>(std::forward<VariantRef>(value));
+        return std::get<I>(std::forward<VariantRef>(value));
     }
 
     template <typename Visitor, typename... VariantRefs> static constexpr decltype(auto) visit(Visitor &&visitor, VariantRefs &&...values) {
-        return detail::variant_adl_visit(std::forward<Visitor>(visitor), std::forward<VariantRefs>(values)...);
+        return std::visit(std::forward<Visitor>(visitor), std::forward<VariantRefs>(values)...);
     }
 
     template <std::size_t I, typename U> static constexpr void assign(variant_type &value, U &&decoded_value) {
-        if constexpr (requires { value.template emplace<I>(std::forward<U>(decoded_value)); }) {
-            value.template emplace<I>(std::forward<U>(decoded_value));
-        } else if constexpr (std::assignable_from<variant_type &, U>) {
-            value = std::forward<U>(decoded_value);
-        } else {
-            static_assert(detail::variant_dependent_false<U>::value,
-                          "variant-like decode requires emplace<I>(value) or assignment from the decoded alternative");
-        }
+        value.template emplace<I>(std::forward<U>(decoded_value));
     }
 };
 
 namespace detail {
 
-template <typename T, typename = void> struct is_variant_like : std::false_type {};
+template <typename T> using variant_traits_t = variant_traits<std::remove_cvref_t<T>>;
+
+struct variant_probe_visitor {
+    template <typename... Args> constexpr void operator()(Args &&...) const noexcept {}
+};
+
+template <typename T, typename = void> struct variant_traits_size : std::integral_constant<std::size_t, 0U> {
+    static constexpr bool valid = false;
+};
 
 template <typename T>
-struct is_variant_like<T, std::void_t<decltype(variant_traits<std::remove_cvref_t<T>>::size)>>
-    : std::bool_constant<(variant_traits<std::remove_cvref_t<T>>::size > 0U)> {};
+struct variant_traits_size<T, std::void_t<decltype(std::integral_constant<std::size_t, variant_traits_t<T>::size>{})>>
+    : std::integral_constant<std::size_t, variant_traits_t<T>::size> {
+    static constexpr bool valid = true;
+};
+
+template <typename T, std::size_t I>
+concept CompleteVariantTraitAlternative = requires(T &value, const T &const_value, variant_probe_visitor visitor,
+                                                   typename variant_traits_t<T>::template alternative<I> alternative) {
+    typename variant_traits_t<T>::template alternative<I>;
+    { variant_traits_t<T>::index(const_value) } -> std::convertible_to<std::size_t>;
+    variant_traits_t<T>::template get<I>(value);
+    variant_traits_t<T>::template get<I>(const_value);
+    variant_traits_t<T>::visit(visitor, const_value);
+    variant_traits_t<T>::visit(visitor, const_value, const_value);
+    variant_traits_t<T>::template assign<I>(value, std::move(alternative));
+};
+
+template <typename T, std::size_t... Is> consteval bool variant_traits_complete_impl(std::index_sequence<Is...>) {
+    return (CompleteVariantTraitAlternative<std::remove_cvref_t<T>, Is> && ...);
+}
+
+template <typename T> consteval bool variant_traits_complete() {
+    if constexpr (!variant_traits_size<T>::valid || variant_traits_size<T>::value == 0U) {
+        return false;
+    } else {
+        return variant_traits_complete_impl<T>(std::make_index_sequence<variant_traits_size<T>::value>{});
+    }
+}
+
+template <typename T, typename = void> struct is_variant_like : std::false_type {};
+
+template <typename T> struct is_variant_like<T, std::enable_if_t<variant_traits_complete<T>()>> : std::true_type {};
 
 template <typename T>
 concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
 
-template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits<std::remove_cvref_t<Variant>>::size;
+template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits_t<Variant>::size;
 
-template <std::size_t I, typename Variant>
-using variant_alternative_t = typename variant_traits<std::remove_cvref_t<Variant>>::template alternative<I>;
+template <std::size_t I, typename Variant> using variant_alternative_t = typename variant_traits_t<Variant>::template alternative<I>;
 
 template <typename Variant> [[nodiscard]] constexpr std::size_t variant_index(const Variant &value) noexcept {
-    return variant_traits<std::remove_cvref_t<Variant>>::index(value);
+    return variant_traits_t<Variant>::index(value);
 }
 
 template <std::size_t I, typename Variant> constexpr decltype(auto) variant_get(Variant &&value) {
-    return variant_traits<std::remove_cvref_t<Variant>>::template get<I>(std::forward<Variant>(value));
+    return variant_traits_t<Variant>::template get<I>(std::forward<Variant>(value));
 }
 
 template <typename Visitor, typename Variant, typename... Variants>
 constexpr decltype(auto) variant_visit(Visitor &&visitor, Variant &&value, Variants &&...values) {
-    return variant_traits<std::remove_cvref_t<Variant>>::visit(std::forward<Visitor>(visitor), std::forward<Variant>(value),
-                                                               std::forward<Variants>(values)...);
+    return variant_traits_t<Variant>::visit(std::forward<Visitor>(visitor), std::forward<Variant>(value),
+                                            std::forward<Variants>(values)...);
 }
 
 template <std::size_t I, typename Variant, typename U> constexpr void variant_assign(Variant &value, U &&decoded_value) {
-    variant_traits<std::remove_cvref_t<Variant>>::template assign<I>(value, std::forward<U>(decoded_value));
+    variant_traits_t<Variant>::template assign<I>(value, std::forward<U>(decoded_value));
 }
 
 template <typename Variant, typename Fn, std::size_t... Is>

--- a/include/cbor_tags/detail/cbor_cddl_tag_traits.h
+++ b/include/cbor_tags/detail/cbor_cddl_tag_traits.h
@@ -59,9 +59,7 @@ template <typename T> consteval bool cddl_contains_tag_header() {
     if constexpr (IsOptional<value_type>) {
         return cddl_contains_tag_header<typename value_type::value_type>();
     } else if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_contains_tag_header<Ts>() || ...);
-        }(static_cast<value_type *>(nullptr));
+        return with_variant_alternatives<value_type>([]<typename... Ts>() { return (cddl_contains_tag_header<Ts>() || ...); });
     } else {
         return IsTagHeader<value_type>;
     }
@@ -72,9 +70,7 @@ template <typename T> consteval bool cddl_contains_fixed_tag() {
     if constexpr (IsOptional<value_type>) {
         return cddl_contains_fixed_tag<typename value_type::value_type>();
     } else if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_contains_fixed_tag<Ts>() || ...);
-        }(static_cast<value_type *>(nullptr));
+        return with_variant_alternatives<value_type>([]<typename... Ts>() { return (cddl_contains_fixed_tag<Ts>() || ...); });
     } else {
         return cddl_direct_fixed_tag_available<value_type>();
     }
@@ -85,9 +81,7 @@ template <typename T, std::uint64_t Tag> consteval bool cddl_contains_fixed_tag_
     if constexpr (IsOptional<value_type>) {
         return cddl_contains_fixed_tag_value<typename value_type::value_type, Tag>();
     } else if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_contains_fixed_tag_value<Ts, Tag>() || ...);
-        }(static_cast<value_type *>(nullptr));
+        return with_variant_alternatives<value_type>([]<typename... Ts>() { return (cddl_contains_fixed_tag_value<Ts, Tag>() || ...); });
     } else if constexpr (cddl_direct_fixed_tag_available<value_type>()) {
         return cddl_direct_fixed_tag<value_type>() == Tag;
     } else {
@@ -100,9 +94,7 @@ template <typename T> consteval bool cddl_contains_shared_graph_pointer() {
     if constexpr (IsOptional<value_type>) {
         return cddl_contains_shared_graph_pointer<typename value_type::value_type>();
     } else if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_contains_shared_graph_pointer<Ts>() || ...);
-        }(static_cast<value_type *>(nullptr));
+        return with_variant_alternatives<value_type>([]<typename... Ts>() { return (cddl_contains_shared_graph_pointer<Ts>() || ...); });
     } else {
         return is_std_shared_ptr<value_type>::value;
     }
@@ -126,13 +118,9 @@ template <typename A, typename B> consteval bool cddl_fixed_tags_overlap() {
     } else if constexpr (IsOptional<b_type>) {
         return cddl_fixed_tags_overlap<a_type, typename b_type::value_type>();
     } else if constexpr (IsVariant<a_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_fixed_tags_overlap<Ts, b_type>() || ...);
-        }(static_cast<a_type *>(nullptr));
+        return with_variant_alternatives<a_type>([]<typename... Ts>() { return (cddl_fixed_tags_overlap<Ts, b_type>() || ...); });
     } else if constexpr (IsVariant<b_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (cddl_fixed_tags_overlap<a_type, Ts>() || ...);
-        }(static_cast<b_type *>(nullptr));
+        return with_variant_alternatives<b_type>([]<typename... Ts>() { return (cddl_fixed_tags_overlap<a_type, Ts>() || ...); });
     } else if constexpr (cddl_direct_fixed_tag_available<a_type>() && cddl_direct_fixed_tag_available<b_type>()) {
         return cddl_direct_fixed_tag<a_type>() == cddl_direct_fixed_tag<b_type>();
     } else {

--- a/include/cbor_tags/detail/cbor_variant_dispatch.h
+++ b/include/cbor_tags/detail/cbor_variant_dispatch.h
@@ -11,23 +11,7 @@
 namespace cbor::tags::detail {
 
 [[nodiscard]] constexpr bool is_variant_alternative_mismatch(status_code status) noexcept {
-    switch (status) {
-    case status_code::no_match_for_tag:
-    case status_code::no_match_for_tag_simple_on_buffer:
-    case status_code::no_match_for_uint_on_buffer:
-    case status_code::no_match_for_nint_on_buffer:
-    case status_code::no_match_for_int_on_buffer:
-    case status_code::no_match_for_enum_on_buffer:
-    case status_code::no_match_for_bstr_on_buffer:
-    case status_code::no_match_for_tstr_on_buffer:
-    case status_code::no_match_for_array_on_buffer:
-    case status_code::no_match_for_map_on_buffer:
-    case status_code::no_match_for_tag_on_buffer:
-    case status_code::no_match_for_simple_on_buffer:
-    case status_code::no_match_for_optional_on_buffer:
-    case status_code::no_match_in_variant_on_buffer: return true;
-    default: return false;
-    }
+    return status > status_code::begin_no_match_decoding && status < status_code::end_no_match_decoding;
 }
 
 template <bool CatchAllPass, typename U> constexpr bool matches_simple_dispatch(std::byte additional_info) {

--- a/include/cbor_tags/detail/cbor_variant_dispatch.h
+++ b/include/cbor_tags/detail/cbor_variant_dispatch.h
@@ -10,7 +10,9 @@
 
 namespace cbor::tags::detail {
 
-[[nodiscard]] constexpr bool is_variant_alternative_mismatch(status_code status) noexcept {
+// Only a structural mismatch may try the next variant alternative. Malformed
+// input and resource failures must be returned to the caller unchanged.
+[[nodiscard]] constexpr bool is_retriable_variant_mismatch(status_code status) noexcept {
     return status > status_code::begin_no_match_decoding && status < status_code::end_no_match_decoding;
 }
 

--- a/include/cbor_tags/detail/cbor_variant_dispatch.h
+++ b/include/cbor_tags/detail/cbor_variant_dispatch.h
@@ -18,9 +18,10 @@ template <bool CatchAllPass, typename U> constexpr bool matches_simple_dispatch(
         }
         return matches_simple_dispatch<CatchAllPass, typename type::value_type>(additional_info);
     } else if constexpr (IsVariant<type>) {
-        return []<typename... Ts>(std::variant<Ts...> *, std::byte info) {
+        return with_variant_alternatives<type>([additional_info]<typename... Ts>() {
+            const auto info = additional_info;
             return (matches_simple_dispatch<CatchAllPass, Ts>(info) || ...);
-        }(static_cast<type *>(nullptr), additional_info);
+        });
     } else if constexpr (std::is_same_v<type, simple>) {
         const auto value = std::to_integer<std::uint8_t>(additional_info);
         return CatchAllPass && value <= static_cast<std::uint8_t>(SimpleType::Simple);
@@ -36,9 +37,10 @@ template <typename U> constexpr bool matches_major_dispatch(major_type major) {
     if constexpr (IsOptional<type>) {
         return major == major_type::Simple || matches_major_dispatch<typename type::value_type>(major);
     } else if constexpr (IsVariant<type>) {
-        return []<typename... Ts>(std::variant<Ts...> *, major_type m) {
+        return with_variant_alternatives<type>([major]<typename... Ts>() {
+            const auto m = major;
             return (matches_major_dispatch<Ts>(m) || ...);
-        }(static_cast<type *>(nullptr), major);
+        });
     } else {
         return is_valid_major<major_type, type>(major);
     }

--- a/include/cbor_tags/detail/cbor_variant_dispatch.h
+++ b/include/cbor_tags/detail/cbor_variant_dispatch.h
@@ -10,6 +10,26 @@
 
 namespace cbor::tags::detail {
 
+[[nodiscard]] constexpr bool is_variant_alternative_mismatch(status_code status) noexcept {
+    switch (status) {
+    case status_code::no_match_for_tag:
+    case status_code::no_match_for_tag_simple_on_buffer:
+    case status_code::no_match_for_uint_on_buffer:
+    case status_code::no_match_for_nint_on_buffer:
+    case status_code::no_match_for_int_on_buffer:
+    case status_code::no_match_for_enum_on_buffer:
+    case status_code::no_match_for_bstr_on_buffer:
+    case status_code::no_match_for_tstr_on_buffer:
+    case status_code::no_match_for_array_on_buffer:
+    case status_code::no_match_for_map_on_buffer:
+    case status_code::no_match_for_tag_on_buffer:
+    case status_code::no_match_for_simple_on_buffer:
+    case status_code::no_match_for_optional_on_buffer:
+    case status_code::no_match_in_variant_on_buffer: return true;
+    default: return false;
+    }
+}
+
 template <bool CatchAllPass, typename U> constexpr bool matches_simple_dispatch(std::byte additional_info) {
     using type = std::remove_cvref_t<U>;
     if constexpr (IsOptional<type>) {

--- a/include/cbor_tags/detail/cbor_variant_traits.h
+++ b/include/cbor_tags/detail/cbor_variant_traits.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "cbor_tags/cbor_variant_traits.h"
+
+#include <concepts>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+namespace cbor::tags::detail {
+
+template <typename T> using variant_traits_t = variant_traits<std::remove_cvref_t<T>>;
+
+template <typename T> struct is_std_variant : std::false_type {};
+
+template <typename... Ts> struct is_std_variant<std::variant<Ts...>> : std::true_type {};
+
+template <typename T, typename = void> struct variant_traits_size : std::integral_constant<std::size_t, 0U> {
+    static constexpr bool valid = false;
+};
+
+template <typename T>
+struct variant_traits_size<T, std::void_t<decltype(std::integral_constant<std::size_t, variant_traits_t<T>::size>{})>>
+    : std::integral_constant<std::size_t, variant_traits_t<T>::size> {
+    static constexpr bool valid = true;
+};
+
+template <typename T, std::size_t I> using variant_trait_alternative_probe_t = typename variant_traits_t<T>::template alternative<I>;
+
+template <typename T, std::size_t I>
+concept VariantTraitAlternative = requires { typename variant_trait_alternative_probe_t<T, I>; };
+
+template <typename T>
+concept VariantTraitIndexable = requires(const T &const_value) {
+    { variant_traits_t<T>::index(const_value) } -> std::convertible_to<std::size_t>;
+};
+
+template <typename T, std::size_t... Is> consteval bool variant_traits_complete_impl(std::index_sequence<Is...>) {
+    return VariantTraitIndexable<std::remove_cvref_t<T>> && (VariantTraitAlternative<std::remove_cvref_t<T>, Is> && ...);
+}
+
+template <typename T> consteval bool variant_traits_complete() {
+    if constexpr (!variant_traits_size<T>::valid || variant_traits_size<T>::value == 0U) {
+        return false;
+    } else {
+        return variant_traits_complete_impl<T>(std::make_index_sequence<variant_traits_size<T>::value>{});
+    }
+}
+
+template <typename T, typename = void> struct is_variant_like : std::false_type {};
+
+template <typename T> struct is_variant_like<T, std::enable_if_t<is_std_variant<std::remove_cvref_t<T>>::value>> : std::true_type {};
+
+template <typename T>
+struct is_variant_like<T, std::enable_if_t<!is_std_variant<std::remove_cvref_t<T>>::value && variant_traits_complete<T>()>>
+    : std::true_type {};
+
+template <typename T>
+concept VariantLike = is_variant_like<std::remove_cvref_t<T>>::value;
+
+template <typename Variant> inline constexpr std::size_t variant_size_v = variant_traits_t<Variant>::size;
+
+template <std::size_t I, typename Variant> using variant_alternative_t = typename variant_traits_t<Variant>::template alternative<I>;
+
+template <typename Variant> [[nodiscard]] constexpr std::size_t variant_index(const Variant &value) noexcept {
+    static_assert(noexcept(variant_traits_t<Variant>::index(value)), "variant_traits::index must be declared noexcept");
+    return variant_traits_t<Variant>::index(value);
+}
+
+template <std::size_t I, typename Variant> constexpr decltype(auto) variant_get(Variant &&value) {
+    return variant_traits_t<Variant>::template get<I>(std::forward<Variant>(value));
+}
+
+template <typename Visitor, typename Variant, typename... Variants>
+constexpr decltype(auto) variant_visit(Visitor &&visitor, Variant &&value, Variants &&...values) {
+    return variant_traits_t<Variant>::visit(std::forward<Visitor>(visitor), std::forward<Variant>(value),
+                                            std::forward<Variants>(values)...);
+}
+
+template <std::size_t I, typename Variant, typename U> constexpr void variant_assign(Variant &value, U &&decoded_value) {
+    variant_traits_t<Variant>::template assign<I>(value, std::forward<U>(decoded_value));
+}
+
+template <typename Variant, typename Fn, std::size_t... Is>
+constexpr decltype(auto) with_variant_alternatives_impl(Fn &&fn, std::index_sequence<Is...>) {
+    return std::forward<Fn>(fn).template operator()<variant_alternative_t<Is, Variant>...>();
+}
+
+template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternatives(Fn &&fn) {
+    return with_variant_alternatives_impl<std::remove_cvref_t<Variant>>(
+        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
+}
+
+template <typename Variant, typename Fn, std::size_t... Is>
+constexpr decltype(auto) with_variant_alternative_indices_impl(Fn &&fn, std::index_sequence<Is...>) {
+    return std::forward<Fn>(fn).template operator()<Is...>();
+}
+
+template <typename Variant, typename Fn> constexpr decltype(auto) with_variant_alternative_indices(Fn &&fn) {
+    return with_variant_alternative_indices_impl<std::remove_cvref_t<Variant>>(
+        std::forward<Fn>(fn), std::make_index_sequence<variant_size_v<std::remove_cvref_t<Variant>>>{});
+}
+
+} // namespace cbor::tags::detail

--- a/include/cbor_tags/detail/custom_codec_1_serialization.h
+++ b/include/cbor_tags/detail/custom_codec_1_serialization.h
@@ -243,7 +243,7 @@ template <typename T> constexpr std::uint64_t tag_for(const T &value) {
     } else if constexpr (HasTagMember<type>) {
         return tag_to_uint64(Access::cbor_tag(value));
     } else if constexpr (HasTagNonConstructible<type>) {
-        return tag_to_uint64(cbor::tags::cbor_tag<type>());
+        return tag_to_uint64(cbor_tag<type>());
     } else if constexpr (HasTagFreeFunction<type>) {
         return tag_to_uint64(cbor_tag(value));
     } else {
@@ -277,7 +277,7 @@ template <typename T> constexpr std::remove_cvref_t<T> make_decode_value_for_exi
         return value;
     } else if constexpr (std::is_aggregate_v<type> && !is_std_array_v<type> && !IsMap<type> && !IsRangeOfCborValues<type> &&
                          !IsVariant<type> && !is_text_string_v<type> && !IsBinaryString<type>) {
-        auto tuple       = cbor::tags::to_tuple(value);
+        auto tuple       = to_tuple(value);
         using tuple_type = std::remove_cvref_t<decltype(tuple)>;
         return [&]<std::size_t... Indices>(std::index_sequence<Indices...>) {
             return type{make_decode_value_for_existing(std::get<Indices>(tuple))...};
@@ -291,7 +291,7 @@ template <typename T> constexpr T make_decode_value_for_existing_optional(std::o
     if (value.has_value()) {
         return make_decode_value_for_existing(*value);
     }
-    return cbor::tags::detail::make_decode_value_for_optional<T>(value);
+    return make_decode_value_for_optional<T>(value);
 }
 
 template <typename T, typename Allocator> constexpr std::remove_cvref_t<T> make_decode_value_with_allocator(const Allocator &allocator) {
@@ -310,7 +310,7 @@ template <typename T, typename Allocator> constexpr std::remove_cvref_t<T> make_
         }(std::make_index_sequence<std::tuple_size_v<type>>{});
     } else if constexpr (std::is_aggregate_v<type> && !is_std_array_v<type> && !IsMap<type> && !IsRangeOfCborValues<type> &&
                          !IsVariant<type> && !is_text_string_v<type> && !IsBinaryString<type>) {
-        using tuple_type = std::remove_cvref_t<decltype(cbor::tags::to_tuple(std::declval<type &>()))>;
+        using tuple_type = std::remove_cvref_t<decltype(to_tuple(std::declval<type &>()))>;
         return [&]<std::size_t... Indices>(std::index_sequence<Indices...>) {
             return type{make_decode_value_with_allocator<std::remove_cvref_t<std::tuple_element_t<Indices, tuple_type>>>(allocator)...};
         }(std::make_index_sequence<std::tuple_size_v<tuple_type>>{});
@@ -529,7 +529,7 @@ template <typename T> constexpr status_code decode_byte_string(span_reader &read
     if (length > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
         return status_code::error;
     }
-    if constexpr (IsConstBinaryView<type> && cbor::tags::detail::is_static_extent_span_v<type>) {
+    if constexpr (IsConstBinaryView<type> && is_static_extent_span_v<type>) {
         if (length != static_cast<std::uint64_t>(type::extent)) {
             return status_code::unexpected_group_size;
         }
@@ -675,34 +675,34 @@ template <typename T> constexpr status_code decode_optional(span_reader &reader,
 }
 
 template <typename Writer, IsVariant Variant> constexpr void encode_variant(Writer &writer, const Variant &value) {
-    write_varuint(writer, static_cast<std::uint64_t>(cbor::tags::detail::variant_index(value)));
-    cbor::tags::detail::variant_visit([&writer](const auto &alternative) { encode_value(writer, alternative); }, value);
+    write_varuint(writer, static_cast<std::uint64_t>(variant_index(value)));
+    variant_visit([&writer](const auto &alternative) { encode_value(writer, alternative); }, value);
 }
 
 template <std::size_t I = 0, IsVariant Variant>
 constexpr status_code decode_variant_alternative(std::uint64_t index, span_reader &reader, Variant &value) {
     using variant_type = std::remove_cvref_t<Variant>;
 
-    if constexpr (I >= cbor::tags::detail::variant_size_v<variant_type>) {
+    if constexpr (I >= variant_size_v<variant_type>) {
         (void)index;
         (void)reader;
         (void)value;
         return status_code::no_match_in_variant_on_buffer;
     } else {
         if (index == I) {
-            using alternative_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
+            using alternative_type = variant_alternative_t<I, variant_type>;
             auto make_alternative  = [&]() -> alternative_type {
                 if constexpr (std::default_initializable<alternative_type>) {
                     return alternative_type{};
                 } else if constexpr (std::copy_constructible<alternative_type>) {
-                    return alternative_type{cbor::tags::detail::variant_get<I>(value)};
+                    return alternative_type{variant_get<I>(value)};
                 } else {
                     static_assert(dependent_false<alternative_type>::value,
                                   "custom_codec_1 variant alternatives must be default-initializable or copy-constructible");
                 }
             };
             if constexpr (!std::default_initializable<alternative_type>) {
-                if (cbor::tags::detail::variant_index(value) != I) {
+                if (variant_index(value) != I) {
                     return status_code::error;
                 }
             }
@@ -711,7 +711,7 @@ constexpr status_code decode_variant_alternative(std::uint64_t index, span_reade
             if (status != status_code::success) {
                 return status;
             }
-            cbor::tags::detail::variant_assign<I>(value, std::move(alternative));
+            variant_assign<I>(value, std::move(alternative));
             return status_code::success;
         }
         return decode_variant_alternative<I + 1>(index, reader, value);
@@ -903,7 +903,7 @@ template <typename Writer, typename T> constexpr void encode_aggregate(Writer &w
     if constexpr (IsUntaggedTuple<std::remove_cvref_t<T>> || IsTaggedTuple<std::remove_cvref_t<T>>) {
         encode_tuple_fields(writer, value);
     } else {
-        const auto tuple = cbor::tags::to_tuple(value);
+        const auto tuple = to_tuple(value);
         encode_tuple_fields(writer, tuple);
     }
 }
@@ -912,7 +912,7 @@ template <typename T> constexpr status_code decode_aggregate(span_reader &reader
     if constexpr (IsUntaggedTuple<std::remove_cvref_t<T>> || IsTaggedTuple<std::remove_cvref_t<T>>) {
         return decode_tuple_fields(reader, value);
     } else {
-        auto tuple = cbor::tags::to_tuple(value);
+        auto tuple = to_tuple(value);
         return decode_tuple_fields(reader, tuple);
     }
 }
@@ -990,9 +990,9 @@ template <typename T> [[nodiscard]] constexpr std::size_t encoded_size(const T &
 }
 
 template <typename Segments, typename T> [[nodiscard]] inline Segments encode_payload_segments_as(const T &value) {
-    Segments                               payload;
-    cbor::tags::detail::appender<Segments> appender;
-    encode_payload_to(appender, payload, value);
+    Segments           payload;
+    appender<Segments> output_appender;
+    encode_payload_to(output_appender, payload, value);
     return payload;
 }
 
@@ -1042,7 +1042,7 @@ template <typename T> struct has_borrowed_decode_refs {
         } else if constexpr (IsOptional<type>) {
             return has_borrowed_decode_refs<typename type::value_type>::value;
         } else if constexpr (IsVariant<type>) {
-            return cbor::tags::detail::with_variant_alternatives<type>(
+            return with_variant_alternatives<type>(
                 []<typename... Ts>() { return (has_borrowed_decode_refs<std::remove_cvref_t<Ts>>::value || ...); });
         } else if constexpr (IsMap<type>) {
             return has_borrowed_decode_refs<typename type::key_type>::value || has_borrowed_decode_refs<typename type::mapped_type>::value;
@@ -1051,7 +1051,7 @@ template <typename T> struct has_borrowed_decode_refs {
         } else if constexpr (IsUntaggedTuple<type> || IsTaggedTuple<type>) {
             return tuple_has_borrowed_decode_refs<type>::value;
         } else if constexpr (std::is_aggregate_v<type>) {
-            using tuple_type = std::remove_cvref_t<decltype(cbor::tags::to_tuple(std::declval<type &>()))>;
+            using tuple_type = std::remove_cvref_t<decltype(to_tuple(std::declval<type &>()))>;
             return tuple_has_borrowed_decode_refs<tuple_type>::value;
         } else {
             return false;

--- a/include/cbor_tags/detail/custom_codec_1_serialization.h
+++ b/include/cbor_tags/detail/custom_codec_1_serialization.h
@@ -674,33 +674,35 @@ template <typename T> constexpr status_code decode_optional(span_reader &reader,
     return status_code::success;
 }
 
-template <typename Writer, typename... Ts> constexpr void encode_variant(Writer &writer, const std::variant<Ts...> &value) {
-    write_varuint(writer, static_cast<std::uint64_t>(value.index()));
-    std::visit([&writer](const auto &alternative) { encode_value(writer, alternative); }, value);
+template <typename Writer, IsVariant Variant> constexpr void encode_variant(Writer &writer, const Variant &value) {
+    write_varuint(writer, static_cast<std::uint64_t>(cbor::tags::detail::variant_index(value)));
+    cbor::tags::detail::variant_visit([&writer](const auto &alternative) { encode_value(writer, alternative); }, value);
 }
 
-template <std::size_t I = 0, typename... Ts>
-constexpr status_code decode_variant_alternative(std::uint64_t index, span_reader &reader, std::variant<Ts...> &value) {
-    if constexpr (I >= sizeof...(Ts)) {
+template <std::size_t I = 0, IsVariant Variant>
+constexpr status_code decode_variant_alternative(std::uint64_t index, span_reader &reader, Variant &value) {
+    using variant_type = std::remove_cvref_t<Variant>;
+
+    if constexpr (I >= cbor::tags::detail::variant_size_v<variant_type>) {
         (void)index;
         (void)reader;
         (void)value;
         return status_code::no_match_in_variant_on_buffer;
     } else {
         if (index == I) {
-            using alternative_type = std::variant_alternative_t<I, std::variant<Ts...>>;
+            using alternative_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
             auto make_alternative  = [&]() -> alternative_type {
                 if constexpr (std::default_initializable<alternative_type>) {
                     return alternative_type{};
                 } else if constexpr (std::copy_constructible<alternative_type>) {
-                    return alternative_type{std::get<I>(value)};
+                    return alternative_type{cbor::tags::detail::variant_get<I>(value)};
                 } else {
                     static_assert(dependent_false<alternative_type>::value,
                                   "custom_codec_1 variant alternatives must be default-initializable or copy-constructible");
                 }
             };
             if constexpr (!std::default_initializable<alternative_type>) {
-                if (value.index() != I) {
+                if (cbor::tags::detail::variant_index(value) != I) {
                     return status_code::error;
                 }
             }
@@ -709,14 +711,14 @@ constexpr status_code decode_variant_alternative(std::uint64_t index, span_reade
             if (status != status_code::success) {
                 return status;
             }
-            value.template emplace<I>(std::move(alternative));
+            cbor::tags::detail::variant_assign<I>(value, std::move(alternative));
             return status_code::success;
         }
         return decode_variant_alternative<I + 1>(index, reader, value);
     }
 }
 
-template <typename... Ts> constexpr status_code decode_variant(span_reader &reader, std::variant<Ts...> &value) {
+template <IsVariant Variant> constexpr status_code decode_variant(span_reader &reader, Variant &value) {
     std::uint64_t index{};
     auto          status = read_varuint(reader, index);
     if (status != status_code::success) {
@@ -1040,9 +1042,8 @@ template <typename T> struct has_borrowed_decode_refs {
         } else if constexpr (IsOptional<type>) {
             return has_borrowed_decode_refs<typename type::value_type>::value;
         } else if constexpr (IsVariant<type>) {
-            return []<typename... Ts>(std::variant<Ts...> *) consteval {
-                return (has_borrowed_decode_refs<std::remove_cvref_t<Ts>>::value || ...);
-            }(static_cast<type *>(nullptr));
+            return cbor::tags::detail::with_variant_alternatives<type>(
+                []<typename... Ts>() { return (has_borrowed_decode_refs<std::remove_cvref_t<Ts>>::value || ...); });
         } else if constexpr (IsMap<type>) {
             return has_borrowed_decode_refs<typename type::key_type>::value || has_borrowed_decode_refs<typename type::mapped_type>::value;
         } else if constexpr (IsRangeOfCborValues<type>) {

--- a/include/cbor_tags/detail/smart_ptr_traits.h
+++ b/include/cbor_tags/detail/smart_ptr_traits.h
@@ -40,11 +40,22 @@ template <typename T>
 constexpr bool decodable_shared_pointer_v =
     nullable_pointer_traits<std::remove_cvref_t<T>>::decodable && nullable_pointer_traits<std::remove_cvref_t<T>>::shared;
 
+template <typename Variant>
+constexpr bool variant_has_decodable_shared_pointer_v =
+    cbor::tags::detail::with_variant_alternatives<Variant>([]<typename... Ts>() { return (decodable_shared_pointer_v<Ts> || ...); });
+
 template <typename... Ts>
 constexpr std::size_t decodable_nullable_pointer_count_v =
     (std::size_t{0} + ... + (decodable_nullable_pointer_v<Ts> ? std::size_t{1} : std::size_t{0}));
 
 template <typename... Ts> constexpr bool has_decodable_nullable_pointer_v = decodable_nullable_pointer_count_v<Ts...> > 0U;
+
+template <typename Variant>
+constexpr std::size_t variant_decodable_nullable_pointer_count_v =
+    cbor::tags::detail::with_variant_alternatives<Variant>([]<typename... Ts>() { return decodable_nullable_pointer_count_v<Ts...>; });
+
+template <typename Variant>
+constexpr bool variant_has_decodable_nullable_pointer_v = variant_decodable_nullable_pointer_count_v<Variant> > 0U;
 
 template <typename T, bool IsVectorOfSharedPtr = cbor::tags::detail::is_std_vector_of_shared_ptr<T>::value>
 struct decodable_shared_graph_vector : std::false_type {};
@@ -67,6 +78,13 @@ constexpr std::size_t decodable_shared_graph_vector_count_v =
 
 template <typename... Ts> constexpr bool has_decodable_shared_graph_vector_v = decodable_shared_graph_vector_count_v<Ts...> > 0U;
 
+template <typename Variant>
+constexpr std::size_t variant_decodable_shared_graph_vector_count_v =
+    cbor::tags::detail::with_variant_alternatives<Variant>([]<typename... Ts>() { return decodable_shared_graph_vector_count_v<Ts...>; });
+
+template <typename Variant>
+constexpr bool variant_has_decodable_shared_graph_vector_v = variant_decodable_shared_graph_vector_count_v<Variant> > 0U;
+
 template <typename Variant, std::uint64_t Tag>
 constexpr bool variant_contains_static_tag_v = [] {
     constexpr auto tags      = ValidConceptMapping<Variant>::tags;
@@ -86,10 +104,14 @@ constexpr bool variant_has_any_tag_header_v = [] {
     return core_mapping[major_index::AnyTagHeader] != 0U;
 }();
 
+template <typename T, typename... Rest> struct variant_from_pack {
+    using type = std::conditional_t<sizeof...(Rest) == 0U && cbor::tags::IsVariant<T>, std::remove_cvref_t<T>, std::variant<T, Rest...>>;
+};
+
 template <typename... Ts>
 constexpr bool variant_has_shared_graph_tag_collision_v = [] {
-    using variant_type = std::variant<Ts...>;
-    return (decodable_shared_pointer_v<Ts> || ...) &&
+    using variant_type = typename variant_from_pack<Ts...>::type;
+    return variant_has_decodable_shared_pointer_v<variant_type> &&
            (variant_has_any_tag_header_v<variant_type> || variant_contains_static_tag_v<variant_type, shareable_tag> ||
             variant_contains_static_tag_v<variant_type, sharedref_tag>);
 }();

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -256,17 +256,15 @@ void buffer_annotate_smart(const CborBuffer &cbor_buffer, OutputBuffer &output_b
 template <typename T> constexpr auto getName(const T &);
 template <typename T> constexpr auto getName();
 
-template <template <typename...> typename Variant, typename... Ts> constexpr auto getVariantNames() {
-    std::string result;
-    ((result += std::string(getName<Ts>()) + " / "), ...);
-    return result.substr(0, result.empty() ? 0 : (result.size() - 3));
+template <IsVariant Variant> constexpr auto getVariantNames() {
+    return detail::with_variant_alternatives<Variant>([]<typename... Ts>() {
+        std::string result;
+        ((result += std::string(getName<Ts>()) + " / "), ...);
+        return result.substr(0, result.empty() ? 0 : (result.size() - 3));
+    });
 }
 
-template <template <typename...> typename Variant, typename... Ts> constexpr auto getVariantNames(const Variant<Ts...> &&) {
-    std::string result;
-    ((result += std::string(getName<Ts>()) + " / "), ...);
-    return result.substr(0, result.empty() ? 0 : (result.size() - 3));
-}
+template <IsVariant Variant> constexpr auto getVariantNames(const Variant &) { return getVariantNames<std::remove_cvref_t<Variant>>(); }
 
 template <IsTag T> constexpr auto getTagDef(const T &t) {
     if constexpr (HasInlineTag<T>) {
@@ -329,7 +327,7 @@ template <typename T> constexpr auto getName() {
             auto name = getName<element_type>();
             return std::string("[0] / [1, ") + std::string(name) + "]";
         } else if constexpr (IsVariant<T>) {
-            return getVariantNames(T{});
+            return getVariantNames<T>();
         } else {
             return detail::short_type_name<T>();
         }
@@ -426,9 +424,8 @@ template <typename T, typename Seen> consteval bool cddl_contains_nullable_point
         } else if constexpr (IsOptional<value_type> || (IsArray<value_type> && !IsIndefiniteWrapper<value_type>)) {
             return cddl_contains_nullable_pointer<typename value_type::value_type, next_seen>();
         } else if constexpr (IsVariant<value_type>) {
-            return []<typename... Ts>(std::variant<Ts...> *) consteval {
-                return (cddl_contains_nullable_pointer<Ts, next_seen>() || ...);
-            }(static_cast<value_type *>(nullptr));
+            return detail::with_variant_alternatives<value_type>(
+                []<typename... Ts>() { return (cddl_contains_nullable_pointer<Ts, next_seen>() || ...); });
         } else if constexpr (IsNamedMapWrapper<value_type>) {
             return cddl_contains_nullable_pointer<named_map_value_t<value_type>, next_seen>();
         } else if constexpr (IsNamedGroupWrapper<value_type>) {
@@ -454,9 +451,8 @@ template <typename T, typename Seen> consteval bool cddl_contains_nullable_point
 template <typename T> consteval std::size_t cddl_nullable_pointer_alternative_count() {
     using value_type = std::remove_cvref_t<T>;
     if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *) consteval {
-            return (std::size_t{0} + ... + cddl_nullable_pointer_alternative_count<Ts>());
-        }(static_cast<value_type *>(nullptr));
+        return detail::with_variant_alternatives<value_type>(
+            []<typename... Ts>() { return (std::size_t{0} + ... + cddl_nullable_pointer_alternative_count<Ts>()); });
     } else {
         return cddl_contains_nullable_pointer<value_type>() ? std::size_t{1} : std::size_t{0};
     }
@@ -1200,38 +1196,36 @@ template <typename T, cddl_shared_pointer_mode PointerMode> std::string cddl_typ
     } else if constexpr (CDDLMultiDimensionalArray<value_type>) {
         return cddl_multi_dimensional_array_expr<value_type, PointerMode>(context, options);
     } else if constexpr (IsVariant<value_type>) {
-        return []<typename... Ts>(std::variant<Ts...> *, CDDLContext &variant_context, CDDLOptions variant_options) {
-            constexpr auto matching_major_types = valid_concept_mapping_array_v<std::variant<Ts...>>;
+        return detail::with_variant_alternatives<value_type>([&context, &options]<typename... Ts>() {
+            constexpr auto matching_major_types = valid_concept_mapping_array_v<value_type>;
             static_assert(matching_major_types[MajorIndex::Tag] <= 1,
-                          "CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported");
+                          "CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported");
             static_assert(!cddl_scoped_variant_has_tag_overlap<PointerMode, Ts...>(),
-                          "CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported");
+                          "CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported");
             static_assert(matching_major_types[MajorIndex::DynamicTag] == 0,
-                          "CDDL for std::variant alternatives with dynamic CBOR tags is unsupported");
+                          "CDDL for variant alternatives with dynamic CBOR tags is unsupported");
             if constexpr (PointerMode == cddl_shared_pointer_mode::shared_graph) {
                 constexpr auto direct_pointer_alternatives =
                     (std::size_t{0} + ... + (cddl_is_direct_nullable_pointer_alternative<Ts>() ? std::size_t{1} : std::size_t{0}));
                 constexpr auto graph_vector_alternatives =
                     (std::size_t{0} + ... + (cddl_is_shared_graph_vector_alternative<Ts>() ? std::size_t{1} : std::size_t{0}));
                 static_assert((!cddl_contains_unsupported_shared_graph_variant_pointer<Ts>() && ...),
-                              "CDDL for std::variant alternatives containing indirect nullable smart pointers is unsupported");
+                              "CDDL for variant alternatives containing indirect nullable smart pointers is unsupported");
                 static_assert(direct_pointer_alternatives <= 1U,
-                              "CDDL for std::variant alternatives containing multiple nullable smart pointers is unsupported");
+                              "CDDL for variant alternatives containing multiple nullable smart pointers is unsupported");
                 static_assert(direct_pointer_alternatives == 0U || matching_major_types[MajorIndex::Array] == 0U,
-                              "CDDL for std::variant alternatives containing nullable smart pointers and array-shaped alternatives is "
+                              "CDDL for variant alternatives containing nullable smart pointers and array-shaped alternatives is "
                               "unsupported");
                 static_assert(graph_vector_alternatives == 0U || matching_major_types[MajorIndex::Array] == 1U,
-                              "CDDL for std::variant alternatives containing shared graph vector smart pointers and other array-shaped "
+                              "CDDL for variant alternatives containing shared graph vector smart pointers and other array-shaped "
                               "alternatives is unsupported");
             } else {
-                static_assert(
-                    (!cddl_contains_nullable_pointer<Ts>() && ...),
-                    "CDDL for std::variant alternatives containing nullable smart pointers is unsupported because runtime variant "
-                    "decode is not extension-codec aware");
+                static_assert((!cddl_contains_nullable_pointer<Ts>() && ...),
+                              "CDDL for variant alternatives containing nullable smart pointers is unsupported because runtime variant "
+                              "decode is not extension-codec aware");
             }
-            return join_cddl(std::array<std::string, sizeof...(Ts)>{cddl_type_expr<Ts, PointerMode>(variant_context, variant_options)...},
-                             " / ");
-        }(static_cast<value_type *>(nullptr), context, options);
+            return join_cddl(std::array<std::string, sizeof...(Ts)>{cddl_type_expr<Ts, PointerMode>(context, options)...}, " / ");
+        });
     } else if constexpr (IsArrayHeader<value_type>) {
         return "[* any]";
     } else if constexpr (IsMapHeader<value_type>) {

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -302,10 +302,9 @@ template <bool GraphTagsPossible, typename Self, IsVariant Variant>
             }
             if (result == status_code::incomplete) {
                 saw_incomplete = true;
-            } else if constexpr (GraphTagsPossible) {
-                if constexpr (decodable_shared_graph_vector_v<raw_type>) {
-                    pointer_error = result;
-                }
+            } else if (!cbor::tags::detail::is_variant_alternative_mismatch(result) ||
+                       (GraphTagsPossible && decodable_shared_graph_vector_v<raw_type>)) {
+                pointer_error = result;
             }
             return false;
         }

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -178,25 +178,29 @@ template <typename Decoder>
     return status_code::success;
 }
 
-template <bool GraphTagsPossible, typename Self, typename... Ts>
-[[nodiscard]] constexpr status_code decode_variant_with_nullable_pointers_impl(Self &dec, std::variant<Ts...> &value, major_type major,
+template <bool GraphTagsPossible, typename Self, IsVariant Variant>
+[[nodiscard]] constexpr status_code decode_variant_with_nullable_pointers_impl(Self &dec, Variant &value, major_type major,
                                                                                std::byte                     additional_info,
                                                                                std::optional<std::uint64_t> &tag) {
+    using variant_type = std::remove_cvref_t<Variant>;
+
     static_assert(
-        ((IsCborMajor<Ts> || decodable_nullable_pointer_v<Ts> || (GraphTagsPossible && decodable_shared_graph_vector_v<Ts>)) && ...),
-        "Variant alternatives must be core CBOR types, decodable nullable smart pointers, or shared graph vectors for this "
-        "codec.");
-    static_assert(decodable_nullable_pointer_count_v<Ts...> <= 1U,
+        cbor::tags::detail::with_variant_alternatives<variant_type>([]<typename... Alternatives>() {
+            return ((IsCborMajor<Alternatives> || decodable_nullable_pointer_v<Alternatives> ||
+                     (GraphTagsPossible && decodable_shared_graph_vector_v<Alternatives>)) &&
+                    ...);
+        }),
+        "Variant alternatives must be core CBOR types, decodable nullable smart pointers, or shared graph vectors for this codec.");
+    static_assert(variant_decodable_nullable_pointer_count_v<variant_type> <= 1U,
                   "Variant nullable smart pointer alternatives are ambiguous because they share the same [0] / [1, value] shape.");
 
-    using variant_type          = std::variant<Ts...>;
     using major_index           = cbor::tags::detail::MajorIndex;
     constexpr auto core_mapping = valid_concept_mapping_array_v<variant_type>;
-    static_assert(decodable_nullable_pointer_count_v<Ts...> == 0U || core_mapping[major_index::Array] == 0,
+    static_assert(variant_decodable_nullable_pointer_count_v<variant_type> == 0U || core_mapping[major_index::Array] == 0,
                   "Variant nullable smart pointer alternatives are ambiguous with other array-shaped alternatives.");
-    static_assert(decodable_shared_graph_vector_count_v<Ts...> == 0U || core_mapping[major_index::Array] == 1U,
+    static_assert(variant_decodable_shared_graph_vector_count_v<variant_type> == 0U || core_mapping[major_index::Array] == 1U,
                   "Variant shared graph vector alternatives are ambiguous with other array-shaped alternatives.");
-    static_assert(!GraphTagsPossible || !variant_has_shared_graph_tag_collision_v<Ts...>,
+    static_assert(!GraphTagsPossible || !variant_has_shared_graph_tag_collision_v<variant_type>,
                   "Variant shared_ptr alternatives in a shared graph collide with tags 28/29 or a catch-all tag alternative.");
     cbor::tags::detail::require_unambiguous_variant_dispatch_without_array<variant_type>();
     static_assert(valid_concept_mapping_v<variant_type>,
@@ -206,8 +210,8 @@ template <bool GraphTagsPossible, typename Self, typename... Ts>
     std::optional<status_code> pointer_error;
 
     auto try_decode = [&dec, major, additional_info, &value, &tag, &saw_incomplete,
-                       &pointer_error]<bool CatchAllPass, typename U>() -> bool {
-        using raw_type = std::remove_cvref_t<U>;
+                       &pointer_error]<bool CatchAllPass, std::size_t I>() -> bool {
+        using raw_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
 
         if (pointer_error.has_value()) {
             return false;
@@ -249,7 +253,7 @@ template <bool GraphTagsPossible, typename Self, typename... Ts>
                 result = dec.decode(decoded_value, major, additional_info);
             }
             if (result == status_code::success) {
-                value = std::move(decoded_value);
+                cbor::tags::detail::variant_assign<I>(value, std::move(decoded_value));
                 return true;
             }
             if (result == status_code::incomplete) {
@@ -293,7 +297,7 @@ template <bool GraphTagsPossible, typename Self, typename... Ts>
             }
 
             if (result == status_code::success) {
-                value = std::move(decoded_value);
+                cbor::tags::detail::variant_assign<I>(value, std::move(decoded_value));
                 return true;
             }
             if (result == status_code::incomplete) {
@@ -307,14 +311,21 @@ template <bool GraphTagsPossible, typename Self, typename... Ts>
         }
     };
 
+    auto try_decode_alternatives = [&]<bool CatchAllPass, std::size_t... Is>(std::index_sequence<Is...>) {
+        return (try_decode.template operator()<CatchAllPass, Is>() || ...);
+    };
+
     bool found = false;
     if (major == major_type::Simple) {
-        found = (try_decode.template operator()<false, Ts>() || ...);
+        found = try_decode_alternatives.template operator()<false>(
+            std::make_index_sequence<cbor::tags::detail::variant_size_v<variant_type>>{});
         if (!found) {
-            found = (try_decode.template operator()<true, Ts>() || ...);
+            found = try_decode_alternatives.template operator()<true>(
+                std::make_index_sequence<cbor::tags::detail::variant_size_v<variant_type>>{});
         }
     } else {
-        found = (try_decode.template operator()<false, Ts>() || ...);
+        found = try_decode_alternatives.template operator()<false>(
+            std::make_index_sequence<cbor::tags::detail::variant_size_v<variant_type>>{});
     }
     if (!found) {
         if (pointer_error.has_value()) {
@@ -328,8 +339,8 @@ template <bool GraphTagsPossible, typename Self, typename... Ts>
     return status_code::success;
 }
 
-template <bool GraphTagsPossible, typename Self, typename... Ts>
-[[nodiscard]] constexpr status_code decode_variant_with_nullable_pointers(Self &dec, std::variant<Ts...> &value, major_type major,
+template <bool GraphTagsPossible, typename Self, IsVariant Variant>
+[[nodiscard]] constexpr status_code decode_variant_with_nullable_pointers(Self &dec, Variant &value, major_type major,
                                                                           std::byte additional_info) {
     std::optional<std::uint64_t> tag;
     return decode_variant_with_nullable_pointers_impl<GraphTagsPossible>(dec, value, major, additional_info, tag);
@@ -505,9 +516,9 @@ template <typename Self> struct nullable_ptr_codec : detail::nullable_ptr_codec_
         return detail::decode_nullable_pointer(static_cast<Self &>(*this), value, major, additional_info);
     }
 
-    template <typename... Ts>
-        requires(detail::has_decodable_nullable_pointer_v<Ts...> && !detail::has_shared_graph_codec_v<Self>)
-    [[nodiscard]] status_code decode(std::variant<Ts...> &value, major_type major, std::byte additional_info) {
+    template <IsVariant Variant>
+        requires(detail::variant_has_decodable_nullable_pointer_v<Variant> && !detail::has_shared_graph_codec_v<Self>)
+    [[nodiscard]] status_code decode(Variant &value, major_type major, std::byte additional_info) {
         return detail::decode_variant_with_nullable_pointers<false>(static_cast<Self &>(*this), value, major, additional_info);
     }
 };
@@ -619,18 +630,18 @@ template <typename Self> struct shared_graph_codec : detail::shared_graph_codec_
         return decode_shared_graph_pointer(value, tag);
     }
 
-    template <typename... Ts>
-        requires(detail::has_decodable_nullable_pointer_v<Ts...> || detail::has_decodable_shared_graph_vector_v<Ts...>)
-    [[nodiscard]] status_code decode(std::variant<Ts...> &value, major_type major, std::byte additional_info) {
+    template <IsVariant Variant>
+        requires(detail::variant_has_decodable_nullable_pointer_v<Variant> || detail::variant_has_decodable_shared_graph_vector_v<Variant>)
+    [[nodiscard]] status_code decode(Variant &value, major_type major, std::byte additional_info) {
         if (active_decode_session_ == nullptr) {
-            if constexpr (detail::has_nullable_ptr_codec_v<Self> && detail::has_decodable_nullable_pointer_v<Ts...> &&
-                          !detail::has_decodable_shared_graph_vector_v<Ts...>) {
+            if constexpr (detail::has_nullable_ptr_codec_v<Self> && detail::variant_has_decodable_nullable_pointer_v<Variant> &&
+                          !detail::variant_has_decodable_shared_graph_vector_v<Variant>) {
                 return detail::decode_variant_with_nullable_pointers<false>(static_cast<Self &>(*this), value, major, additional_info);
             } else {
                 return status_code::error;
             }
         }
-        if constexpr (detail::variant_has_shared_graph_tag_collision_v<Ts...>) {
+        if constexpr (detail::variant_has_shared_graph_tag_collision_v<Variant>) {
             return status_code::error;
         } else {
             return detail::decode_variant_with_nullable_pointers<true>(static_cast<Self &>(*this), value, major, additional_info);
@@ -638,9 +649,9 @@ template <typename Self> struct shared_graph_codec : detail::shared_graph_codec_
     }
 
   private:
-    template <bool GraphTagsPossible, typename FriendSelf, typename... Ts>
-    friend constexpr status_code detail::decode_variant_with_nullable_pointers_impl(FriendSelf &, std::variant<Ts...> &, major_type,
-                                                                                    std::byte, std::optional<std::uint64_t> &);
+    template <bool GraphTagsPossible, typename FriendSelf, IsVariant FriendVariant>
+    friend constexpr status_code detail::decode_variant_with_nullable_pointers_impl(FriendSelf &, FriendVariant &, major_type, std::byte,
+                                                                                    std::optional<std::uint64_t> &);
 
     template <detail::NullablePointerValue T>
         requires std::default_initializable<T>

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -302,7 +302,7 @@ template <bool GraphTagsPossible, typename Self, IsVariant Variant>
             }
             if (result == status_code::incomplete) {
                 saw_incomplete = true;
-            } else if (!cbor::tags::detail::is_variant_alternative_mismatch(result) ||
+            } else if (!cbor::tags::detail::is_retriable_variant_mismatch(result) ||
                        (GraphTagsPossible && decodable_shared_graph_vector_v<raw_type>)) {
                 pointer_error = result;
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_nullable_pointer_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives containing nullable smart pointers is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives containing nullable smart pointers is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -71,7 +71,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_shared_graph_variant_tag_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -84,7 +84,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_shared_graph_variant_array_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives containing nullable smart pointers and array-shaped alternatives is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives containing nullable smart pointers and array-shaped alternatives is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -110,35 +110,35 @@ add_cddl_shared_graph_compile_fail_test(
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_tag29_compile_fails
   cddl_shared_graph_variant_tag29_compile_fail.cc
-  "CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
+  "CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_any_tag_compile_fails
   cddl_shared_graph_variant_any_tag_compile_fail.cc
-  "CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
+  "CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_nested_any_tag_compile_fails
   cddl_shared_graph_variant_nested_any_tag_compile_fail.cc
-  "CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
+  "CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_multiple_pointers_compile_fails
   cddl_shared_graph_variant_multiple_pointers_compile_fail.cc
-  "CDDL for std::variant alternatives containing multiple nullable smart pointers is unsupported")
+  "CDDL for variant alternatives containing multiple nullable smart pointers is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_optional_pointer_compile_fails
   cddl_shared_graph_variant_optional_pointer_compile_fail.cc
-  "CDDL for std::variant alternatives containing indirect nullable smart pointers is unsupported")
+  "CDDL for variant alternatives containing indirect nullable smart pointers is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_nested_pointer_compile_fails
   cddl_shared_graph_variant_nested_pointer_compile_fail.cc
-  "CDDL for std::variant alternatives containing indirect nullable smart pointers is unsupported")
+  "CDDL for variant alternatives containing indirect nullable smart pointers is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_map_pointer_compile_fails
   cddl_shared_graph_variant_map_pointer_compile_fail.cc
-  "CDDL for std::variant alternatives containing indirect nullable smart pointers is unsupported")
+  "CDDL for variant alternatives containing indirect nullable smart pointers is unsupported")
 add_cddl_shared_graph_compile_fail_test(
   cddl_shared_graph_variant_vector_array_compile_fails
   cddl_shared_graph_variant_vector_array_compile_fail.cc
-  "CDDL for std::variant alternatives containing shared graph vector smart pointers and other array-shaped alternatives is unsupported")
+  "CDDL for variant alternatives containing shared graph vector smart pointers and other array-shaped alternatives is unsupported")
 
 add_executable(cddl_variant_duplicate_tags_compile_fails EXCLUDE_FROM_ALL cddl_variant_duplicate_tags_compile_fail.cc)
 target_link_libraries(cddl_variant_duplicate_tags_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
@@ -149,7 +149,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_duplicate_tags_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -162,7 +162,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_ref_duplicate_tags_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -175,7 +175,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_nested_duplicate_tags_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -188,7 +188,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_structural_duplicate_tags_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -201,7 +201,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_nested_any_tag_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -214,7 +214,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_optional_duplicate_tags_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -227,7 +227,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_any_tag_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -240,7 +240,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_static_tag_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
@@ -253,7 +253,7 @@ add_test(
     "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
     "-DTEST_TARGET=cddl_variant_dynamic_tag_compile_fails"
     "-DCONFIG=$<CONFIG>"
-    "-DPASS_REGEX=CDDL for std::variant alternatives with dynamic CBOR tags is unsupported"
+    "-DPASS_REGEX=CDDL for variant alternatives with dynamic CBOR tags is unsupported"
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,19 @@ add_test(
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
+add_executable(cddl_variant_traits_duplicate_tags_compile_fails EXCLUDE_FROM_ALL cddl_variant_traits_duplicate_tags_compile_fail.cc)
+target_link_libraries(cddl_variant_traits_duplicate_tags_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
+add_test(
+  NAME cddl_variant_traits_duplicate_tags_compile_fails
+  COMMAND
+    ${CMAKE_COMMAND}
+    "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+    "-DTEST_TARGET=cddl_variant_traits_duplicate_tags_compile_fails"
+    "-DCONFIG=$<CONFIG>"
+    "-DPASS_REGEX=CDDL for variant alternatives with duplicate or catch-all CBOR tag matches is unsupported"
+    -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+
 add_executable(cddl_variant_ref_duplicate_tags_compile_fails EXCLUDE_FROM_ALL cddl_variant_ref_duplicate_tags_compile_fail.cc)
 target_link_libraries(cddl_variant_ref_duplicate_tags_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
 add_test(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -166,6 +166,19 @@ add_test(
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
+add_executable(variant_traits_throwing_index_compile_fails EXCLUDE_FROM_ALL variant_traits_throwing_index_compile_fail.cc)
+target_link_libraries(variant_traits_throwing_index_compile_fails PRIVATE cbor::tags)
+add_test(
+  NAME variant_traits_throwing_index_compile_fails
+  COMMAND
+    ${CMAKE_COMMAND}
+    "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+    "-DTEST_TARGET=variant_traits_throwing_index_compile_fails"
+    "-DCONFIG=$<CONFIG>"
+    "-DPASS_REGEX=variant_traits::index must be declared noexcept"
+    -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+
 add_executable(cddl_variant_ref_duplicate_tags_compile_fails EXCLUDE_FROM_ALL cddl_variant_ref_duplicate_tags_compile_fail.cc)
 target_link_libraries(cddl_variant_ref_duplicate_tags_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
 add_test(

--- a/test/cddl_variant_traits_duplicate_tags_compile_fail.cc
+++ b/test/cddl_variant_traits_duplicate_tags_compile_fail.cc
@@ -1,0 +1,53 @@
+#include "cbor_tags/extensions/cbor_visualization.h"
+#include "cbor_tags/extensions/rfc8746_typed_arrays.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <fmt/format.h>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+namespace variant_traits_compile_fail_test {
+
+template <typename... Ts> struct manual_variant {
+    std::variant<Ts...> storage;
+};
+
+} // namespace variant_traits_compile_fail_test
+
+namespace cbor::tags {
+
+template <typename... Ts> struct variant_traits<variant_traits_compile_fail_test::manual_variant<Ts...>> {
+    using variant_type = variant_traits_compile_fail_test::manual_variant<Ts...>;
+
+    static constexpr std::size_t size = sizeof...(Ts);
+
+    template <std::size_t I> using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+    [[nodiscard]] static constexpr std::size_t index(const variant_type &value) noexcept { return value.storage.index(); }
+
+    template <std::size_t I, typename VariantRef> static constexpr decltype(auto) get(VariantRef &&value) {
+        return std::get<I>(std::forward<VariantRef>(value).storage);
+    }
+
+    template <typename Visitor, typename... VariantRefs> static constexpr decltype(auto) visit(Visitor &&visitor, VariantRefs &&...values) {
+        return std::visit(std::forward<Visitor>(visitor), std::forward<VariantRefs>(values).storage...);
+    }
+
+    template <std::size_t I, typename U> static constexpr void assign(variant_type &value, U &&decoded_value) {
+        value.storage.template emplace<I>(std::forward<U>(decoded_value));
+    }
+};
+
+} // namespace cbor::tags
+
+int main() {
+    using namespace cbor::tags::ext::rfc8746;
+
+    using value_type = variant_traits_compile_fail_test::manual_variant<typed_array<std::int32_t>, typed_array_view<std::int32_t>>;
+
+    fmt::memory_buffer buffer;
+    cbor::tags::cddl_schema_to<value_type>(buffer, {.row_options = {.format_by_rows = false}});
+    return 0;
+}

--- a/test/test_header_split_variant_traits.cpp
+++ b/test/test_header_split_variant_traits.cpp
@@ -1,0 +1,18 @@
+#include <cbor_tags/cbor_variant_traits.h>
+#include <cstddef>
+#include <doctest/doctest.h>
+#include <string>
+#include <type_traits>
+#include <variant>
+
+TEST_CASE("variant traits public header is directly usable") {
+    using variant_type = std::variant<int, std::string>;
+    using traits       = cbor::tags::variant_traits<variant_type>;
+
+    static_assert(traits::size == 2U);
+    static_assert(std::is_same_v<traits::alternative<0>, int>);
+
+    variant_type value{std::string{"text"}};
+    CHECK(traits::index(value) == 1U);
+    CHECK(traits::get<1>(value) == "text");
+}

--- a/test/test_status_handling.cpp
+++ b/test/test_status_handling.cpp
@@ -136,11 +136,11 @@ TEST_CASE("status messages cover every declared status code") {
 }
 
 TEST_CASE("variant mismatch classification uses the no-match status range") {
-    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::begin_no_match_decoding));
-    CHECK(detail::is_variant_alternative_mismatch(status_code::no_match_for_tag));
-    CHECK(detail::is_variant_alternative_mismatch(status_code::no_match_in_variant_on_buffer));
-    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::end_no_match_decoding));
-    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::unexpected_group_size));
+    CHECK_FALSE(detail::is_retriable_variant_mismatch(status_code::begin_no_match_decoding));
+    CHECK(detail::is_retriable_variant_mismatch(status_code::no_match_for_tag));
+    CHECK(detail::is_retriable_variant_mismatch(status_code::no_match_in_variant_on_buffer));
+    CHECK_FALSE(detail::is_retriable_variant_mismatch(status_code::end_no_match_decoding));
+    CHECK_FALSE(detail::is_retriable_variant_mismatch(status_code::unexpected_group_size));
 }
 
 TEST_CASE("nested variants dispatch through core tag alternatives") {

--- a/test/test_status_handling.cpp
+++ b/test/test_status_handling.cpp
@@ -135,6 +135,14 @@ TEST_CASE("status messages cover every declared status code") {
     CHECK_EQ(status_message(static_cast<status_code>(255)), "Unknown CBOR status code"sv);
 }
 
+TEST_CASE("variant mismatch classification uses the no-match status range") {
+    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::begin_no_match_decoding));
+    CHECK(detail::is_variant_alternative_mismatch(status_code::no_match_for_tag));
+    CHECK(detail::is_variant_alternative_mismatch(status_code::no_match_in_variant_on_buffer));
+    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::end_no_match_decoding));
+    CHECK_FALSE(detail::is_variant_alternative_mismatch(status_code::unexpected_group_size));
+}
+
 TEST_CASE("nested variants dispatch through core tag alternatives") {
     using nested_type = std::variant<static_tag<42>, std::string>;
     using value_type  = std::variant<std::uint64_t, nested_type>;

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -1,0 +1,247 @@
+#include "cbor_tags/cbor.h"
+#include "cbor_tags/cbor_concepts.h"
+#include "cbor_tags/cbor_concepts_checking.h"
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/cbor_operators.h"
+#include "cbor_tags/extensions/cbor_visualization.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+#include "test_util.h"
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <doctest/doctest.h>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#if __has_include(<boost/variant.hpp>)
+#include <boost/variant.hpp>
+#define CBOR_TAGS_TEST_HAS_BOOST_VARIANT 1
+#endif
+
+#if __has_include(<boost/variant2/variant.hpp>)
+#include <boost/variant2/variant.hpp>
+#define CBOR_TAGS_TEST_HAS_BOOST_VARIANT2 1
+#endif
+
+namespace tags = cbor::tags;
+
+namespace variant_like_test {
+
+template <typename... Ts> struct adl_variant {
+    std::variant<Ts...> storage;
+
+    constexpr adl_variant() = default;
+
+    template <typename T>
+        requires(!std::same_as<std::remove_cvref_t<T>, adl_variant> && std::constructible_from<std::variant<Ts...>, T>)
+    constexpr adl_variant(T &&value) : storage(std::forward<T>(value)) {}
+
+    template <typename T>
+        requires(!std::same_as<std::remove_cvref_t<T>, adl_variant> && std::assignable_from<std::variant<Ts...> &, T>)
+    constexpr adl_variant &operator=(T &&value) {
+        storage = std::forward<T>(value);
+        return *this;
+    }
+
+    [[nodiscard]] constexpr std::size_t index() const noexcept { return storage.index(); }
+
+    template <std::size_t I, typename... Args> constexpr decltype(auto) emplace(Args &&...args) {
+        return storage.template emplace<I>(std::forward<Args>(args)...);
+    }
+};
+
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(adl_variant<Ts...> &value) noexcept {
+    return std::get<I>(value.storage);
+}
+
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const adl_variant<Ts...> &value) noexcept {
+    return std::get<I>(value.storage);
+}
+
+template <typename Visitor, typename... Variants> constexpr decltype(auto) visit(Visitor &&visitor, Variants &&...variants) {
+    return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
+}
+
+template <typename... Ts> struct which_variant {
+    std::variant<Ts...> storage;
+
+    constexpr which_variant() = default;
+
+    template <typename T>
+        requires(!std::same_as<std::remove_cvref_t<T>, which_variant> && std::constructible_from<std::variant<Ts...>, T>)
+    constexpr which_variant(T &&value) : storage(std::forward<T>(value)) {}
+
+    template <typename T>
+        requires(!std::same_as<std::remove_cvref_t<T>, which_variant> && std::assignable_from<std::variant<Ts...> &, T>)
+    constexpr which_variant &operator=(T &&value) {
+        storage = std::forward<T>(value);
+        return *this;
+    }
+
+    [[nodiscard]] constexpr int which() const noexcept { return static_cast<int>(storage.index()); }
+};
+
+template <typename T, typename... Ts> constexpr decltype(auto) get(which_variant<Ts...> &value) noexcept {
+    return std::get<T>(value.storage);
+}
+
+template <typename T, typename... Ts> constexpr decltype(auto) get(const which_variant<Ts...> &value) noexcept {
+    return std::get<T>(value.storage);
+}
+
+template <typename Visitor, typename... Variants> constexpr decltype(auto) apply_visitor(Visitor &&visitor, Variants &&...variants) {
+    return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
+}
+
+} // namespace variant_like_test
+
+TEST_CASE("variant-like traits recognize non-std variant APIs") {
+    using adl_variant   = variant_like_test::adl_variant<std::uint64_t, std::string>;
+    using which_variant = variant_like_test::which_variant<std::uint64_t, std::string>;
+
+    static_assert(tags::IsVariant<adl_variant>);
+    static_assert(tags::IsVariant<which_variant>);
+    static_assert(tags::IsCborMajor<adl_variant>);
+    static_assert(tags::IsCborMajor<which_variant>);
+    static_assert(tags::valid_concept_mapping_v<adl_variant>);
+    static_assert(tags::valid_concept_mapping_v<which_variant>);
+    static_assert(!tags::IsVariant<std::tuple<std::uint64_t, std::string>>);
+
+    CHECK(tags::detail::variant_size_v<adl_variant> == 2U);
+    CHECK(tags::detail::variant_size_v<which_variant> == 2U);
+}
+
+TEST_CASE("variant-like type with ADL visit and indexed get roundtrips through normal CBOR") {
+    using variant = variant_like_test::adl_variant<std::uint64_t, std::string>;
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    variant                input{std::string{"variant-like"}};
+    REQUIRE(enc(input));
+
+    auto    dec = tags::make_decoder(buffer);
+    variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 1U);
+    CHECK(variant_like_test::get<1>(output) == "variant-like");
+}
+
+TEST_CASE("variant-like type with which and apply_visitor uses assignment fallback") {
+    using variant = variant_like_test::which_variant<std::uint64_t, std::string>;
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    variant                input{std::uint64_t{42}};
+    REQUIRE(enc(input));
+
+    auto    dec = tags::make_decoder(buffer);
+    variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 0U);
+    CHECK(variant_like_test::get<std::uint64_t>(output) == 42U);
+}
+
+TEST_CASE("nested variant-like alternatives decode recursively") {
+    using nested_variant = variant_like_test::which_variant<std::uint64_t, std::string>;
+    using outer_variant  = variant_like_test::adl_variant<nested_variant, bool>;
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    REQUIRE(enc(std::string{"nested"}));
+
+    auto          dec = tags::make_decoder(buffer);
+    outer_variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 0U);
+    const auto &nested = variant_like_test::get<0>(output);
+    REQUIRE(tags::detail::variant_index(nested) == 1U);
+    CHECK(variant_like_test::get<std::string>(nested) == "nested");
+}
+
+TEST_CASE("variant-like operators use the variant traits hooks") {
+    using variant = variant_like_test::adl_variant<std::uint64_t, std::string, std::nullptr_t>;
+
+    const variant number{std::uint64_t{7}};
+    const variant text{std::string{"text"}};
+    const variant same_number{std::uint64_t{7}};
+
+    CHECK(tags::variant_comparator<>{}(number, text));
+    CHECK(tags::variant_hasher{}(number) == tags::variant_hasher{}(same_number));
+}
+
+TEST_CASE("variant-like CDDL rendering uses the alternative list") {
+    using variant = variant_like_test::adl_variant<std::uint64_t, std::string>;
+
+    std::string schema;
+    tags::cddl_schema_to<variant>(schema, {.row_options = {.format_by_rows = false}});
+    CHECK_EQ(schema, "root = uint / tstr");
+}
+
+TEST_CASE("custom codec variant serialization uses variant-like traits") {
+    namespace compact = tags::ext::custom_codec_1;
+
+    using variant = variant_like_test::which_variant<std::uint8_t, std::string>;
+
+    std::vector<std::byte> compact_buffer;
+    auto                   enc = tags::make_encoder<compact::custom_codec_1>(compact_buffer);
+    variant                input{std::string{"hi"}};
+    REQUIRE(enc(compact::as_custom_codec_1(tags::static_tag<77>{}, input)));
+
+    auto    dec = tags::make_decoder<compact::custom_codec_1>(compact_buffer);
+    variant output;
+    REQUIRE(dec(compact::as_custom_codec_1(tags::static_tag<77>{}, output)));
+
+    REQUIRE(tags::detail::variant_index(output) == 1U);
+    CHECK(variant_like_test::get<std::string>(output) == "hi");
+}
+
+#if CBOR_TAGS_TEST_HAS_BOOST_VARIANT
+TEST_CASE("boost variant roundtrips through variant-like traits when available") {
+    using variant = boost::variant<std::uint64_t, std::string>;
+
+    static_assert(tags::IsVariant<variant>);
+    static_assert(tags::valid_concept_mapping_v<variant>);
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    variant                input{std::string{"boost"}};
+    REQUIRE(enc(input));
+
+    auto    dec = tags::make_decoder(buffer);
+    variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 1U);
+    CHECK(boost::get<std::string>(output) == "boost");
+}
+#endif
+
+#if CBOR_TAGS_TEST_HAS_BOOST_VARIANT2
+TEST_CASE("boost variant2 roundtrips through variant-like traits when available") {
+    using variant = boost::variant2::variant<std::uint64_t, std::string>;
+
+    static_assert(tags::IsVariant<variant>);
+    static_assert(tags::valid_concept_mapping_v<variant>);
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    variant                input{std::string{"boost2"}};
+    REQUIRE(enc(input));
+
+    auto    dec = tags::make_decoder(buffer);
+    variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 1U);
+    CHECK(boost::variant2::get<std::string>(output) == "boost2");
+}
+#endif

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -198,17 +198,15 @@ TEST_CASE("variant decoding preserves hard alternative failures") {
     }
 }
 
-TEST_CASE("custom variant traits support operators") {
+TEST_CASE("custom variant traits support comparison") {
     using variant = variant_traits_test::manual_variant<std::uint64_t, std::string, std::nullptr_t>;
 
     const variant number{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::uint64_t{7}}};
     const variant text{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::string{"aa"}}};
     const variant later_text{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::string{"zz"}}};
-    const variant same_number{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::uint64_t{7}}};
 
     CHECK(tags::variant_comparator<>{}(number, text));
     CHECK(tags::variant_comparator<>{}(text, later_text));
-    CHECK(tags::variant_hasher{}(number) == tags::variant_hasher{}(same_number));
 }
 
 TEST_CASE("custom variant traits render CDDL") {

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -64,7 +64,17 @@ template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const adl_
     return std::get<I>(value.storage);
 }
 
-template <typename Visitor, typename... Variants> constexpr decltype(auto) visit(Visitor &&visitor, Variants &&...variants) {
+template <typename T>
+concept HasVariantStorage = requires(T &&value) { std::forward<T>(value).storage; };
+
+template <typename T>
+concept HasIndexMember = requires(const std::remove_cvref_t<T> &value) {
+    { value.index() } -> std::convertible_to<std::size_t>;
+};
+
+template <typename Visitor, typename... Variants>
+    requires((HasVariantStorage<Variants> && HasIndexMember<Variants>) && ...)
+constexpr decltype(auto) visit(Visitor &&visitor, Variants &&...variants) {
     return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
 }
 
@@ -95,25 +105,60 @@ template <typename T, typename... Ts> constexpr decltype(auto) get(const which_v
     return std::get<T>(value.storage);
 }
 
-template <typename Visitor, typename... Variants> constexpr decltype(auto) apply_visitor(Visitor &&visitor, Variants &&...variants) {
+template <typename Visitor, typename... Variants>
+    requires(HasVariantStorage<Variants> && ...)
+constexpr decltype(auto) apply_visitor(Visitor &&visitor, Variants &&...variants) {
     return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
 }
+
+template <typename... Ts> struct aggregate_adl_variant {
+    std::variant<Ts...> storage;
+
+    [[nodiscard]] constexpr std::size_t index() const noexcept { return storage.index(); }
+
+    template <std::size_t I, typename... Args> constexpr decltype(auto) emplace(Args &&...args) {
+        return storage.template emplace<I>(std::forward<Args>(args)...);
+    }
+};
+
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(aggregate_adl_variant<Ts...> &value) noexcept {
+    return std::get<I>(value.storage);
+}
+
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const aggregate_adl_variant<Ts...> &value) noexcept {
+    return std::get<I>(value.storage);
+}
+
+template <typename... Ts> struct indexed_aggregate {
+    std::size_t selected{};
+
+    [[nodiscard]] constexpr std::size_t index() const noexcept { return selected; }
+};
 
 } // namespace variant_like_test
 
 TEST_CASE("variant-like traits recognize non-std variant APIs") {
-    using adl_variant   = variant_like_test::adl_variant<std::uint64_t, std::string>;
-    using which_variant = variant_like_test::which_variant<std::uint64_t, std::string>;
+    using adl_variant       = variant_like_test::adl_variant<std::uint64_t, std::string>;
+    using aggregate_variant = variant_like_test::aggregate_adl_variant<std::uint64_t, std::string>;
+    using indexed_aggregate = variant_like_test::indexed_aggregate<std::uint64_t, std::string>;
+    using which_variant     = variant_like_test::which_variant<std::uint64_t, std::string>;
 
     static_assert(tags::IsVariant<adl_variant>);
+    static_assert(tags::IsVariant<aggregate_variant>);
     static_assert(tags::IsVariant<which_variant>);
     static_assert(tags::IsCborMajor<adl_variant>);
+    static_assert(tags::IsCborMajor<aggregate_variant>);
     static_assert(tags::IsCborMajor<which_variant>);
     static_assert(tags::valid_concept_mapping_v<adl_variant>);
+    static_assert(tags::valid_concept_mapping_v<aggregate_variant>);
     static_assert(tags::valid_concept_mapping_v<which_variant>);
+    static_assert(!tags::IsVariant<indexed_aggregate>);
+    static_assert(std::is_aggregate_v<aggregate_variant>);
+    static_assert(!tags::IsAggregate<aggregate_variant>);
     static_assert(!tags::IsVariant<std::tuple<std::uint64_t, std::string>>);
 
     CHECK(tags::detail::variant_size_v<adl_variant> == 2U);
+    CHECK(tags::detail::variant_size_v<aggregate_variant> == 2U);
     CHECK(tags::detail::variant_size_v<which_variant> == 2U);
 }
 
@@ -131,6 +176,22 @@ TEST_CASE("variant-like type with ADL visit and indexed get roundtrips through n
 
     REQUIRE(tags::detail::variant_index(output) == 1U);
     CHECK(variant_like_test::get<1>(output) == "variant-like");
+}
+
+TEST_CASE("aggregate variant-like wrapper roundtrips as a variant instead of an aggregate") {
+    using variant = variant_like_test::aggregate_adl_variant<std::uint64_t, std::string>;
+
+    std::vector<std::byte> buffer;
+    auto                   enc = tags::make_encoder(buffer);
+    variant                input{std::variant<std::uint64_t, std::string>{std::string{"aggregate-variant"}}};
+    REQUIRE(enc(input));
+
+    auto    dec = tags::make_decoder(buffer);
+    variant output;
+    REQUIRE(dec(output));
+
+    REQUIRE(tags::detail::variant_index(output) == 1U);
+    CHECK(variant_like_test::get<1>(output) == "aggregate-variant");
 }
 
 TEST_CASE("variant-like type with which and apply_visitor uses assignment fallback") {

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -9,6 +9,7 @@
 #include "cbor_tags/extensions/smart_ptr.h"
 #include "test_util.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <doctest/doctest.h>
@@ -169,6 +170,34 @@ TEST_CASE("custom variant traits decode nested alternatives recursively") {
     CHECK(std::get<1>(nested.storage) == "nested");
 }
 
+TEST_CASE("variant decoding preserves hard alternative failures") {
+    const std::vector<std::byte> wrong_sized_bstr{std::byte{0x41}, std::byte{0xaa}};
+
+    SUBCASE("std variant") {
+        std::variant<std::uint64_t, std::array<std::byte, 2>> output{std::uint64_t{7}};
+        auto                                                  dec    = tags::make_decoder(wrong_sized_bstr);
+        const auto                                            result = dec(output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), tags::status_code::unexpected_group_size);
+        REQUIRE(output.index() == 0U);
+        CHECK_EQ(std::get<0>(output), 7U);
+    }
+
+    SUBCASE("trait-backed variant") {
+        using variant = variant_traits_test::manual_variant<std::uint64_t, std::array<std::byte, 2>>;
+
+        variant    output{std::variant<std::uint64_t, std::array<std::byte, 2>>{std::uint64_t{7}}};
+        auto       dec    = tags::make_decoder(wrong_sized_bstr);
+        const auto result = dec(output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), tags::status_code::unexpected_group_size);
+        REQUIRE(tags::detail::variant_index(output) == 0U);
+        CHECK_EQ(std::get<0>(output.storage), 7U);
+    }
+}
+
 TEST_CASE("custom variant traits support operators") {
     using variant = variant_traits_test::manual_variant<std::uint64_t, std::string, std::nullptr_t>;
 
@@ -261,6 +290,21 @@ TEST_CASE("custom variant traits work with nullable smart pointer codec") {
 
         REQUIRE(tags::detail::variant_index(output) == 1U);
         CHECK_EQ(std::get<1>(output.storage), "ok");
+    }
+
+    {
+        using fixed_bstr_variant = variant_traits_test::manual_variant<std::shared_ptr<std::uint64_t>, std::array<std::byte, 2>>;
+
+        const std::vector<std::byte> wrong_sized_bstr{std::byte{0x41}, std::byte{0xaa}};
+        auto                         original = std::make_shared<std::uint64_t>(9U);
+        fixed_bstr_variant           output{std::variant<std::shared_ptr<std::uint64_t>, std::array<std::byte, 2>>{original}};
+        auto                         dec    = tags::make_decoder<smart::nullable_ptr_codec>(wrong_sized_bstr);
+        auto                         result = dec(output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), tags::status_code::unexpected_group_size);
+        REQUIRE(tags::detail::variant_index(output) == 0U);
+        CHECK(std::get<0>(output.storage) == original);
     }
 }
 

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -125,6 +125,7 @@ TEST_CASE("non-std variants require explicit variant_traits opt-in") {
     static_assert(!tags::IsVariant<std::tuple<std::uint64_t, std::string>>);
 
     static_assert(tags::IsVariant<std::variant<std::uint64_t, std::string>>);
+    static_assert(tags::IsVariant<tags::detail::catch_all_variant>);
     static_assert(tags::IsVariant<manual_variant>);
     static_assert(std::is_aggregate_v<manual_variant>);
     static_assert(tags::IsCborMajor<manual_variant>);

--- a/test/test_variant_like.cpp
+++ b/test/test_variant_like.cpp
@@ -6,12 +6,13 @@
 #include "cbor_tags/cbor_operators.h"
 #include "cbor_tags/extensions/cbor_visualization.h"
 #include "cbor_tags/extensions/custom_codec_1.h"
+#include "cbor_tags/extensions/smart_ptr.h"
 #include "test_util.h"
 
-#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <doctest/doctest.h>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -19,35 +20,12 @@
 #include <variant>
 #include <vector>
 
-#if __has_include(<boost/variant.hpp>)
-#include <boost/variant.hpp>
-#define CBOR_TAGS_TEST_HAS_BOOST_VARIANT 1
-#endif
-
-#if __has_include(<boost/variant2/variant.hpp>)
-#include <boost/variant2/variant.hpp>
-#define CBOR_TAGS_TEST_HAS_BOOST_VARIANT2 1
-#endif
-
 namespace tags = cbor::tags;
 
-namespace variant_like_test {
+namespace variant_traits_test {
 
-template <typename... Ts> struct adl_variant {
+template <typename... Ts> struct structural_variant {
     std::variant<Ts...> storage;
-
-    constexpr adl_variant() = default;
-
-    template <typename T>
-        requires(!std::same_as<std::remove_cvref_t<T>, adl_variant> && std::constructible_from<std::variant<Ts...>, T>)
-    constexpr adl_variant(T &&value) : storage(std::forward<T>(value)) {}
-
-    template <typename T>
-        requires(!std::same_as<std::remove_cvref_t<T>, adl_variant> && std::assignable_from<std::variant<Ts...> &, T>)
-    constexpr adl_variant &operator=(T &&value) {
-        storage = std::forward<T>(value);
-        return *this;
-    }
 
     [[nodiscard]] constexpr std::size_t index() const noexcept { return storage.index(); }
 
@@ -56,118 +34,112 @@ template <typename... Ts> struct adl_variant {
     }
 };
 
-template <std::size_t I, typename... Ts> constexpr decltype(auto) get(adl_variant<Ts...> &value) noexcept {
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(structural_variant<Ts...> &value) noexcept {
     return std::get<I>(value.storage);
 }
 
-template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const adl_variant<Ts...> &value) noexcept {
+template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const structural_variant<Ts...> &value) noexcept {
     return std::get<I>(value.storage);
 }
 
-template <typename T>
-concept HasVariantStorage = requires(T &&value) { std::forward<T>(value).storage; };
-
-template <typename T>
-concept HasIndexMember = requires(const std::remove_cvref_t<T> &value) {
-    { value.index() } -> std::convertible_to<std::size_t>;
-};
-
-template <typename Visitor, typename... Variants>
-    requires((HasVariantStorage<Variants> && HasIndexMember<Variants>) && ...)
-constexpr decltype(auto) visit(Visitor &&visitor, Variants &&...variants) {
+template <typename Visitor, typename... Variants> constexpr decltype(auto) visit(Visitor &&visitor, Variants &&...variants) {
     return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
 }
 
-template <typename... Ts> struct which_variant {
+template <typename... Ts> struct legacy_structural_variant {
     std::variant<Ts...> storage;
-
-    constexpr which_variant() = default;
-
-    template <typename T>
-        requires(!std::same_as<std::remove_cvref_t<T>, which_variant> && std::constructible_from<std::variant<Ts...>, T>)
-    constexpr which_variant(T &&value) : storage(std::forward<T>(value)) {}
-
-    template <typename T>
-        requires(!std::same_as<std::remove_cvref_t<T>, which_variant> && std::assignable_from<std::variant<Ts...> &, T>)
-    constexpr which_variant &operator=(T &&value) {
-        storage = std::forward<T>(value);
-        return *this;
-    }
 
     [[nodiscard]] constexpr int which() const noexcept { return static_cast<int>(storage.index()); }
-};
 
-template <typename T, typename... Ts> constexpr decltype(auto) get(which_variant<Ts...> &value) noexcept {
-    return std::get<T>(value.storage);
-}
-
-template <typename T, typename... Ts> constexpr decltype(auto) get(const which_variant<Ts...> &value) noexcept {
-    return std::get<T>(value.storage);
-}
-
-template <typename Visitor, typename... Variants>
-    requires(HasVariantStorage<Variants> && ...)
-constexpr decltype(auto) apply_visitor(Visitor &&visitor, Variants &&...variants) {
-    return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
-}
-
-template <typename... Ts> struct aggregate_adl_variant {
-    std::variant<Ts...> storage;
-
-    [[nodiscard]] constexpr std::size_t index() const noexcept { return storage.index(); }
-
-    template <std::size_t I, typename... Args> constexpr decltype(auto) emplace(Args &&...args) {
-        return storage.template emplace<I>(std::forward<Args>(args)...);
+    template <typename U> constexpr legacy_structural_variant &operator=(U &&value) {
+        storage = std::forward<U>(value);
+        return *this;
     }
 };
 
-template <std::size_t I, typename... Ts> constexpr decltype(auto) get(aggregate_adl_variant<Ts...> &value) noexcept {
-    return std::get<I>(value.storage);
+template <typename T, typename... Ts> constexpr decltype(auto) get(legacy_structural_variant<Ts...> &value) noexcept {
+    return std::get<T>(value.storage);
 }
 
-template <std::size_t I, typename... Ts> constexpr decltype(auto) get(const aggregate_adl_variant<Ts...> &value) noexcept {
-    return std::get<I>(value.storage);
+template <typename T, typename... Ts> constexpr decltype(auto) get(const legacy_structural_variant<Ts...> &value) noexcept {
+    return std::get<T>(value.storage);
 }
 
-template <typename... Ts> struct indexed_aggregate {
-    std::size_t selected{};
+template <typename Visitor, typename... Variants> constexpr decltype(auto) apply_visitor(Visitor &&visitor, Variants &&...variants) {
+    return std::visit(std::forward<Visitor>(visitor), std::forward<Variants>(variants).storage...);
+}
 
-    [[nodiscard]] constexpr std::size_t index() const noexcept { return selected; }
+template <typename... Ts> struct manual_variant {
+    std::variant<Ts...> storage;
+
+    [[nodiscard]] constexpr std::size_t selected() const noexcept { return storage.index(); }
 };
 
-} // namespace variant_like_test
+struct incomplete_traits_variant {
+    std::variant<std::uint64_t, std::string> storage;
+};
 
-TEST_CASE("variant-like traits recognize non-std variant APIs") {
-    using adl_variant       = variant_like_test::adl_variant<std::uint64_t, std::string>;
-    using aggregate_variant = variant_like_test::aggregate_adl_variant<std::uint64_t, std::string>;
-    using indexed_aggregate = variant_like_test::indexed_aggregate<std::uint64_t, std::string>;
-    using which_variant     = variant_like_test::which_variant<std::uint64_t, std::string>;
+} // namespace variant_traits_test
 
-    static_assert(tags::IsVariant<adl_variant>);
-    static_assert(tags::IsVariant<aggregate_variant>);
-    static_assert(tags::IsVariant<which_variant>);
-    static_assert(tags::IsCborMajor<adl_variant>);
-    static_assert(tags::IsCborMajor<aggregate_variant>);
-    static_assert(tags::IsCborMajor<which_variant>);
-    static_assert(tags::valid_concept_mapping_v<adl_variant>);
-    static_assert(tags::valid_concept_mapping_v<aggregate_variant>);
-    static_assert(tags::valid_concept_mapping_v<which_variant>);
-    static_assert(!tags::IsVariant<indexed_aggregate>);
-    static_assert(std::is_aggregate_v<aggregate_variant>);
-    static_assert(!tags::IsAggregate<aggregate_variant>);
+namespace cbor::tags {
+
+template <typename... Ts> struct variant_traits<variant_traits_test::manual_variant<Ts...>> {
+    using variant_type = variant_traits_test::manual_variant<Ts...>;
+
+    static constexpr std::size_t size = sizeof...(Ts);
+
+    template <std::size_t I> using alternative = std::tuple_element_t<I, std::tuple<Ts...>>;
+
+    [[nodiscard]] static constexpr std::size_t index(const variant_type &value) noexcept { return value.selected(); }
+
+    template <std::size_t I, typename VariantRef> static constexpr decltype(auto) get(VariantRef &&value) {
+        return std::get<I>(std::forward<VariantRef>(value).storage);
+    }
+
+    template <typename Visitor, typename... VariantRefs> static constexpr decltype(auto) visit(Visitor &&visitor, VariantRefs &&...values) {
+        return std::visit(std::forward<Visitor>(visitor), std::forward<VariantRefs>(values).storage...);
+    }
+
+    template <std::size_t I, typename U> static constexpr void assign(variant_type &value, U &&decoded_value) {
+        value.storage.template emplace<I>(std::forward<U>(decoded_value));
+    }
+};
+
+template <> struct variant_traits<variant_traits_test::incomplete_traits_variant> {
+    static constexpr std::size_t size = 2U;
+};
+
+} // namespace cbor::tags
+
+TEST_CASE("non-std variants require explicit variant_traits opt-in") {
+    using structural_variant = variant_traits_test::structural_variant<std::uint64_t, std::string>;
+    using legacy_variant     = variant_traits_test::legacy_structural_variant<std::uint64_t, std::string>;
+    using manual_variant     = variant_traits_test::manual_variant<std::uint64_t, std::string>;
+    using incomplete_variant = variant_traits_test::incomplete_traits_variant;
+
+    static_assert(!tags::IsVariant<structural_variant>);
+    static_assert(tags::IsAggregate<structural_variant>);
+    static_assert(!tags::IsVariant<legacy_variant>);
+    static_assert(!tags::IsCborMajor<legacy_variant>);
+    static_assert(!tags::IsVariant<incomplete_variant>);
     static_assert(!tags::IsVariant<std::tuple<std::uint64_t, std::string>>);
 
-    CHECK(tags::detail::variant_size_v<adl_variant> == 2U);
-    CHECK(tags::detail::variant_size_v<aggregate_variant> == 2U);
-    CHECK(tags::detail::variant_size_v<which_variant> == 2U);
+    static_assert(tags::IsVariant<std::variant<std::uint64_t, std::string>>);
+    static_assert(tags::IsVariant<manual_variant>);
+    static_assert(std::is_aggregate_v<manual_variant>);
+    static_assert(tags::IsCborMajor<manual_variant>);
+    static_assert(tags::valid_concept_mapping_v<manual_variant>);
+    static_assert(!tags::IsAggregate<manual_variant>);
+
+    CHECK(tags::detail::variant_size_v<manual_variant> == 2U);
 }
 
-TEST_CASE("variant-like type with ADL visit and indexed get roundtrips through normal CBOR") {
-    using variant = variant_like_test::adl_variant<std::uint64_t, std::string>;
+TEST_CASE("custom variant traits roundtrip through normal CBOR") {
+    using variant = variant_traits_test::manual_variant<std::uint64_t, std::string>;
 
     std::vector<std::byte> buffer;
     auto                   enc = tags::make_encoder(buffer);
-    variant                input{std::string{"variant-like"}};
+    variant                input{std::variant<std::uint64_t, std::string>{std::string{"manual-variant"}}};
     REQUIRE(enc(input));
 
     auto    dec = tags::make_decoder(buffer);
@@ -175,44 +147,12 @@ TEST_CASE("variant-like type with ADL visit and indexed get roundtrips through n
     REQUIRE(dec(output));
 
     REQUIRE(tags::detail::variant_index(output) == 1U);
-    CHECK(variant_like_test::get<1>(output) == "variant-like");
+    CHECK(std::get<1>(output.storage) == "manual-variant");
 }
 
-TEST_CASE("aggregate variant-like wrapper roundtrips as a variant instead of an aggregate") {
-    using variant = variant_like_test::aggregate_adl_variant<std::uint64_t, std::string>;
-
-    std::vector<std::byte> buffer;
-    auto                   enc = tags::make_encoder(buffer);
-    variant                input{std::variant<std::uint64_t, std::string>{std::string{"aggregate-variant"}}};
-    REQUIRE(enc(input));
-
-    auto    dec = tags::make_decoder(buffer);
-    variant output;
-    REQUIRE(dec(output));
-
-    REQUIRE(tags::detail::variant_index(output) == 1U);
-    CHECK(variant_like_test::get<1>(output) == "aggregate-variant");
-}
-
-TEST_CASE("variant-like type with which and apply_visitor uses assignment fallback") {
-    using variant = variant_like_test::which_variant<std::uint64_t, std::string>;
-
-    std::vector<std::byte> buffer;
-    auto                   enc = tags::make_encoder(buffer);
-    variant                input{std::uint64_t{42}};
-    REQUIRE(enc(input));
-
-    auto    dec = tags::make_decoder(buffer);
-    variant output;
-    REQUIRE(dec(output));
-
-    REQUIRE(tags::detail::variant_index(output) == 0U);
-    CHECK(variant_like_test::get<std::uint64_t>(output) == 42U);
-}
-
-TEST_CASE("nested variant-like alternatives decode recursively") {
-    using nested_variant = variant_like_test::which_variant<std::uint64_t, std::string>;
-    using outer_variant  = variant_like_test::adl_variant<nested_variant, bool>;
+TEST_CASE("custom variant traits decode nested alternatives recursively") {
+    using nested_variant = variant_traits_test::manual_variant<std::uint64_t, std::string>;
+    using outer_variant  = variant_traits_test::manual_variant<nested_variant, bool>;
 
     std::vector<std::byte> buffer;
     auto                   enc = tags::make_encoder(buffer);
@@ -223,38 +163,40 @@ TEST_CASE("nested variant-like alternatives decode recursively") {
     REQUIRE(dec(output));
 
     REQUIRE(tags::detail::variant_index(output) == 0U);
-    const auto &nested = variant_like_test::get<0>(output);
+    const auto &nested = std::get<0>(output.storage);
     REQUIRE(tags::detail::variant_index(nested) == 1U);
-    CHECK(variant_like_test::get<std::string>(nested) == "nested");
+    CHECK(std::get<1>(nested.storage) == "nested");
 }
 
-TEST_CASE("variant-like operators use the variant traits hooks") {
-    using variant = variant_like_test::adl_variant<std::uint64_t, std::string, std::nullptr_t>;
+TEST_CASE("custom variant traits support operators") {
+    using variant = variant_traits_test::manual_variant<std::uint64_t, std::string, std::nullptr_t>;
 
-    const variant number{std::uint64_t{7}};
-    const variant text{std::string{"text"}};
-    const variant same_number{std::uint64_t{7}};
+    const variant number{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::uint64_t{7}}};
+    const variant text{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::string{"aa"}}};
+    const variant later_text{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::string{"zz"}}};
+    const variant same_number{std::variant<std::uint64_t, std::string, std::nullptr_t>{std::uint64_t{7}}};
 
     CHECK(tags::variant_comparator<>{}(number, text));
+    CHECK(tags::variant_comparator<>{}(text, later_text));
     CHECK(tags::variant_hasher{}(number) == tags::variant_hasher{}(same_number));
 }
 
-TEST_CASE("variant-like CDDL rendering uses the alternative list") {
-    using variant = variant_like_test::adl_variant<std::uint64_t, std::string>;
+TEST_CASE("custom variant traits render CDDL") {
+    using variant = variant_traits_test::manual_variant<std::uint64_t, std::string>;
 
     std::string schema;
     tags::cddl_schema_to<variant>(schema, {.row_options = {.format_by_rows = false}});
     CHECK_EQ(schema, "root = uint / tstr");
 }
 
-TEST_CASE("custom codec variant serialization uses variant-like traits") {
+TEST_CASE("custom codec variant serialization uses custom variant traits") {
     namespace compact = tags::ext::custom_codec_1;
 
-    using variant = variant_like_test::which_variant<std::uint8_t, std::string>;
+    using variant = variant_traits_test::manual_variant<std::uint8_t, std::string>;
 
     std::vector<std::byte> compact_buffer;
     auto                   enc = tags::make_encoder<compact::custom_codec_1>(compact_buffer);
-    variant                input{std::string{"hi"}};
+    variant                input{std::variant<std::uint8_t, std::string>{std::string{"hi"}}};
     REQUIRE(enc(compact::as_custom_codec_1(tags::static_tag<77>{}, input)));
 
     auto    dec = tags::make_decoder<compact::custom_codec_1>(compact_buffer);
@@ -262,47 +204,96 @@ TEST_CASE("custom codec variant serialization uses variant-like traits") {
     REQUIRE(dec(compact::as_custom_codec_1(tags::static_tag<77>{}, output)));
 
     REQUIRE(tags::detail::variant_index(output) == 1U);
-    CHECK(variant_like_test::get<std::string>(output) == "hi");
+    CHECK(std::get<1>(output.storage) == "hi");
 }
 
-#if CBOR_TAGS_TEST_HAS_BOOST_VARIANT
-TEST_CASE("boost variant roundtrips through variant-like traits when available") {
-    using variant = boost::variant<std::uint64_t, std::string>;
+TEST_CASE("custom variant traits work with nullable smart pointer codec") {
+    namespace smart = tags::ext::smart_ptr;
 
-    static_assert(tags::IsVariant<variant>);
-    static_assert(tags::valid_concept_mapping_v<variant>);
+    using variant = variant_traits_test::manual_variant<std::shared_ptr<std::uint64_t>, std::string>;
 
-    std::vector<std::byte> buffer;
-    auto                   enc = tags::make_encoder(buffer);
-    variant                input{std::string{"boost"}};
-    REQUIRE(enc(input));
+    {
+        variant input{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::make_shared<std::uint64_t>(42U)}};
 
-    auto    dec = tags::make_decoder(buffer);
-    variant output;
-    REQUIRE(dec(output));
+        std::vector<std::byte> buffer;
+        auto                   enc = tags::make_encoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(enc(input));
+        CHECK_EQ(to_hex(buffer), "8201182a");
 
-    REQUIRE(tags::detail::variant_index(output) == 1U);
-    CHECK(boost::get<std::string>(output) == "boost");
+        variant output{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::string{"before"}}};
+        auto    dec = tags::make_decoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(dec(output));
+
+        REQUIRE(tags::detail::variant_index(output) == 0U);
+        const auto &ptr = std::get<0>(output.storage);
+        REQUIRE(static_cast<bool>(ptr));
+        CHECK_EQ(*ptr, 42U);
+    }
+
+    {
+        variant input{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::shared_ptr<std::uint64_t>{}}};
+
+        std::vector<std::byte> buffer;
+        auto                   enc = tags::make_encoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(enc(input));
+        CHECK_EQ(to_hex(buffer), "8100");
+
+        variant output{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::string{"before"}}};
+        auto    dec = tags::make_decoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(dec(output));
+
+        REQUIRE(tags::detail::variant_index(output) == 0U);
+        CHECK_FALSE(static_cast<bool>(std::get<0>(output.storage)));
+    }
+
+    {
+        variant input{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::string{"ok"}}};
+
+        std::vector<std::byte> buffer;
+        auto                   enc = tags::make_encoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(enc(input));
+        CHECK_EQ(to_hex(buffer), "626f6b");
+
+        variant output{std::variant<std::shared_ptr<std::uint64_t>, std::string>{std::shared_ptr<std::uint64_t>{}}};
+        auto    dec = tags::make_decoder<smart::nullable_ptr_codec>(buffer);
+        REQUIRE(dec(output));
+
+        REQUIRE(tags::detail::variant_index(output) == 1U);
+        CHECK_EQ(std::get<1>(output.storage), "ok");
+    }
 }
-#endif
 
-#if CBOR_TAGS_TEST_HAS_BOOST_VARIANT2
-TEST_CASE("boost variant2 roundtrips through variant-like traits when available") {
-    using variant = boost::variant2::variant<std::uint64_t, std::string>;
+TEST_CASE("custom variant traits work with shared graph smart pointer codec") {
+    namespace smart = tags::ext::smart_ptr;
 
-    static_assert(tags::IsVariant<variant>);
-    static_assert(tags::valid_concept_mapping_v<variant>);
+    using variant = variant_traits_test::manual_variant<std::shared_ptr<std::uint64_t>, tags::static_tag<42>, std::string>;
 
-    std::vector<std::byte> buffer;
-    auto                   enc = tags::make_encoder(buffer);
-    variant                input{std::string{"boost2"}};
-    REQUIRE(enc(input));
+    auto          shared = std::make_shared<std::uint64_t>(42U);
+    const variant first{std::variant<std::shared_ptr<std::uint64_t>, tags::static_tag<42>, std::string>{shared}};
+    const variant second{std::variant<std::shared_ptr<std::uint64_t>, tags::static_tag<42>, std::string>{shared}};
 
-    auto    dec = tags::make_decoder(buffer);
-    variant output;
-    REQUIRE(dec(output));
+    std::vector<std::byte>             buffer;
+    auto                               enc = tags::make_encoder<smart::shared_graph_codec>(buffer);
+    smart::shared_graph_encode_session encode_graph;
 
-    REQUIRE(tags::detail::variant_index(output) == 1U);
-    CHECK(boost::variant2::get<std::string>(output) == "boost2");
+    REQUIRE(enc(smart::as_shared_graph(encode_graph, first)));
+    REQUIRE(enc(smart::as_shared_graph(encode_graph, second)));
+    CHECK_EQ(to_hex(buffer), "d81c182ad81d00");
+
+    auto                               dec = tags::make_decoder<smart::shared_graph_codec>(buffer);
+    smart::shared_graph_decode_session decode_graph;
+    variant decoded_first{std::variant<std::shared_ptr<std::uint64_t>, tags::static_tag<42>, std::string>{std::string{"first"}}};
+    variant decoded_second{std::variant<std::shared_ptr<std::uint64_t>, tags::static_tag<42>, std::string>{std::string{"second"}}};
+
+    REQUIRE(dec(smart::as_shared_graph(decode_graph, decoded_first)));
+    REQUIRE(dec(smart::as_shared_graph(decode_graph, decoded_second)));
+    REQUIRE(tags::detail::variant_index(decoded_first) == 0U);
+    REQUIRE(tags::detail::variant_index(decoded_second) == 0U);
+
+    const auto &first_ptr  = std::get<0>(decoded_first.storage);
+    const auto &second_ptr = std::get<0>(decoded_second.storage);
+    REQUIRE(static_cast<bool>(first_ptr));
+    REQUIRE(static_cast<bool>(second_ptr));
+    CHECK_EQ(*first_ptr, 42U);
+    CHECK(first_ptr.get() == second_ptr.get());
 }
-#endif

--- a/test/variant_traits_throwing_index_compile_fail.cc
+++ b/test/variant_traits_throwing_index_compile_fail.cc
@@ -1,0 +1,33 @@
+#include "cbor_tags/cbor_variant_traits.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+#include <variant>
+
+namespace variant_traits_compile_fail_test {
+
+struct throwing_index_variant {
+    std::variant<std::uint64_t, bool> storage;
+};
+
+} // namespace variant_traits_compile_fail_test
+
+namespace cbor::tags {
+
+template <> struct variant_traits<variant_traits_compile_fail_test::throwing_index_variant> {
+    using variant_type = variant_traits_compile_fail_test::throwing_index_variant;
+
+    static constexpr std::size_t size = 2U;
+
+    template <std::size_t I> using alternative = std::tuple_element_t<I, std::tuple<std::uint64_t, bool>>;
+
+    [[nodiscard]] static std::size_t index(const variant_type &value) { return value.storage.index(); }
+};
+
+} // namespace cbor::tags
+
+int main() {
+    variant_traits_compile_fail_test::throwing_index_variant value;
+    return static_cast<int>(cbor::tags::detail::variant_index(value));
+}

--- a/test/variant_traits_throwing_index_compile_fail.cc
+++ b/test/variant_traits_throwing_index_compile_fail.cc
@@ -1,4 +1,4 @@
-#include "cbor_tags/cbor_variant_traits.h"
+#include "cbor_tags/detail/cbor_variant_traits.h"
 
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
## Summary
- keep std::variant on the dedicated fast path
- remove structural variant-like auto-detection for non-std union types
- require non-std variants to opt in with cbor::tags::variant_traits hooks
- recognize explicit traits from size/alternatives/index, with get/visit/assign checked at encoder, decoder, and operator call sites
- cover aggregate-but-opted-in variants across normal CBOR, nested variants, operators, CDDL, custom codec, nullable pointers, and shared graph pointers
- keep GCC 12 away from eager std::visit probes during variant recognition

## Review notes
- subagent review found coverage gaps around two-variant visit, legacy which/apply_visitor shapes, smart pointer consumers, and explicit-traits CDDL failures
- addressed the material gaps with focused tests and a manual-traits compile-fail fixture
- non-std variant docs now use a direct boost::variant2 specialization and note that raw union storage should usually use ADL encode/decode

## Validation
- cmake --build --preset=debug --parallel
- ctest --preset=debug --output-on-failure
- scripts/format-cxx.sh --check
- scripts/lint-cxx.sh
- GCC 12 container compile: static_assert(cbor::tags::IsVariant<catch-all std::variant shape>)
- GCC 12 container compile: static_assert(IsVariant/IsCborMajor/valid_concept_mapping_v<manual variant_traits type>)
