### PR TITLE
feat(decoder): use internal structural traversal cursor

### DIFF
--- a/include/cbor_tags/cbor_lazy_tags.h
+++ b/include/cbor_tags/cbor_lazy_tags.h
@@ -124,7 +124,7 @@ template <CborInputBuffer Buffer, typename Predicate> class tag_view : public st
 
         iterator() = default;
         explicit iterator(tag_view *view)
-            : view_(view), walker_(std::ranges::begin(std::as_const(view->buffer_)), std::ranges::end(std::as_const(view->buffer_))) {
+            : view_(view), cursor_(std::ranges::begin(std::as_const(view->buffer_)), std::ranges::end(std::as_const(view->buffer_))) {
             find_next();
         }
 
@@ -153,31 +153,20 @@ template <CborInputBuffer Buffer, typename Predicate> class tag_view : public st
             }
 
             detail::cbor_tag_event<iterator_t> event{};
-            while (walker_.next_tag(event)) {
-                if (!std::invoke(view_->predicate_, event.tag)) {
-                    continue;
-                }
-
-                auto        payload_end = event.payload_begin;
-                status_code status      = status_code::success;
-                if (!detail::cbor_item_skipper<max_stack_depth>::skip_item(payload_end, walker_.end(), status, walker_.stack_depth())) {
-                    fail(status);
-                    return;
-                }
-
-                current_ = match_type{event.tag, event.payload_begin, payload_end};
+            while (cursor_.next_matching_tag(view_->predicate_, event)) {
+                current_ = match_type{event.tag, event.payload_begin, event.payload_end};
                 return;
             }
 
-            view_->status_ = walker_.status();
+            view_->status_ = cursor_.status();
             done_          = true;
         }
 
-        static constexpr std::size_t                          max_stack_depth = 256;
-        tag_view                                             *view_{};
-        detail::cbor_item_walker<max_stack_depth, iterator_t> walker_{};
-        match_type                                            current_{};
-        bool                                                  done_{};
+        static constexpr std::size_t                                     max_indefinite_depth = 256;
+        tag_view                                                        *view_{};
+        detail::cbor_structural_cursor<max_indefinite_depth, iterator_t> cursor_{};
+        match_type                                                       current_{};
+        bool                                                             done_{};
     };
 
     constexpr tag_view(buffer_type buffer, Predicate predicate) : buffer_(std::move(buffer)), predicate_(std::move(predicate)) {}

--- a/include/cbor_tags/detail/cbor_item.h
+++ b/include/cbor_tags/detail/cbor_item.h
@@ -6,9 +6,11 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <ranges>
+#include <type_traits>
 
 namespace cbor::tags::detail {
 
@@ -19,10 +21,9 @@ struct cbor_item_header {
 };
 
 struct cbor_item_frame {
-    bool          indefinite{};
     major_type    major{};
-    std::uint64_t remaining{};
     bool          map_expects_value{};
+    std::uint64_t parent_pending{};
 };
 
 struct cbor_item_reader {
@@ -110,194 +111,136 @@ struct cbor_item_reader {
 
 template <typename Iterator> struct cbor_tag_event {
     std::uint64_t tag{};
+    Iterator      tag_begin{};
     Iterator      payload_begin{};
+    Iterator      payload_end{};
+    Iterator      item_end{};
 };
 
-template <std::size_t MaxDepth, typename Iterator> class cbor_item_walker {
+template <std::size_t MaxDepth, typename Iterator> class cbor_structural_cursor {
   public:
-    cbor_item_walker() = default;
-    constexpr cbor_item_walker(Iterator begin, Iterator end) : cursor_(begin), end_(end) {}
+    cbor_structural_cursor() = default;
+    constexpr cbor_structural_cursor(Iterator begin, Iterator end) : cursor_(begin), end_(end) {}
 
     [[nodiscard]] constexpr Iterator    end() const { return end_; }
     [[nodiscard]] constexpr status_code status() const noexcept { return status_; }
     [[nodiscard]] constexpr bool        failed() const noexcept { return status_ != status_code::success; }
     [[nodiscard]] constexpr bool        done() const noexcept { return done_; }
-    [[nodiscard]] constexpr std::size_t stack_depth() const noexcept { return stack_size_; }
+    [[nodiscard]] constexpr Iterator    position() const { return cursor_; }
 
-    constexpr bool next_tag(cbor_tag_event<Iterator> &event) {
+    constexpr bool skip_one(Iterator &item_end) {
+        pending_    = 1;
+        stack_size_ = 0;
+        status_     = status_code::success;
+        done_       = false;
+
+        while (true) {
+            auto has_item = false;
+            if (!prepare_item(false, has_item)) {
+                return false;
+            }
+            if (!has_item) {
+                item_end = cursor_;
+                return true;
+            }
+            event_sink sink{};
+            auto       ignored = false;
+            if (!consume_item(static_cast<no_predicate *>(nullptr), sink, ignored)) {
+                return false;
+            }
+        }
+    }
+
+    template <typename Predicate> constexpr bool next_matching_tag(Predicate &predicate, cbor_tag_event<Iterator> &event) {
         if (done_) {
             return false;
         }
 
         while (true) {
-            pop_completed_frames();
-
-            if (cursor_ == end_) {
-                if (stack_empty()) {
-                    done_   = true;
-                    status_ = status_code::success;
-                } else {
-                    fail(status_code::incomplete);
-                }
+            auto has_item = false;
+            if (!prepare_item(true, has_item)) {
                 return false;
             }
-
-            if (consume_indefinite_break_if_present()) {
-                if (done_) {
-                    return false;
-                }
-                continue;
-            }
-
-            if (is_cbor_break_byte(cbor_byte_to_u8(*cursor_))) {
-                fail(status_code::error);
+            if (!has_item) {
                 return false;
             }
-
-            if (!consume_parent_item()) {
-                fail(status_code::error);
+            auto emitted = false;
+            if (!consume_item(&predicate, event, emitted)) {
                 return false;
             }
-
-            cbor_item_header header{};
-            auto             read_status = status_code::success;
-            if (!cbor_item_reader::read_header(cursor_, end_, header, read_status)) {
-                fail(read_status);
-                return false;
-            }
-
-            switch (header.major) {
-            case major_type::UnsignedInteger:
-            case major_type::NegativeInteger: {
-                std::uint64_t ignored{};
-                if (header.additional_info == 31U || !read_argument(header.additional_info, ignored)) {
-                    if (!done_) {
-                        fail(status_code::error);
-                    }
-                    return false;
-                }
-                break;
-            }
-            case major_type::ByteString:
-            case major_type::TextString: {
-                if (header.additional_info == 31U) {
-                    if (!skip_indefinite_string(header.major)) {
-                        return false;
-                    }
-                } else {
-                    std::uint64_t length{};
-                    if (!read_argument(header.additional_info, length) || !skip_bytes(length)) {
-                        return false;
-                    }
-                }
-                break;
-            }
-            case major_type::Array: {
-                if (header.additional_info == 31U) {
-                    if (!push_frame(cbor_item_frame{.indefinite = true, .major = major_type::Array})) {
-                        return false;
-                    }
-                } else {
-                    std::uint64_t length{};
-                    if (!read_argument(header.additional_info, length)) {
-                        return false;
-                    }
-                    if (length > 0U && !push_frame(cbor_item_frame{.major = major_type::Array, .remaining = length})) {
-                        return false;
-                    }
-                }
-                break;
-            }
-            case major_type::Map: {
-                if (header.additional_info == 31U) {
-                    if (!push_frame(cbor_item_frame{.indefinite = true, .major = major_type::Map})) {
-                        return false;
-                    }
-                } else {
-                    std::uint64_t length{};
-                    if (!read_argument(header.additional_info, length)) {
-                        return false;
-                    }
-                    if (length > (std::numeric_limits<std::uint64_t>::max() / 2U)) {
-                        fail(status_code::error);
-                        return false;
-                    }
-                    const auto item_count = length * 2U;
-                    if (item_count > 0U && !push_frame(cbor_item_frame{.major = major_type::Map, .remaining = item_count})) {
-                        return false;
-                    }
-                }
-                break;
-            }
-            case major_type::Tag: {
-                std::uint64_t tag{};
-                if (header.additional_info == 31U || !read_argument(header.additional_info, tag)) {
-                    if (!done_) {
-                        fail(status_code::error);
-                    }
-                    return false;
-                }
-                auto payload_begin = cursor_;
-                if (!push_frame(cbor_item_frame{.major = major_type::Tag, .remaining = 1})) {
-                    return false;
-                }
-                event = cbor_tag_event<Iterator>{.tag = tag, .payload_begin = payload_begin};
+            if (emitted) {
                 return true;
-            }
-            case major_type::Simple:
-                if (is_reserved_simple_argument(header.additional_info)) {
-                    fail(status_code::error);
-                    return false;
-                }
-                if (header.additional_info >= 24U && !skip_bytes(std::uint64_t{1U << (header.additional_info - 24U)})) {
-                    return false;
-                }
-                break;
-            default: fail(status_code::error); return false;
             }
         }
     }
 
   private:
+    struct event_sink {};
+    struct no_predicate {};
+
     constexpr void fail(status_code status) noexcept {
         status_ = status;
         done_   = true;
     }
 
-    constexpr void pop_completed_frames() noexcept {
-        while (!stack_empty() && !stack_back().indefinite && stack_back().remaining == 0) {
-            stack_pop_back();
-        }
-    }
+    constexpr bool prepare_item(bool sequence, bool &has_item) {
+        while (pending_ == 0U) {
+            if (stack_empty()) {
+                if (sequence && cursor_ != end_) {
+                    pending_ = 1;
+                    has_item = true;
+                    return true;
+                }
+                done_    = true;
+                has_item = false;
+                return true;
+            }
 
-    constexpr bool consume_parent_item() noexcept {
-        if (stack_empty()) {
-            return true;
-        }
-        auto &frame = stack_back();
-        if (frame.indefinite) {
+            if (cursor_ == end_) {
+                fail(status_code::incomplete);
+                return false;
+            }
+
+            auto &frame = stack_back();
+            if (is_cbor_break_byte(cbor_byte_to_u8(*cursor_))) {
+                if (frame.major == major_type::Map && frame.map_expects_value) {
+                    fail(status_code::error);
+                    return false;
+                }
+                ++cursor_;
+                pending_ = frame.parent_pending;
+                stack_pop_back();
+                continue;
+            }
+
             if (frame.major == major_type::Map) {
                 frame.map_expects_value = !frame.map_expects_value;
             }
+            pending_ = 1;
+            has_item = true;
             return true;
         }
-        if (frame.remaining == 0) {
-            return false;
-        }
-        --frame.remaining;
+
+        has_item = true;
         return true;
     }
 
-    constexpr bool consume_indefinite_break_if_present() {
-        if (stack_empty() || !stack_back().indefinite || cursor_ == end_ || !is_cbor_break_byte(cbor_byte_to_u8(*cursor_))) {
+    constexpr bool add_pending(std::uint64_t count) {
+        if (count > std::numeric_limits<std::uint64_t>::max() - pending_) {
+            fail(status_code::error);
             return false;
         }
-        if (stack_back().major == major_type::Map && stack_back().map_expects_value) {
+        pending_ += count;
+        return true;
+    }
+
+    constexpr bool enter_indefinite(major_type major) {
+        if (stack_size_ == stack_.size()) {
             fail(status_code::error);
-            return true;
+            return false;
         }
-        ++cursor_;
-        stack_pop_back();
+        stack_[stack_size_++] = cbor_item_frame{.major = major, .parent_pending = pending_};
+        pending_              = 0;
         return true;
     }
 
@@ -328,184 +271,144 @@ template <std::size_t MaxDepth, typename Iterator> class cbor_item_walker {
         return true;
     }
 
-    [[nodiscard]] constexpr bool  stack_empty() const noexcept { return stack_size_ == 0; }
-    [[nodiscard]] constexpr auto &stack_back() noexcept { return stack_[stack_size_ - 1]; }
-    constexpr void                stack_pop_back() noexcept { --stack_size_; }
-    constexpr bool                push_frame(cbor_item_frame frame) {
-        if (stack_size_ == stack_.size()) {
+    template <typename Predicate, typename Event> constexpr bool consume_item(Predicate *predicate, Event &event, bool &emitted_tag) {
+        emitted_tag = false;
+        if (pending_ == 0U) {
             fail(status_code::error);
             return false;
         }
-        stack_[stack_size_++] = frame;
+        --pending_;
+
+        if (cursor_ == end_) {
+            fail(status_code::incomplete);
+            return false;
+        }
+        if (is_cbor_break_byte(cbor_byte_to_u8(*cursor_))) {
+            fail(status_code::error);
+            return false;
+        }
+
+        const auto       item_begin = cursor_;
+        cbor_item_header header{};
+        auto             read_status = status_code::success;
+        if (!cbor_item_reader::read_header(cursor_, end_, header, read_status)) {
+            fail(read_status);
+            return false;
+        }
+
+        switch (header.major) {
+        case major_type::UnsignedInteger:
+        case major_type::NegativeInteger:
+            if (header.additional_info == 31U || !read_argument(header.additional_info, header.argument)) {
+                if (!done_) {
+                    fail(status_code::error);
+                }
+                return false;
+            }
+            break;
+        case major_type::ByteString:
+        case major_type::TextString:
+            if (header.additional_info == 31U) {
+                if (!skip_indefinite_string(header.major)) {
+                    return false;
+                }
+            } else {
+                if (!read_argument(header.additional_info, header.argument) || !skip_bytes(header.argument)) {
+                    return false;
+                }
+            }
+            break;
+        case major_type::Array:
+            if (header.additional_info == 31U) {
+                if (!enter_indefinite(major_type::Array)) {
+                    return false;
+                }
+            } else if (!read_argument(header.additional_info, header.argument) || !add_pending(header.argument)) {
+                return false;
+            }
+            break;
+        case major_type::Map:
+            if (header.additional_info == 31U) {
+                if (!enter_indefinite(major_type::Map)) {
+                    return false;
+                }
+            } else {
+                if (!read_argument(header.additional_info, header.argument)) {
+                    return false;
+                }
+                if (header.argument > (std::numeric_limits<std::uint64_t>::max() / 2U)) {
+                    fail(status_code::error);
+                    return false;
+                }
+                if (!add_pending(header.argument * 2U)) {
+                    return false;
+                }
+            }
+            break;
+        case major_type::Tag: {
+            if (header.additional_info == 31U || !read_argument(header.additional_info, header.argument) || !add_pending(1)) {
+                if (!done_) {
+                    fail(status_code::error);
+                }
+                return false;
+            }
+            const auto payload_begin = cursor_;
+            if constexpr (!std::is_same_v<Event, event_sink>) {
+                if (predicate != nullptr && std::invoke(*predicate, header.argument)) {
+                    cbor_structural_cursor<MaxDepth, Iterator> payload_cursor{payload_begin, end_};
+                    auto                                       payload_end = payload_begin;
+                    if (!payload_cursor.skip_one(payload_end)) {
+                        fail(payload_cursor.status());
+                        return false;
+                    }
+                    event       = cbor_tag_event<Iterator>{.tag           = header.argument,
+                                                           .tag_begin     = item_begin,
+                                                           .payload_begin = payload_begin,
+                                                           .payload_end   = payload_end,
+                                                           .item_end      = payload_end};
+                    emitted_tag = true;
+                }
+            }
+            break;
+        }
+        case major_type::Simple:
+            if (is_reserved_simple_argument(header.additional_info)) {
+                fail(status_code::error);
+                return false;
+            }
+            if (header.additional_info >= 24U && !skip_bytes(std::uint64_t{1U << (header.additional_info - 24U)})) {
+                return false;
+            }
+            break;
+        default: fail(status_code::error); return false;
+        }
         return true;
     }
+
+    [[nodiscard]] constexpr bool  stack_empty() const noexcept { return stack_size_ == 0; }
+    [[nodiscard]] constexpr auto &stack_back() noexcept { return stack_[stack_size_ - 1]; }
+    constexpr void                stack_pop_back() noexcept { --stack_size_; }
 
     Iterator                              cursor_{};
     Iterator                              end_{};
     std::array<cbor_item_frame, MaxDepth> stack_{};
     std::size_t                           stack_size_{};
+    std::uint64_t                         pending_{};
     status_code                           status_{status_code::success};
     bool                                  done_{};
 };
 
 template <std::size_t MaxDepth = 256> struct cbor_item_skipper {
-    template <typename Iterator> static bool skip_item(Iterator &cursor, Iterator end, status_code &status, std::size_t initial_depth = 0) {
-        if (initial_depth > MaxDepth) {
-            status = status_code::error;
+    template <typename Iterator> static bool skip_item(Iterator &cursor, Iterator end, status_code &status) {
+        cbor_structural_cursor<MaxDepth, Iterator> structural_cursor{cursor, end};
+        auto                                       item_end = cursor;
+        if (!structural_cursor.skip_one(item_end)) {
+            status = structural_cursor.status();
             return false;
         }
-        std::array<cbor_item_frame, MaxDepth> stack{};
-        std::size_t                           stack_size{};
-        bool                                  root_started{};
-
-        auto stack_empty = [&] { return stack_size == 0; };
-        auto stack_back  = [&]() -> cbor_item_frame  &{ return stack[stack_size - 1]; };
-        auto pop_frame   = [&] { --stack_size; };
-        auto push_frame  = [&](cbor_item_frame frame) {
-            if (initial_depth + stack_size == stack.size()) {
-                status = status_code::error;
-                return false;
-            }
-            stack[stack_size++] = frame;
-            return true;
-        };
-
-        while (true) {
-            while (!stack_empty() && !stack_back().indefinite && stack_back().remaining == 0) {
-                pop_frame();
-            }
-            if (root_started && stack_empty()) {
-                return true;
-            }
-
-            if (!stack_empty() && stack_back().indefinite) {
-                if (cursor == end) {
-                    status = status_code::incomplete;
-                    return false;
-                }
-                if (is_cbor_break_byte(cbor_byte_to_u8(*cursor))) {
-                    if (stack_back().major == major_type::Map && stack_back().map_expects_value) {
-                        status = status_code::error;
-                        return false;
-                    }
-                    ++cursor;
-                    pop_frame();
-                    continue;
-                }
-            }
-
-            if (cursor == end) {
-                status = status_code::incomplete;
-                return false;
-            }
-            if (is_cbor_break_byte(cbor_byte_to_u8(*cursor))) {
-                status = status_code::error;
-                return false;
-            }
-
-            if (stack_empty()) {
-                root_started = true;
-            } else if (auto &frame = stack_back(); frame.indefinite) {
-                if (frame.major == major_type::Map) {
-                    frame.map_expects_value = !frame.map_expects_value;
-                }
-            } else {
-                if (frame.remaining == 0) {
-                    status = status_code::error;
-                    return false;
-                }
-                --frame.remaining;
-            }
-
-            cbor_item_header header{};
-            if (!cbor_item_reader::read_header(cursor, end, header, status)) {
-                return false;
-            }
-
-            switch (header.major) {
-            case major_type::UnsignedInteger:
-            case major_type::NegativeInteger:
-                if (header.additional_info == 31U) {
-                    status = status_code::error;
-                    return false;
-                }
-                if (!cbor_item_reader::read_argument(cursor, end, header.additional_info, header.argument, status)) {
-                    return false;
-                }
-                break;
-            case major_type::ByteString:
-            case major_type::TextString:
-                if (header.additional_info == 31U) {
-                    if (!cbor_item_reader::skip_indefinite_string(cursor, end, header.major, status)) {
-                        return false;
-                    }
-                } else {
-                    if (!cbor_item_reader::read_argument(cursor, end, header.additional_info, header.argument, status)) {
-                        return false;
-                    }
-                    if (!cbor_item_reader::advance_bytes(cursor, end, header.argument, status)) {
-                        return false;
-                    }
-                }
-                break;
-            case major_type::Array:
-                if (header.additional_info == 31U) {
-                    if (!push_frame(cbor_item_frame{.indefinite = true, .major = major_type::Array})) {
-                        return false;
-                    }
-                } else {
-                    if (!cbor_item_reader::read_argument(cursor, end, header.additional_info, header.argument, status)) {
-                        return false;
-                    }
-                    if (header.argument > 0U && !push_frame(cbor_item_frame{.major = major_type::Array, .remaining = header.argument})) {
-                        return false;
-                    }
-                }
-                break;
-            case major_type::Map:
-                if (header.additional_info == 31U) {
-                    if (!push_frame(cbor_item_frame{.indefinite = true, .major = major_type::Map})) {
-                        return false;
-                    }
-                } else {
-                    if (!cbor_item_reader::read_argument(cursor, end, header.additional_info, header.argument, status)) {
-                        return false;
-                    }
-                    if (header.argument > (std::numeric_limits<std::uint64_t>::max() / 2U)) {
-                        status = status_code::error;
-                        return false;
-                    }
-                    const auto item_count = header.argument * 2U;
-                    if (item_count > 0U && !push_frame(cbor_item_frame{.major = major_type::Map, .remaining = item_count})) {
-                        return false;
-                    }
-                }
-                break;
-            case major_type::Tag:
-                if (header.additional_info == 31U) {
-                    status = status_code::error;
-                    return false;
-                }
-                if (!cbor_item_reader::read_argument(cursor, end, header.additional_info, header.argument, status)) {
-                    return false;
-                }
-                if (!push_frame(cbor_item_frame{.major = major_type::Tag, .remaining = 1})) {
-                    return false;
-                }
-                break;
-            case major_type::Simple:
-                if (is_reserved_simple_argument(header.additional_info)) {
-                    status = status_code::error;
-                    return false;
-                }
-                if (header.additional_info >= 24U &&
-                    !cbor_item_reader::advance_bytes(cursor, end, std::uint64_t{1U << (header.additional_info - 24U)}, status)) {
-                    return false;
-                }
-                break;
-            default: status = status_code::error; return false;
-            }
-        }
+        cursor = item_end;
+        status = status_code::success;
+        return true;
     }
 };
 

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -1699,6 +1699,14 @@ template <typename OutputBuffer> struct smart_annotator {
         std::uint8_t additional_info{};
     };
 
+    struct annotation_frame {
+        major_type    major{};
+        bool          indefinite{};
+        std::uint64_t remaining{};
+        bool          map_expects_value{};
+        std::size_t   child_depth{};
+    };
+
     [[nodiscard]] bool empty() const noexcept { return position >= bytes.size(); }
 
     [[nodiscard]] std::uint8_t byte_at(std::size_t index) const { return std::to_integer<std::uint8_t>(bytes[index]); }
@@ -1954,11 +1962,27 @@ template <typename OutputBuffer> struct smart_annotator {
         }
     }
 
-    void parse_string(std::size_t depth, item_header header) {
+    void parse_definite_string(std::size_t depth, item_header header, std::string_view kind) {
         check_depth(depth);
+        const auto length = read_argument(header.additional_info);
+        emit_header(depth, header.begin, position, text::format("{}({})", kind, length));
+        ensure_payload_available(length);
+        const auto payload_begin = position;
+        const auto payload_size  = static_cast<std::size_t>(length);
+        position += payload_size;
+        const auto is_text = header.major == static_cast<std::uint8_t>(major_type::TextString);
+        if (!is_text) {
+            ensure_output_capacity(bytes_comment_size(payload_size));
+        }
+        const auto comment = is_text ? text_or_non_utf8_comment(payload_begin, payload_size) : bytes_comment(payload_begin, payload_size);
+        emit_payload(depth + 1U, payload_begin, payload_size, comment);
+    }
+
+    void parse_string(std::size_t depth, item_header header) {
         const auto kind =
             header.major == static_cast<std::uint8_t>(major_type::TextString) ? std::string_view{"text"} : std::string_view{"bytes"};
         if (header.additional_info == 31U) {
+            check_depth(depth);
             emit_header(depth, header.begin, position, text::format("{}(*)", kind));
             while (true) {
                 if (empty()) {
@@ -1975,79 +1999,53 @@ template <typename OutputBuffer> struct smart_annotator {
                 if (chunk_major != header.major || chunk_info == 31U) {
                     throw std::runtime_error("Invalid indefinite CBOR string chunk");
                 }
-                parse_string(depth + 1U, {.begin           = chunk_begin,
-                                          .major           = static_cast<std::uint8_t>(chunk_major),
-                                          .additional_info = static_cast<std::uint8_t>(chunk_info)});
+                parse_definite_string(depth + 1U,
+                                      {.begin           = chunk_begin,
+                                       .major           = static_cast<std::uint8_t>(chunk_major),
+                                       .additional_info = static_cast<std::uint8_t>(chunk_info)},
+                                      kind);
             }
+        } else {
+            parse_definite_string(depth, header, kind);
         }
-
-        const auto length = read_argument(header.additional_info);
-        emit_header(depth, header.begin, position, text::format("{}({})", kind, length));
-        ensure_payload_available(length);
-        const auto payload_begin = position;
-        const auto payload_size  = static_cast<std::size_t>(length);
-        position += payload_size;
-        const auto is_text = header.major == static_cast<std::uint8_t>(major_type::TextString);
-        if (!is_text) {
-            ensure_output_capacity(bytes_comment_size(payload_size));
-        }
-        const auto comment = is_text ? text_or_non_utf8_comment(payload_begin, payload_size) : bytes_comment(payload_begin, payload_size);
-        emit_payload(depth + 1U, payload_begin, payload_size, comment);
     }
 
-    void parse_array(std::size_t depth, item_header header) {
+    void parse_array(std::size_t depth, item_header header, std::vector<annotation_frame> &frames) {
         if (header.additional_info == 31U) {
             emit_header(depth, header.begin, position, "array(*)");
-            while (true) {
-                if (empty()) {
-                    throw std::runtime_error("Unterminated indefinite CBOR array");
-                }
-                if (next_is_break()) {
-                    consume_break(depth + 1U);
-                    return;
-                }
-                parse_item(depth + 1U);
-            }
+            frames.push_back(annotation_frame{.major = major_type::Array, .indefinite = true, .child_depth = depth + 1U});
+            return;
         }
 
         const auto size = read_argument(header.additional_info);
         emit_header(depth, header.begin, position, text::format("array({})", size));
-        for (std::uint64_t index = 0; index < size; ++index) {
-            parse_item(depth + 1U);
+        if (size > 0U) {
+            frames.push_back(annotation_frame{.major = major_type::Array, .remaining = size, .child_depth = depth + 1U});
         }
     }
 
-    void parse_map(std::size_t depth, item_header header) {
+    void parse_map(std::size_t depth, item_header header, std::vector<annotation_frame> &frames) {
         if (header.additional_info == 31U) {
             emit_header(depth, header.begin, position, "map(*)");
-            while (true) {
-                if (empty()) {
-                    throw std::runtime_error("Unterminated indefinite CBOR map");
-                }
-                if (next_is_break()) {
-                    consume_break(depth + 1U);
-                    return;
-                }
-                parse_item(depth + 1U);
-                if (empty() || next_is_break()) {
-                    throw std::runtime_error("Indefinite CBOR map missing value");
-                }
-                parse_item(depth + 1U);
-            }
+            frames.push_back(annotation_frame{.major = major_type::Map, .indefinite = true, .child_depth = depth + 1U});
+            return;
         }
 
         const auto size = read_argument(header.additional_info);
         emit_header(depth, header.begin, position, text::format("map({})", size));
-        for (std::uint64_t index = 0; index < size; ++index) {
-            parse_item(depth + 1U);
-            parse_item(depth + 1U);
+        if (size > (std::numeric_limits<std::uint64_t>::max() / 2U)) {
+            throw std::runtime_error("CBOR annotation size overflow");
+        }
+        const auto item_count = size * 2U;
+        if (item_count > 0U) {
+            frames.push_back(annotation_frame{.major = major_type::Map, .remaining = item_count, .child_depth = depth + 1U});
         }
     }
 
-    void parse_tag(std::size_t depth, item_header header) {
+    void parse_tag(std::size_t depth, item_header header, std::vector<annotation_frame> &frames) {
         const auto tag = read_argument(header.additional_info);
         emit_header(depth, header.begin, position, tag_comment(tag));
-        parse_item(depth + 1U);
+        frames.push_back(annotation_frame{.major = major_type::Tag, .remaining = 1, .child_depth = depth + 1U});
     }
 
     void parse_simple(std::size_t depth, item_header header) {
@@ -2100,7 +2098,7 @@ template <typename OutputBuffer> struct smart_annotator {
         emit_header(depth, header_begin, position, "break");
     }
 
-    void parse_item(std::size_t depth) {
+    void parse_next_item(std::size_t depth, std::vector<annotation_frame> &frames) {
         check_depth(depth);
         const auto header_begin = position;
         const auto initial_byte = read_byte();
@@ -2121,17 +2119,55 @@ template <typename OutputBuffer> struct smart_annotator {
         }
         case 2:
         case 3: parse_string(depth, header); return;
-        case 4: parse_array(depth, header); return;
-        case 5: parse_map(depth, header); return;
-        case 6: parse_tag(depth, header); return;
+        case 4: parse_array(depth, header, frames); return;
+        case 5: parse_map(depth, header, frames); return;
+        case 6: parse_tag(depth, header, frames); return;
         case 7: parse_simple(depth, header); return;
         default: throw std::runtime_error("Invalid CBOR major type");
         }
     }
 
     void annotate_sequence() {
-        while (!empty()) {
-            parse_item(0);
+        std::vector<annotation_frame> frames;
+        while (true) {
+            if (frames.empty()) {
+                if (empty()) {
+                    return;
+                }
+                parse_next_item(0, frames);
+                continue;
+            }
+
+            auto &frame = frames.back();
+            if (!frame.indefinite) {
+                if (frame.remaining == 0U) {
+                    frames.pop_back();
+                    continue;
+                }
+                --frame.remaining;
+                const auto child_depth = frame.child_depth;
+                parse_next_item(child_depth, frames);
+                continue;
+            }
+
+            if (empty()) {
+                throw std::runtime_error(frame.major == major_type::Map ? "Unterminated indefinite CBOR map"
+                                                                        : "Unterminated indefinite CBOR array");
+            }
+            if (next_is_break()) {
+                if (frame.major == major_type::Map && frame.map_expects_value) {
+                    throw std::runtime_error("Indefinite CBOR map missing value");
+                }
+                const auto break_depth = frame.child_depth;
+                consume_break(break_depth);
+                frames.pop_back();
+                continue;
+            }
+            if (frame.major == major_type::Map) {
+                frame.map_expects_value = !frame.map_expects_value;
+            }
+            const auto child_depth = frame.child_depth;
+            parse_next_item(child_depth, frames);
         }
     }
 };

--- a/test/test_cbor_segments.cpp
+++ b/test/test_cbor_segments.cpp
@@ -221,6 +221,25 @@ int count_borrowed_segments(const cbor_segments &segments) {
     return count;
 }
 
+std::vector<std::byte> nested_definite_arrays(std::size_t depth) {
+    std::vector<std::byte> bytes(depth, std::byte{0x81});
+    bytes.push_back(std::byte{0x00});
+    return bytes;
+}
+
+std::vector<std::byte> nested_indefinite_arrays(std::size_t depth) {
+    std::vector<std::byte> bytes;
+    bytes.reserve((depth * 2U) + 1U);
+    for (std::size_t index = 0; index < depth; ++index) {
+        bytes.push_back(std::byte{0x9F});
+    }
+    bytes.push_back(std::byte{0x00});
+    for (std::size_t index = 0; index < depth; ++index) {
+        bytes.push_back(std::byte{0xFF});
+    }
+    return bytes;
+}
+
 } // namespace
 
 using tiny_inline_byte_segments   = basic_byte_segments<default_byte_segment_storage<4>>;
@@ -625,6 +644,44 @@ TEST_CASE("encoded item segment validation requires exactly one complete cbor it
 
         REQUIRE_FALSE(item);
         CHECK_EQ(item.error(), status_code::incomplete);
+    }
+}
+
+TEST_CASE("encoded item segment validation skips deep definite containers without frame depth pressure") {
+    const auto bytes = nested_definite_arrays(1024);
+
+    cbor_segments segments;
+    segments.append_owned(std::span<const std::byte>{bytes.data(), bytes.size()});
+
+    auto item = validate_item_segments(std::move(segments));
+
+    REQUIRE(item);
+    CHECK_EQ(to_hex(item->flatten()), to_hex(bytes));
+}
+
+TEST_CASE("encoded item segment validation keeps indefinite traversal state bounded internally") {
+    {
+        const auto bytes = nested_indefinite_arrays(256);
+
+        cbor_segments segments;
+        segments.append_owned(std::span<const std::byte>{bytes.data(), bytes.size()});
+
+        auto item = validate_item_segments(std::move(segments));
+
+        REQUIRE(item);
+        CHECK_EQ(to_hex(item->flatten()), to_hex(bytes));
+    }
+
+    {
+        const auto bytes = nested_indefinite_arrays(257);
+
+        cbor_segments segments;
+        segments.append_owned(std::span<const std::byte>{bytes.data(), bytes.size()});
+
+        auto item = validate_item_segments(std::move(segments));
+
+        REQUIRE_FALSE(item);
+        CHECK_EQ(item.error(), status_code::error);
     }
 }
 

--- a/test/test_lazy_tags.cpp
+++ b/test/test_lazy_tags.cpp
@@ -63,6 +63,22 @@ std::vector<std::byte> make_deeply_nested_tag(std::size_t depth) {
     return buffer;
 }
 
+std::vector<std::byte> make_indefinitely_nested_tag(std::size_t depth) {
+    std::vector<std::byte> buffer;
+    buffer.reserve((depth * 2U) + 4U);
+    for (std::size_t index = 0; index < depth; ++index) {
+        buffer.push_back(std::byte{0x9F});
+    }
+    buffer.push_back(std::byte{0xD8});
+    buffer.push_back(std::byte{0x64});
+    buffer.push_back(std::byte{0x18});
+    buffer.push_back(std::byte{0x2A});
+    for (std::size_t index = 0; index < depth; ++index) {
+        buffer.push_back(std::byte{0xFF});
+    }
+    return buffer;
+}
+
 template <typename Buffer>
 concept CanFindStaticTags = requires(Buffer &&buffer) { find_tags<100>(std::forward<Buffer>(buffer)); };
 
@@ -519,9 +535,31 @@ TEST_CASE("lazy tag scanner stress scans deeply nested definite containers witho
     CHECK_EQ(view.status(), status_code::success);
 }
 
-TEST_CASE("lazy tag scanner handles no-allocation depth boundary") {
+TEST_CASE("lazy tag scanner does not spend frame stack on definite nesting") {
+    auto buffer = make_deeply_nested_tag(1024);
+    auto view   = find_tags<100>(buffer);
+    bool threw  = false;
+    int  matches{};
+
     {
-        auto buffer = make_deeply_nested_tag(255);
+        allocation_failure_guard guard;
+        try {
+            for (auto it = view.begin(); it != view.end(); ++it) {
+                ++matches;
+                CHECK_EQ(it->tag(), 100);
+                CHECK_EQ(to_hex(it->payload_range()), "182a");
+            }
+        } catch (...) { threw = true; }
+    }
+
+    CHECK(!threw);
+    CHECK_EQ(matches, 1);
+    CHECK_EQ(view.status(), status_code::success);
+}
+
+TEST_CASE("lazy tag scanner keeps indefinite traversal state private and bounded") {
+    {
+        auto buffer = make_indefinitely_nested_tag(256);
         auto view   = find_tags<100>(buffer);
         bool threw  = false;
         int  matches{};
@@ -541,7 +579,7 @@ TEST_CASE("lazy tag scanner handles no-allocation depth boundary") {
     }
 
     {
-        auto buffer = make_deeply_nested_tag(256);
+        auto buffer = make_indefinitely_nested_tag(257);
         auto view   = find_tags<100>(buffer);
         bool threw  = false;
 

--- a/test/test_range_support_regressions.cpp
+++ b/test/test_range_support_regressions.cpp
@@ -597,7 +597,7 @@ TEST_CASE("sized non-contiguous readers use size for offset bounds checks") {
     CHECK_EQ(input.increments, 1);
 }
 
-TEST_CASE("lazy tag scanner applies remaining depth budget to matched payload validation") {
+TEST_CASE("lazy tag scanner validates matched payloads without definite parent depth leakage") {
     {
         auto buffer = make_deep_tag_with_array_payload(254);
         auto view   = find_tags<100>(buffer);
@@ -613,13 +613,17 @@ TEST_CASE("lazy tag scanner applies remaining depth budget to matched payload va
     }
 
     {
-        auto buffer = make_deep_tag_with_array_payload(255);
+        auto buffer = make_deep_tag_with_array_payload(1024);
         auto view   = find_tags<100>(buffer);
         auto it     = view.begin();
 
+        REQUIRE(it != view.end());
+        CHECK_EQ(it->tag(), 100);
+        CHECK_EQ(to_hex(it->payload_range()), "81182a");
+
+        ++it;
         CHECK(it == view.end());
-        CHECK(view.failed());
-        CHECK_EQ(view.status(), status_code::error);
+        CHECK_EQ(view.status(), status_code::success);
     }
 }
 

--- a/test/test_raw_views.cpp
+++ b/test/test_raw_views.cpp
@@ -147,6 +147,25 @@ void check_raw_item_decode_error(const char *hex, status_code expected) {
     CHECK_EQ(result.error(), expected);
 }
 
+std::vector<std::byte> nested_definite_arrays(std::size_t depth) {
+    std::vector<std::byte> bytes(depth, std::byte{0x81});
+    bytes.push_back(std::byte{0x00});
+    return bytes;
+}
+
+std::vector<std::byte> nested_indefinite_arrays(std::size_t depth) {
+    std::vector<std::byte> bytes;
+    bytes.reserve((depth * 2U) + 1U);
+    for (std::size_t index = 0; index < depth; ++index) {
+        bytes.push_back(std::byte{0x9F});
+    }
+    bytes.push_back(std::byte{0x00});
+    for (std::size_t index = 0; index < depth; ++index) {
+        bytes.push_back(std::byte{0xFF});
+    }
+    return bytes;
+}
+
 } // namespace
 
 TEST_CASE("raw encoded item views decode one item and re-encode exact bytes") {
@@ -218,6 +237,41 @@ TEST_CASE("raw encoded views preserve indefinite arrays and maps") {
         REQUIRE(dec(map));
         CHECK_EQ(to_hex(map.bytes()), "bf016161029f0304ffff");
         CHECK_EQ(to_hex(reencode(map)), "bf016161029f0304ffff");
+    }
+}
+
+TEST_CASE("raw encoded views skip deeply nested definite containers without frame depth pressure") {
+    auto bytes = nested_definite_arrays(1024);
+    auto dec   = make_decoder(bytes);
+
+    encoded_item_view item;
+
+    REQUIRE(dec(item));
+    CHECK_EQ(item.size(), bytes.size());
+    CHECK_EQ(to_hex(item.bytes()), to_hex(bytes));
+}
+
+TEST_CASE("raw encoded views keep indefinite traversal state bounded internally") {
+    {
+        auto bytes = nested_indefinite_arrays(256);
+        auto dec   = make_decoder(bytes);
+
+        encoded_item_view item;
+
+        REQUIRE(dec(item));
+        CHECK_EQ(item.size(), bytes.size());
+        CHECK_EQ(to_hex(item.bytes()), to_hex(bytes));
+    }
+
+    {
+        auto bytes = nested_indefinite_arrays(257);
+        auto dec   = make_decoder(bytes);
+
+        encoded_item_view item;
+        auto              result = dec(item);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace raw/lazy structural traversal with an internal cursor that uses pending counts for definite containers and private frames for indefinite containers
- keep typed decode APIs context-free; no public structural/depth context is added
- make smart annotation use an explicit private frame loop instead of recursive array/map/tag descent
- update raw view, segment validation, and lazy tag tests for deep definite nesting and bounded indefinite traversal

Stacked on #53 / `feat/decode-depth-limit`.

## Validation
- `cmake --build --preset debug-tests`
- `ctest --preset debug-tests --output-on-failure`
- `BUILD_DIR=/tmp/cbor_tags_tidy_structural_cursor scripts/lint-cxx.sh`