### PR TITLE
Cover lazy RFC 8746 typed-array payloads

### DIFF
--- a/include/cbor_tags/cbor_lazy_tags.h
+++ b/include/cbor_tags/cbor_lazy_tags.h
@@ -25,13 +25,28 @@ template <typename Buffer>
 concept LazyTagViewableBuffer =
     requires(Buffer &buffer) { std::views::all(buffer); } && CborInputBuffer<decltype(std::views::all(std::declval<Buffer &>()))>;
 
+template <typename Subrange, template <typename> typename... Extensions> struct lazy_payload_decoder_type {
+    static auto make(Subrange &range) {
+        if constexpr (sizeof...(Extensions) == 0) {
+            return cbor::tags::make_decoder(range);
+        } else {
+            return cbor::tags::make_decoder<Extensions...>(range);
+        }
+    }
+
+    using type = decltype(make(std::declval<Subrange &>()));
+};
+
 } // namespace detail
 
 template <CborInputBuffer Buffer, template <typename> typename... Extensions> class tag_payload_decoder {
   public:
-    using buffer_type = std::remove_cvref_t<Buffer>;
-    using iterator    = std::ranges::iterator_t<const buffer_type>;
-    using subrange    = std::ranges::subrange<iterator>;
+    using buffer_type       = std::remove_cvref_t<Buffer>;
+    using iterator          = std::ranges::iterator_t<const buffer_type>;
+    using subrange          = std::ranges::subrange<iterator>;
+    using decoder_type      = typename detail::lazy_payload_decoder_type<subrange, Extensions...>::type;
+    using input_buffer_type = typename decoder_type::input_buffer_type;
+    using bstr_view_t       = typename decoder_type::bstr_view_t;
 
     constexpr explicit tag_payload_decoder(subrange range) : range_(std::move(range)) {}
 

--- a/include/cbor_tags/cbor_segments.h
+++ b/include/cbor_tags/cbor_segments.h
@@ -480,12 +480,18 @@ template <typename Encoder> auto encode(Encoder &enc, encoded_item_bstr value) {
     return typename Encoder::expected_type{};
 }
 
+// Visitor spans are callback-scoped. Header spans point at stack-owned bytes and
+// must be consumed before the callback returns; retain only copied bytes or
+// encoded segment objects created by the higher-level segment helpers.
 template <typename VisitSegment> constexpr void visit_bstr_segments(std::span<const std::byte> payload, VisitSegment &&visit_segment) {
     const auto header = detail::encode_cbor_bstr_header(payload.size());
     visit_segment(header.span());
     visit_segment(payload);
 }
 
+// Visitor spans are callback-scoped. Header spans point at stack-owned bytes and
+// must be consumed before the callback returns; retain only copied bytes or
+// encoded segment objects created by the higher-level segment helpers.
 template <typename VisitSegment>
 constexpr void visit_indefinite_bstr_segments(std::span<const std::byte> payload, VisitSegment &&visit_segment,
                                               std::size_t chunk_size = 4096) {
@@ -507,6 +513,9 @@ constexpr void visit_indefinite_bstr_segments(std::span<const std::byte> payload
     visit_segment(std::span<const std::byte>{stop});
 }
 
+// Visitor spans are callback-scoped. Header spans point at stack-owned bytes and
+// must be consumed before the callback returns; retain only copied bytes or
+// encoded segment objects created by the higher-level segment helpers.
 template <typename VisitSegment>
 constexpr void visit_tagged_bstr_segments(std::uint64_t tag, std::span<const std::byte> payload, VisitSegment &&visit_segment) {
     const auto tag_header  = detail::encode_cbor_tag_header(tag);

--- a/include/cbor_tags/extensions/rfc8746_typed_arrays.h
+++ b/include/cbor_tags/extensions/rfc8746_typed_arrays.h
@@ -77,6 +77,11 @@ template <> struct typed_array_traits<double, typed_array_byte_order::little> : 
 template <>
 struct typed_array_traits<float128_t, typed_array_byte_order::little> : typed_array_traits_base<87, std::array<std::byte, 16>> {};
 
+static_assert(std::numeric_limits<float>::is_iec559 && sizeof(float) == sizeof(std::uint32_t),
+              "RFC 8746 float typed arrays require IEEE 754 binary32 float");
+static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == sizeof(std::uint64_t),
+              "RFC 8746 double typed arrays require IEEE 754 binary64 double");
+
 inline constexpr std::uint64_t multi_dimensional_array_tag              = 40;
 inline constexpr std::uint64_t homogeneous_array_tag                    = 41;
 inline constexpr std::uint64_t multi_dimensional_column_major_array_tag = 1040;

--- a/test/test_cbor_typed_arrays.cpp
+++ b/test/test_cbor_typed_arrays.cpp
@@ -4,6 +4,7 @@
 #include <bit>
 #include <cbor_tags/cbor_decoder.h>
 #include <cbor_tags/cbor_encoder.h>
+#include <cbor_tags/cbor_lazy_tags.h>
 #include <cbor_tags/extensions/rfc8746_typed_arrays.h>
 #include <cstddef>
 #include <cstdint>
@@ -268,9 +269,12 @@ template <typename Segments> bool has_borrowed_segment(const Segments &segments,
 
 TEST_CASE("codec extensions append user mixins to default encoder and decoder") {
     using default_encoder   = decltype(make_encoder(std::declval<std::vector<std::byte> &>()));
+    using default_decoder   = decltype(make_decoder(std::declval<std::vector<std::byte> &>()));
     using extension_encoder = decltype(make_encoder<typed_array_codec>(std::declval<std::vector<std::byte> &>()));
 
     static_assert(!CanEncode<default_encoder, typed_array<std::int32_t>>);
+    static_assert(!CanDecode<default_decoder, typed_array<std::int32_t>>);
+    static_assert(!CanDecode<default_decoder, typed_array_view<std::int32_t>>);
     static_assert(CanEncode<extension_encoder, typed_array<std::int32_t>>);
 
     std::vector<std::byte> buffer;
@@ -313,6 +317,47 @@ TEST_CASE("rfc8746 typed arrays encode and decode supported element types throug
     check_big_endian_roundtrip<float>({-2.5F, 0.0F, 3.25F});
     check_big_endian_roundtrip<double>({-2.5, 0.0, 3.25});
     check_big_endian_roundtrip<float128_t>({float128_value});
+}
+
+TEST_CASE("rfc8746 typed arrays handle empty payloads across decode paths") {
+    const std::vector<std::int32_t> values;
+    const auto                      encoded = encode_normal(std::span<const std::int32_t>{values});
+    CHECK_EQ(to_hex(encoded), "d84e40");
+
+    {
+        typed_array<std::int32_t> decoded;
+        auto                      dec = make_decoder<typed_array_codec>(encoded);
+        REQUIRE(dec(decoded));
+        CHECK(decoded.values().empty());
+    }
+
+    {
+        typed_array_view<std::int32_t> decoded;
+        auto                           dec = make_decoder<typed_array_codec>(encoded);
+        REQUIRE(dec(decoded));
+        CHECK_EQ(decoded.size(), 0U);
+        CHECK(decoded.copy_values().empty());
+        CHECK(decoded.payload_bytes().empty());
+    }
+
+    {
+        const auto segments = encode_typed_array_segments_copy(std::span<const std::int32_t>{values});
+        CHECK_EQ(to_hex(flatten_segments(segments)), to_hex(encoded));
+    }
+
+    {
+        auto tagged = std::vector<std::byte>{};
+        auto enc    = make_encoder<typed_array_codec>(tagged);
+        REQUIRE(enc(make_tag_pair(static_tag<100>{}, as_typed_array(values))));
+
+        auto view = find_tags<100>(tagged);
+        auto it   = view.begin();
+        REQUIRE(it != view.end());
+
+        typed_array<std::int32_t> decoded;
+        REQUIRE(it->decode<typed_array_codec>(decoded));
+        CHECK(decoded.values().empty());
+    }
 }
 
 TEST_CASE("rfc8746 typed arrays use exact wire bytes for all integer tags") {
@@ -366,8 +411,13 @@ TEST_CASE("rfc8746 typed arrays use exact wire bytes for all float tags") {
     CHECK_EQ(to_hex(encode_big_endian(std::span<const double>{f64_values})), "d852503ff0000000000000c004000000000000");
 
     const std::array<float128_t, 1> f128_values{float128_value};
-    CHECK_EQ(to_hex(encode_big_endian(std::span<const float128_t>{f128_values})), "d853500f0e0d0c0b0a09080706050403020100");
-    CHECK_EQ(to_hex(encode_normal(std::span<const float128_t>{f128_values})), "d85750000102030405060708090a0b0c0d0e0f");
+    if constexpr (std::endian::native == std::endian::little) {
+        CHECK_EQ(to_hex(encode_big_endian(std::span<const float128_t>{f128_values})), "d853500f0e0d0c0b0a09080706050403020100");
+        CHECK_EQ(to_hex(encode_normal(std::span<const float128_t>{f128_values})), "d85750000102030405060708090a0b0c0d0e0f");
+    } else {
+        CHECK_EQ(to_hex(encode_big_endian(std::span<const float128_t>{f128_values})), "d85350000102030405060708090a0b0c0d0e0f");
+        CHECK_EQ(to_hex(encode_normal(std::span<const float128_t>{f128_values})), "d857500f0e0d0c0b0a09080706050403020100");
+    }
 }
 
 TEST_CASE("rfc8746 structural array tags encode and decode fixed-tag wrappers") {
@@ -1033,6 +1083,26 @@ TEST_CASE("rfc8746 typed array view decodes non-contiguous definite byte strings
         REQUIRE(result);
         CHECK_EQ(decoded.values(), std::vector<std::int32_t>{1, -2, 3});
     }
+
+    {
+        const std::array<std::int32_t, 3> lazy_values{1, -2, 3};
+        std::vector<std::byte>            tagged;
+        auto                              enc = make_encoder<typed_array_codec>(tagged);
+        REQUIRE(enc(make_tag_pair(static_tag<100>{}, as_typed_array(std::span<const std::int32_t>{lazy_values}))));
+
+        std::deque<std::byte> tagged_input(tagged.begin(), tagged.end());
+        auto                  tags = find_tags<100>(tagged_input);
+        auto                  it   = tags.begin();
+        REQUIRE(it != tags.end());
+
+        auto payload_dec      = it->make_decoder<typed_array_codec>();
+        using lazy_typed_view = typed_array_view_for<std::int32_t, decltype(payload_dec)>;
+        static_assert(std::same_as<typename lazy_typed_view::payload_range_type, typename decltype(payload_dec)::bstr_view_t>);
+
+        lazy_typed_view decoded;
+        REQUIRE(payload_dec(decoded));
+        CHECK_EQ(decoded.copy_values(), std::vector<std::int32_t>{1, -2, 3});
+    }
 }
 
 TEST_CASE("rfc8746 big-endian typed array view decodes non-contiguous byte strings without copying") {
@@ -1122,7 +1192,11 @@ TEST_CASE("rfc8746 typed array decode rejects truncated extended headers and lar
     }
 
     check_decode_error<std::int32_t>("d84e5affffffff", status_code::incomplete);
-    check_decode_error<std::int32_t>("d84e5b0000000100000000", status_code::incomplete);
+    if constexpr (std::numeric_limits<std::size_t>::max() < std::numeric_limits<std::uint64_t>::max()) {
+        check_decode_error<std::int32_t>("d84e5b0000000100000000", status_code::error);
+    } else {
+        check_decode_error<std::int32_t>("d84e5b0000000100000000", status_code::incomplete);
+    }
 }
 
 TEST_CASE("rfc8746 typed array decode accepts non-minimal integer headers through the normal decoder") {

--- a/test/test_lazy_tags.cpp
+++ b/test/test_lazy_tags.cpp
@@ -603,6 +603,12 @@ TEST_CASE("lazy tag scanner reports truncated matching payloads") {
     CHECK(it == view.end());
     CHECK(view.failed());
     CHECK_EQ(view.status(), status_code::incomplete);
+
+    std::deque<std::byte> non_contiguous(buffer.begin(), buffer.end());
+    auto                  non_contiguous_view = find_tags<100>(non_contiguous);
+    CHECK(non_contiguous_view.begin() == non_contiguous_view.end());
+    CHECK(non_contiguous_view.failed());
+    CHECK_EQ(non_contiguous_view.status(), status_code::incomplete);
 }
 
 TEST_CASE("lazy tag scanner reports malformed tagged payloads") {
@@ -633,6 +639,16 @@ TEST_CASE("lazy tag scanner reports malformed tagged payloads") {
         CHECK(view.failed());
         CHECK_EQ(view.status(), status_code::error);
     }
+
+    {
+        auto                  vector_buffer = to_bytes("d864df");
+        std::deque<std::byte> buffer(vector_buffer.begin(), vector_buffer.end());
+        auto                  view = find_tags<100>(buffer);
+        auto                  it   = view.begin();
+        CHECK(it == view.end());
+        CHECK(view.failed());
+        CHECK_EQ(view.status(), status_code::error);
+    }
 }
 
 TEST_CASE("lazy tag scanner reports malformed indefinite items") {
@@ -640,6 +656,16 @@ TEST_CASE("lazy tag scanner reports malformed indefinite items") {
         auto buffer = to_bytes("bf01ff");
         auto view   = find_tags<100>(buffer);
         auto it     = view.begin();
+        CHECK(it == view.end());
+        CHECK(view.failed());
+        CHECK_EQ(view.status(), status_code::error);
+    }
+
+    {
+        auto                  vector_buffer = to_bytes("bf01ff");
+        std::deque<std::byte> buffer(vector_buffer.begin(), vector_buffer.end());
+        auto                  view = find_tags<100>(buffer);
+        auto                  it   = view.begin();
         CHECK(it == view.end());
         CHECK(view.failed());
         CHECK_EQ(view.status(), status_code::error);


### PR DESCRIPTION
## Summary

Splits the RFC 8746/lazy-tag work out of the broader review-fix draft:

- exposes lazy payload decoder aliases needed by typed-array view traits
- asserts RFC 8746 float/double typed arrays are built on IEEE 754 binary32/binary64 types
- documents callback-scoped segment spans
- adds coverage for empty typed-array payloads, opt-in rejection by the default decoder, non-contiguous typed-array views, lazy payload decoding, endian-aware float128 expectations, and 32-bit `size_t` oversized-payload status

## Validation

- `cmake --preset=debug-tests && cmake --build --preset=debug-tests --parallel && ctest --preset=debug-tests --output-on-failure`
- `scripts/format-cxx.sh --check && scripts/lint-cxx.sh`