### PR TITLE
Split validation cleanup and example build

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -121,6 +121,38 @@ jobs:
           -c tools.cmake.cmaketoolchain:generator=Ninja \
           ${options}
 
+  conan-stl-only-package:
+    name: Conan package consumer (stl-only)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Create and test STL-only package in Fedora
+      shell: bash
+      run: |
+        docker run --rm \
+          -v "${{ github.workspace }}:/work:ro,z" \
+          -w /work \
+          registry.fedoraproject.org/fedora:44 \
+          bash -euxo pipefail -c '
+            dnf -y install \
+              cmake \
+              gcc-c++ \
+              git \
+              ninja-build \
+              python3-pip
+            python3 -m pip install --user "conan>=2,<3"
+            export PATH="${HOME}/.local/bin:${PATH}"
+            conan profile detect --force
+            conan create . \
+              --build=missing \
+              -s build_type=Release \
+              -s compiler.cppstd=26 \
+              -c tools.cmake.cmaketoolchain:generator=Ninja \
+              -o cbor-tags/*:stl_only=True
+          '
+
   benchmark-build:
     name: C++ Benchmark Compile (${{ matrix.config.name }})
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ option(CBOR_TAGS_BUILD_TESTS "Build tests" OFF)
 option(CBOR_TAGS_BUILD_CLI "Build cbor_tags_cli" ${CBOR_TAGS_BUILD_TESTS})
 option(CBOR_TAGS_BUILD_TOOLS "Build tools (for to_tuple(...) generation, it is required for struct reflection)" OFF)
 option(CBOR_TAGS_BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(CBOR_TAGS_BUILD_EXAMPLES "Build examples" OFF)
 option(CBOR_TAGS_INSTALL "Install the library" OFF)
 if(CBOR_TAGS_STL_ONLY AND CBOR_TAGS_BUILD_TOOLS)
   message(FATAL_ERROR "CBOR_TAGS_STL_ONLY uses C++26 std::meta and does not support the legacy fmt-based reflection generator.")
@@ -338,6 +339,10 @@ endif()
 # add benchmarks
 if(CBOR_TAGS_BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
+endif()
+
+if(CBOR_TAGS_BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif()
 
 if(CBOR_TAGS_INSTALL)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,7 +102,10 @@
       "name": "debug",
       "inherits": "base-debug",
       "displayName": "Debug",
-      "description": "CMAKE_BUILD_TYPE=Debug (typically -O0 -g)"
+      "description": "CMAKE_BUILD_TYPE=Debug (typically -O0 -g)",
+      "cacheVariables": {
+        "CBOR_TAGS_BUILD_TESTS": "ON"
+      }
     },
     {
       "name": "debug-tests",
@@ -220,19 +223,28 @@
       "name": "release",
       "inherits": "base-release",
       "displayName": "Release",
-      "description": "CMAKE_BUILD_TYPE=Release (typically -O3)"
+      "description": "CMAKE_BUILD_TYPE=Release (typically -O3)",
+      "cacheVariables": {
+        "CBOR_TAGS_BUILD_TESTS": "ON"
+      }
     },
     {
       "name": "relwithdebinfo",
       "inherits": "base-relwithdebinfo",
       "displayName": "Release with Debug Info",
-      "description": "CMAKE_BUILD_TYPE=RelWithDebInfo (typically -O2 -g)"
+      "description": "CMAKE_BUILD_TYPE=RelWithDebInfo (typically -O2 -g)",
+      "cacheVariables": {
+        "CBOR_TAGS_BUILD_TESTS": "ON"
+      }
     },
     {
       "name": "minsizerel",
       "inherits": "base-minsizerel",
       "displayName": "Minimum Size Release",
-      "description": "Size-optimized build (-Os), minimal binary size for embedded or space-constrained deployments"
+      "description": "Size-optimized build (-Os), minimal binary size for embedded or space-constrained deployments",
+      "cacheVariables": {
+        "CBOR_TAGS_BUILD_TESTS": "ON"
+      }
     },
     {
       "name": "coverage",
@@ -856,6 +868,9 @@
         "outputOnFailure": true,
         "verbosity": "default"
       },
+      "execution": {
+        "noTestsAction": "error"
+      },
       "environment": {
         "CCACHE_DIR": "${sourceDir}/build/.ccache",
         "CCACHE_BASEDIR": "${sourceDir}",
@@ -1435,8 +1450,8 @@
     },
     {
       "name": "package",
-      "displayName": "Package Workflow",
-      "description": "Complete release workflow: configure → build → test → package with CPack",
+      "displayName": "Release Validation Workflow",
+      "description": "Complete release validation workflow: configure → build → test",
       "steps": [
         {
           "type": "configure",

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ pattern.
 - Optional C++26 STL-only mode with `CBOR_TAGS_STL_ONLY=ON`; this uses `std::expected`, `std::format`, and `std::meta` and exports no fmt, nameof, or tl::expected dependency.
 - Optional C++20 named-map support through Boost.PFR field names, requiring Boost 1.84 or newer, `BOOST_PFR_CORE_NAME_ENABLED`, and a Boost CMake package config when enabled through CMake.
 - Optional CDDL enum-name support through C++26 static reflection or magic_enum 0.9.7 or newer.
-- CMake 3.20+, or 3.25+ when building an installed CMake package with `CBOR_TAGS_INSTALL=ON`.
+- CMake 3.20+ for raw `cmake -S/-B` builds, 3.25+ when building an installed CMake package with `CBOR_TAGS_INSTALL=ON`, and 3.31+ for the checked-in preset workflows.
 
 ## 📦 Installation
 
@@ -1061,7 +1061,7 @@ Please see the public online database of [tags](https://www.iana.org/assignments
 - Supports encoding and decoding of various CBOR data types according to [RFC8949](https://datatracker.ietf.org/doc/html/rfc8949) 
 - CDDL [RFC8610](https://datatracker.ietf.org/doc/html/rfc8610) support for defining custom data structures
 
-For more examples and detailed documentation, visit our [Wiki](link-to-wiki).
+Additional focused examples and design notes live under [`doc/`](doc/), including codec extensions, typed arrays, smart pointers, CDDL handling, and named maps.
 
 ## Testing Performance and Benchmarks
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -38,7 +38,7 @@ class CborTagsConan(ConanFile):
         self.requires("fmt/[>=11.0.2 <12]")
         self.requires("nameof/0.10.4")
         if not self.options.std_expected:
-            self.requires("tl-expected/1.1.0")
+            self.requires("tl-expected/1.3.1")
         if self.options.boost_pfr_names:
             self.requires("boost/[>=1.84.0 <2]")
         if self.options.magic_enum_names:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(cbor_tags_basic_roundtrip basic_roundtrip.cpp)
+target_link_libraries(cbor_tags_basic_roundtrip PRIVATE cbor::tags)

--- a/examples/basic_roundtrip.cpp
+++ b/examples/basic_roundtrip.cpp
@@ -1,0 +1,32 @@
+#include <cbor_tags/cbor_decoder.h>
+#include <cbor_tags/cbor_encoder.h>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+struct sample_record {
+    static constexpr std::uint64_t cbor_tag = 1001;
+    std::uint32_t                  id{};
+    std::string                    label;
+};
+
+int main() {
+    using namespace std::string_view_literals;
+
+    std::vector<std::byte> buffer;
+    auto                   enc   = cbor::tags::make_encoder(buffer);
+    const sample_record    input = {.id = 42, .label = "ready"};
+    if (!enc(input)) {
+        return 1;
+    }
+
+    sample_record output;
+    auto          dec = cbor::tags::make_decoder(buffer);
+    if (!dec(output)) {
+        return 2;
+    }
+
+    return output.id == input.id && output.label == "ready"sv ? 0 : 3;
+}


### PR DESCRIPTION
## Summary

Splits the ancillary build/docs cleanup out of the broader review-fix draft:

- adds a small `basic_roundtrip` example and wires `CBOR_TAGS_BUILD_EXAMPLES`
- makes standard configure presets build tests and makes CTest treat zero discovered tests as an error
- renames the `package` workflow preset to describe release validation instead of implying CPack packaging
- updates README CMake preset requirements and the docs pointer
- aligns the Conan `tl-expected` requirement and adds a Fedora STL-only Conan CI job

## Validation

- `cmake --list-presets=all`
- `cmake --preset=debug && cmake --build --preset=debug --parallel && ctest --preset=debug --output-on-failure`
- `cmake -S . -B build/examples -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCBOR_TAGS_BUILD_EXAMPLES=ON && cmake --build build/examples --target cbor_tags_basic_roundtrip --parallel && ./build/examples/examples/cbor_tags_basic_roundtrip`
- `scripts/format-cxx.sh --check && scripts/lint-cxx.sh`