### PR TITLE
[codex] Preserve half NaN and map structure

### DIFF
--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1078,7 +1078,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                     auto key          = detail::make_decode_value_for<key_type>(value);
                     auto mapped_value = detail::make_decode_value_for<mapped_type>(value);
                     auto status       = decode(key, major, additionalInfo);
-                    status            = (status == status_code::success) ? decode(mapped_value) : status;
+                    if (status == status_code::success) {
+                        auto [mapped_major, mapped_additional_info] = read_initial_byte();
+                        if (mapped_major == major_type::Simple && mapped_additional_info == static_cast<byte>(31)) {
+                            return status_code::no_match_for_map_on_buffer;
+                        }
+                        status = decode(mapped_value, mapped_major, mapped_additional_info);
+                    }
                     if (status != status_code::success) {
                         return status;
                     }
@@ -1087,7 +1093,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 } else {
                     value_type result{};
                     auto       status = decode(result.first, major, additionalInfo);
-                    status            = (status == status_code::success) ? decode(result.second) : status;
+                    if (status == status_code::success) {
+                        auto [mapped_major, mapped_additional_info] = read_initial_byte();
+                        if (mapped_major == major_type::Simple && mapped_additional_info == static_cast<byte>(31)) {
+                            return status_code::no_match_for_map_on_buffer;
+                        }
+                        status = decode(result.second, mapped_major, mapped_additional_info);
+                    }
                     if (status != status_code::success) {
                         return status;
                     }

--- a/include/cbor_tags/float16_ieee754.h
+++ b/include/cbor_tags/float16_ieee754.h
@@ -39,11 +39,14 @@ struct float16_t {
         std::uint32_t x;
         std::memcpy(&x, &f, sizeof(float));
 
-        std::uint32_t sign     = (x >> 16) & 0x8000;
-        int           exponent = static_cast<int>((x >> 23) & 0xffU) - 127;
-        std::uint32_t mantissa = x & 0x7fffff;
+        std::uint32_t sign         = (x >> 16) & 0x8000;
+        std::uint32_t raw_exponent = (x >> 23) & 0xffU;
+        int           exponent     = static_cast<int>(raw_exponent) - 127;
+        std::uint32_t mantissa     = x & 0x7fffff;
 
-        if (exponent > 15) {
+        if (raw_exponent == 0xffU) {
+            value = sign | (mantissa == 0U ? 0x7c00U : 0x7e00U);
+        } else if (exponent > 15) {
             // Overflow, set to infinity
             value = sign | 0x7c00;
         } else if (exponent < -14) {

--- a/test/test_cbor_simple.cpp
+++ b/test/test_cbor_simple.cpp
@@ -60,6 +60,20 @@ TEST_CASE("CBOR Encoder - NaN float") {
     CHECK_EQ(to_hex(data), "fa7fc00000");
 }
 
+TEST_CASE("CBOR Encoder - half NaN") {
+    std::vector<std::byte> data;
+    auto                   enc   = make_encoder(data);
+    float16_t              value = std::numeric_limits<float>::quiet_NaN();
+    CHECK(enc(value));
+    CBOR_TAGS_TEST_LOG("Half NaN: {}", to_hex(data));
+    CHECK_EQ(to_hex(data), "f97e00");
+
+    auto      dec = make_decoder(data);
+    float16_t decoded;
+    REQUIRE(dec(decoded));
+    CHECK(std::isnan(static_cast<float>(decoded)));
+}
+
 TEST_CASE("CBOR Encoder - Positive double") {
     std::vector<std::byte> data;
     auto                   enc   = make_encoder(data);

--- a/test/test_indefinite.cpp
+++ b/test/test_indefinite.cpp
@@ -254,6 +254,18 @@ TEST_CASE("decode indefinite map without break returns incomplete") {
     CHECK_EQ(result.error(), status_code::incomplete);
 }
 
+TEST_CASE("decode indefinite map rejects break as value") {
+    std::vector<std::byte> buffer{std::byte{0xBF}, std::byte{0x01}, std::byte{0xFF}};
+
+    auto dec = make_decoder(buffer);
+
+    std::map<int, int> decoded{{9, 9}};
+    auto               result = dec(decoded);
+
+    CHECK_FALSE_MESSAGE(result, "A map key followed by break is malformed.");
+    CHECK_EQ(result.error(), status_code::no_match_for_map_on_buffer);
+}
+
 TEST_CASE("decode indefinite bstr without break returns incomplete") {
     std::vector<std::byte> buffer{std::byte{0x5F}, std::byte{0x41}, std::byte{0xAA}};
 


### PR DESCRIPTION
## Summary

Narrows this PR to the two agreed core fixes:

- preserve `float16_t` NaN payload class when assigning from `float`, so quiet NaN encodes as half NaN instead of infinity
- reject an indefinite map key followed directly by break (`bf 01 ff`) when decoding into a concrete map, because the map target cannot represent a key without a value

This intentionally does not change core low-level `simple` or `negative` wrapper behavior. `simple{24}` / `f8 18` and `negative{0}` / `3bffffffffffffffff` remain available for raw edge construction and inspection.

## Validation

- `cmake --preset=debug-tests && cmake --build --preset=debug-tests --parallel && ctest --preset=debug-tests --output-on-failure`
- `scripts/format-cxx.sh --check && scripts/lint-cxx.sh`
- `git diff --check`