### PR TITLE
feat(codec): add runtime size bounds

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -114,23 +114,23 @@ jobs:
       with:
         cmakeVersion: '3.31.5'
 
-    - name: Install LLVM 21 tools
+    - name: Install LLVM 22 tools
       shell: bash
       run: |
         sudo apt-get update
         sudo apt-get install -y ca-certificates ccache gnupg ninja-build wget
         wget -q https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 21
-        sudo apt-get install -y clang-format-21 clang-tidy-21
+        sudo ./llvm.sh 22
+        sudo apt-get install -y clang-format-22 clang-tidy-22
 
     - name: Run lint
       shell: bash
       run: |
-        CC=clang-21 \
-        CXX=clang++-21 \
-        CLANG_FORMAT=clang-format-21 \
-        CLANG_TIDY_EXE=clang-tidy-21 \
+        CC=clang-22 \
+        CXX=clang++-22 \
+        CLANG_FORMAT=clang-format-22 \
+        CLANG_TIDY_EXE=clang-tidy-22 \
         scripts/lint-cxx.sh
 
   coverage:
@@ -259,11 +259,11 @@ jobs:
               family: "gcc"
             }
           - {
-              name: "LLVM 21",
-              cc: "clang-21",
-              cxx: "clang++-21",
+              name: "LLVM 22",
+              cc: "clang-22",
+              cxx: "clang++-22",
               family: "llvm",
-              version: "21"
+              version: "22"
             }
 
     steps:

--- a/README.md
+++ b/README.md
@@ -978,7 +978,8 @@ When decoding untrusted CBOR into owning containers, an input can declare very
 large array, map, text-string, or byte-string sizes. Plain containers do not
 impose schema or application size limits for you. Use
 `cbor::tags::bounded_size<T, Min, Max>` for per-field protocol size bounds, and
-use allocator-aware types backed by a bounded `std::pmr::memory_resource` for
+`cbor::tags::as_bounded_size(value, min, max)` for limits selected at runtime.
+Use allocator-aware types backed by a bounded `std::pmr::memory_resource` for
 allocation containment.
 
 This assumes the input byte buffer itself is already bounded by your transport,
@@ -1012,7 +1013,8 @@ std::pmr::monotonic_buffer_resource arena(
 std::pmr::vector<std::pmr::string> values{&arena};
 
 auto dec = ct::make_decoder(input);
-auto result = dec(values);
+std::size_t max_items = 64; // From application configuration.
+auto result = dec(ct::as_bounded_size(values, 0, max_items));
 
 if (!result && result.error() == ct::status_code::out_of_memory) {
     // The bounded arena was exhausted.
@@ -1031,14 +1033,20 @@ std::pmr::vector<std::optional<std::pmr::string>>
 Important limitations:
 
 - PMR is allocation containment, not schema validation.
-- `bounded_size<T, Min, Max>` validates only the immediately wrapped field and
-  generates matching CDDL. An unwrapped inner container is intentionally
-  unbounded; wrap it separately when it also has a protocol limit.
+- Static and runtime size bounds validate only the immediately wrapped field.
+  An unwrapped inner container is intentionally unbounded; wrap it separately
+  when it also has a limit.
 - A size bound constrains one incoming or outgoing CBOR item, not the accumulated
   size of a pre-populated decode destination. Appending a valid item can leave the
   destination larger than `Max`.
-- RFC 8746 scalar typed arrays can also be wrapped in `bounded_size`; the C++
-  bounds are element counts, while generated CDDL constrains byte-string size.
+- `bounded_size<T, Min, Max>` generates matching type-based CDDL.
+  `dynamic_bounded_size<T>` stores instance data and cannot be represented by
+  type-based CDDL.
+- A runtime-bounded decode destination must already have its bounds. Generic
+  variant, optional, and container decoding cannot invent bounds for a value it
+  creates.
+- RFC 8746 scalar typed arrays support static and runtime bounds as element
+  counts. Static bounds generate CDDL constraints on byte-string size.
 - Normal typed decoding is single-pass and has no built-in nesting-depth limit.
 - Input-controlled stack growth is limited to [recursive decode paths](doc/decoder_resource_limits.md#recursive-decode-paths), such as
   recursively defined destination types or custom codecs that explicitly recurse.

--- a/benchmarks/custom_codec_1/bench_custom_codec_1.cpp
+++ b/benchmarks/custom_codec_1/bench_custom_codec_1.cpp
@@ -516,7 +516,7 @@ TEST_CASE("custom_codec_1 encode wire throughput benchmarks") {
         if constexpr (std::endian::native == std::endian::little) {
             auto const typed_zc_vector = rfc8746::encode_typed_array_segments(std::span<const double>{values.data(), values.size()});
             auto const typed_zc_name   = std::string{"rfc8746 typed array zc vector<double>["} + std::to_string(count) +
-                                       "] encode segment assembly (represented bytes)";
+                                         "] encode segment assembly (represented bytes)";
             bench.batch(typed_zc_vector.total_size()).run(typed_zc_name, [&] {
                 auto segments = rfc8746::encode_typed_array_segments(std::span<const double>{values.data(), values.size()});
                 ankerl::nanobench::doNotOptimizeAway(segments);

--- a/benchmarks/decoder/bench_decoder.cpp
+++ b/benchmarks/decoder/bench_decoder.cpp
@@ -788,8 +788,10 @@ std::vector<std::byte> make_indefinite_zero_array(std::size_t count) {
 void benchmark_bounded_array_decode(std::string_view title, const std::vector<std::byte> &encoded, std::size_t count) {
     std::vector<std::uint64_t> direct_value;
     std::vector<std::uint64_t> bounded_value;
+    std::vector<std::uint64_t> dynamic_bounded_value;
     direct_value.reserve(count);
     bounded_value.reserve(count);
+    dynamic_bounded_value.reserve(count);
 
     {
         auto decoder = make_decoder(encoded);
@@ -799,7 +801,12 @@ void benchmark_bounded_array_decode(std::string_view title, const std::vector<st
         auto decoder = make_decoder(encoded);
         REQUIRE(decoder(as_bounded_size<0, 4096>(bounded_value)));
     }
+    {
+        auto decoder = make_decoder(encoded);
+        REQUIRE(decoder(as_bounded_size(dynamic_bounded_value, 0, count)));
+    }
     REQUIRE(direct_value == bounded_value);
+    REQUIRE(direct_value == dynamic_bounded_value);
 
     ankerl::nanobench::Bench bench;
     bench.title(std::string{title});
@@ -824,6 +831,14 @@ void benchmark_bounded_array_decode(std::string_view title, const std::vector<st
         auto result  = decoder(as_bounded_size<0, 4096>(bounded_value));
         ankerl::nanobench::doNotOptimizeAway(result);
         ankerl::nanobench::doNotOptimizeAway(bounded_value.data());
+    });
+
+    bench.batch(encoded.size()).run("dynamic bounded typed decode", [&] {
+        dynamic_bounded_value.clear();
+        auto decoder = make_decoder(encoded);
+        auto result  = decoder(as_bounded_size(dynamic_bounded_value, 0, count));
+        ankerl::nanobench::doNotOptimizeAway(result);
+        ankerl::nanobench::doNotOptimizeAway(dynamic_bounded_value.data());
     });
 }
 

--- a/benchmarks/ranges/bench_ranges.cpp
+++ b/benchmarks/ranges/bench_ranges.cpp
@@ -114,7 +114,7 @@ TEST_CASE("Range encoding benchmarks") {
     auto filtered_values   = values | std::views::filter([](int) { return true; });
     auto transformed_pairs = values | std::views::transform([](int value) { return std::pair{value, value * 2}; });
     auto filtered_pairs    = values | std::views::filter([](int) { return true; }) |
-                          std::views::transform([](int value) { return std::pair{value, value * 2}; });
+                             std::views::transform([](int value) { return std::pair{value, value * 2}; });
     auto transformed_bytes = values | std::views::transform([](int value) { return static_cast<std::uint8_t>(value); });
     auto chunked_bytes     = bytes | std::views::filter([](std::byte) { return true; });
 
@@ -146,8 +146,8 @@ TEST_CASE("Range decoding benchmarks") {
 
     auto filtered_values = values | std::views::filter([](int) { return true; });
     auto filtered_pairs  = values | std::views::filter([](int) { return true; }) |
-                          std::views::transform([](int value) { return std::pair{value, value * 2}; });
-    auto chunked_bytes = bytes | std::views::filter([](std::byte) { return true; });
+                           std::views::transform([](int value) { return std::pair{value, value * 2}; });
+    auto chunked_bytes   = bytes | std::views::filter([](std::byte) { return true; });
 
     auto definite_array    = encode_to_vector(as_array_range(values));
     auto indef_array       = encode_to_vector(as_array_range(filtered_values));

--- a/doc/cddl_handling.md
+++ b/doc/cddl_handling.md
@@ -262,10 +262,10 @@ using bounded_rows = ct::max_size<std::vector<bounded_row>, 16>;
 // Limits both the number of rows and the number of values in each row.
 ```
 
-The bound describes the cardinality of one encoded or decoded CBOR item. It is
-not a persistent invariant on the backing C++ container. Decoding into an
-existing mutable destination validates only the incoming item, then follows the
-core decoder's append/insert contract:
+Static and runtime bounds describe the cardinality of one encoded or decoded
+CBOR item. They are not persistent invariants on the backing C++ container.
+Decoding into an existing mutable destination validates only the incoming item,
+then follows the core decoder's append/insert contract:
 
 ```cpp
 std::vector<int> incoming{1, 2};
@@ -275,7 +275,8 @@ ct::make_encoder(input)(incoming);
 std::vector<int> destination{9, 8, 7};
 auto result = ct::make_decoder(input)(ct::as_bounded_size<2, 2>(destination));
 // result succeeds; destination is now {9, 8, 7, 1, 2}.
-// Its final size may exceed Max because Max constrained the incoming CBOR array.
+// Its final size may exceed the configured maximum because that maximum
+// constrained the incoming CBOR array.
 ```
 
 Encoding validates the complete wrapped source value. To encode only a bounded

--- a/doc/cddl_handling.md
+++ b/doc/cddl_handling.md
@@ -151,6 +151,56 @@ auto enc = ct::make_encoder(output);
 auto result = enc(ct::as_bounded_size<1, 3>(values));
 ```
 
+Use `dynamic_bounded_size<T>` when the limits are application state rather than
+part of the protocol type. The overload
+`as_bounded_size(value, min, max)` references an lvalue and owns an rvalue:
+
+```cpp
+namespace ct = cbor::tags;
+
+std::size_t max_scores = load_configured_score_limit();
+std::vector<int> scores;
+
+auto dec = ct::make_decoder(input);
+auto result = dec(ct::as_bounded_size(scores, 1, max_scores));
+```
+
+Runtime wrappers have no default constructor because a decoder must never
+receive an unconfigured bound. Construct aggregate fields before decoding:
+
+```cpp
+struct RuntimePerson {
+    ct::dynamic_bounded_size<std::string> name;
+    ct::dynamic_bounded_size<std::vector<int>> scores;
+};
+
+RuntimePerson person{
+    ct::dynamic_bounded_size<std::string>{std::string{}, 1, max_name_bytes},
+    ct::dynamic_bounded_size<std::vector<int>>{
+        std::vector<int>{}, 0, max_scores},
+};
+
+auto result = dec(person);
+```
+
+`min > max` throws `std::invalid_argument` when a runtime wrapper is created.
+Wrapping an already bounded value replaces its old bounds and keeps only one
+wrapper:
+
+```cpp
+auto configured = ct::as_bounded_size(scores, 0, max_scores);
+auto request_bound = ct::as_bounded_size(configured, 1, request_max);
+// request_bound refers to scores and uses [1, request_max].
+```
+
+Type-based CDDL cannot read per-instance limits, so
+`cddl_schema_to<dynamic_bounded_size<T>>` is intentionally rejected. Use
+`bounded_size<T, Min, Max>` for schema-visible protocol limits. Runtime-bounded
+values may be encoded through a selected `std::variant` alternative, but they
+cannot be decoded as variant alternatives or as values that generic optional or
+container decoding must create. Those paths have no configured `min` and `max`
+to attach to the new object.
+
 Explicit range wrappers can be bounded for encode and CDDL generation when the
 wrapped range is a sized range. The encoder reads `size()` before writing:
 
@@ -277,12 +327,34 @@ struct samples_codec : cbor::tags::cbor_codec_mixin_base<Self> {
         auto values = cbor::tags::as_bounded_size<Min, Max>(bounded.value().values);
         return static_cast<Self&>(*this).decode(values, major, additional_info);
     }
+
+    template <typename Value>
+        requires std::same_as<std::remove_cvref_t<Value>, samples>
+    void encode(const cbor::tags::dynamic_bounded_size<Value>& bounded) {
+        static_cast<Self&>(*this).encode(cbor::tags::as_bounded_size(
+            bounded.value().values,
+            bounded.min_size(),
+            bounded.max_size()));
+    }
+
+    template <typename Value>
+        requires std::same_as<std::remove_cvref_t<Value>, samples>
+    cbor::tags::status_code decode(
+        cbor::tags::dynamic_bounded_size<Value>& bounded,
+        cbor::tags::major_type major,
+        std::byte additional_info) {
+        auto values = cbor::tags::as_bounded_size(
+            bounded.value().values,
+            bounded.min_size(),
+            bounded.max_size());
+        return static_cast<Self&>(*this).decode(values, major, additional_info);
+    }
 };
 ```
 
-The RFC 8746 scalar typed-array extension supports `bounded_size` as element
-counts. CDDL renders the corresponding byte-string byte count because the wire
-payload is a `bstr`:
+The RFC 8746 scalar typed-array extension supports static and runtime bounds as
+element counts. Static bounds render the corresponding byte-string byte count
+in CDDL because the wire payload is a `bstr`:
 
 ```cpp
 namespace ct = cbor::tags;

--- a/doc/experimental_ranges.md
+++ b/doc/experimental_ranges.md
@@ -196,6 +196,18 @@ enc(ct::as_bounded_size<0, 3>(ct::as_array_range(values)));
 // CDDL: [0*3 int]
 ```
 
+Limits selected at runtime use the same sized-range path:
+
+```cpp
+std::size_t max_values = configured_limit();
+enc(ct::as_bounded_size(
+    ct::as_array_range(values), 0, max_values));
+```
+
+The runtime form checks `size()` once before encoding and does not describe a
+type-based CDDL constraint. Use the compile-time form when the bound belongs in
+the schema.
+
 Bounded encoding of a non-sized range is intentionally unsupported because
 checking the bound before writing would require a separate counting traversal.
 The unbounded explicit wrapper remains one-pass:
@@ -209,6 +221,7 @@ auto evens = values | std::views::filter([](int value) {
 
 enc(ct::as_array_range(evens));                            // supported
 enc(ct::as_bounded_size<0, 2>(ct::as_array_range(evens))); // unsupported
+enc(ct::as_bounded_size(ct::as_array_range(evens), 0, 2)); // unsupported
 ```
 
 ```cpp

--- a/doc/rfc8746_typed_arrays.md
+++ b/doc/rfc8746_typed_arrays.md
@@ -201,9 +201,30 @@ ct::cddl_schema_to<bounded_samples>(schema);
 // root = #6.78(bstr .size (4..12))
 ```
 
-All scalar typed-array wrappers render bounded CDDL. `typed_array<T>` supports
-bounded encode and decode, `typed_array_ref<T>` supports bounded encode, and
-`typed_array_view<T>` supports bounded decode.
+Use runtime bounds when the element limit comes from application configuration:
+
+```cpp
+std::size_t max_samples = configured_sample_limit();
+
+enc(ct::as_bounded_size(
+    rfc8746::as_typed_array(values), 1, max_samples));
+
+rfc8746::typed_array<std::int32_t> decoded;
+dec(ct::as_bounded_size(decoded, 1, max_samples));
+```
+
+Runtime bounds work for owned scalar typed arrays, borrowed encode wrappers,
+and typed-array decode views. They are still element counts. The decoder checks
+the corresponding payload byte range and element alignment before allocating
+owned values or assigning a view.
+
+`dynamic_bounded_size<T>` cannot be rendered as type-based CDDL because its
+limits belong to an object, not its type. Use `bounded_size<T, Min, Max>` when
+the typed-array limit is part of the schema.
+
+`bounded_size` around any scalar typed-array wrapper renders bounded CDDL.
+`typed_array<T>` supports bounded encode and decode, `typed_array_ref<T>`
+supports bounded encode, and `typed_array_view<T>` supports bounded decode.
 
 Structural wrappers render their actual encoded payload:
 
@@ -345,7 +366,7 @@ homogeneous array wrapper.
 - variant decode by fixed tag with compile-time collision checks,
 - structural tags `#6.40`, `#6.41`, and `#6.1040`,
 - CDDL rendering for scalar typed arrays and structural wrappers,
-- element-count bounds for scalar typed arrays through `bounded_size`.
+- static and runtime element-count bounds for scalar typed arrays.
 
 ## Validation
 

--- a/include/cbor_tags/cbor.h
+++ b/include/cbor_tags/cbor.h
@@ -149,6 +149,7 @@ template <typename V1, typename V2, typename T> struct values_equal : std::bool_
 
 template <typename T, std::size_t Min, std::size_t Max> struct bounded_size {
     static_assert(Min <= Max, "bounded_size<T, Min, Max> requires Min <= Max");
+    static_assert(!IsAnyBoundedSizeWrapper<T>, "bounded size wrappers cannot directly contain another bounded size wrapper");
 
     using value_type = std::remove_reference_t<T>;
 
@@ -173,26 +174,109 @@ template <typename T, std::size_t Min, std::size_t Max> struct bounded_size {
         requires(std::is_lvalue_reference_v<T>)
         : value_(value) {}
 
-    [[nodiscard]] constexpr decltype(auto) value() noexcept { return (value_); }
-    [[nodiscard]] constexpr decltype(auto) value() const noexcept { return (value_); }
+    [[nodiscard]] constexpr decltype(auto) value() & noexcept { return (value_); }
+    [[nodiscard]] constexpr decltype(auto) value() const & noexcept { return (value_); }
+    [[nodiscard]] constexpr decltype(auto) value() && noexcept {
+        if constexpr (std::is_reference_v<T>) {
+            return (value_);
+        } else {
+            return std::move(value_);
+        }
+    }
+    [[nodiscard]] constexpr decltype(auto) value() const && noexcept {
+        if constexpr (std::is_reference_v<T>) {
+            return (value_);
+        } else {
+            return std::move(value_);
+        }
+    }
+};
+
+template <typename T> struct dynamic_bounded_size {
+    static_assert(!IsAnyBoundedSizeWrapper<T>, "bounded size wrappers cannot directly contain another bounded size wrapper");
+
+    using value_type = std::remove_reference_t<T>;
+
+  private:
+    [[nodiscard]] static constexpr std::size_t checked_max(std::size_t min, std::size_t max) {
+        if (min > max) {
+            throw std::invalid_argument("dynamic_bounded_size<T> requires min <= max");
+        }
+        return max;
+    }
+
+    std::size_t min_size_;
+    std::size_t max_size_;
+
+  public:
+    T value_;
+
+    constexpr explicit dynamic_bounded_size(const value_type &value, std::size_t min, std::size_t max)
+        requires(!std::is_reference_v<T> && std::copy_constructible<value_type>)
+        : min_size_(min), max_size_(checked_max(min, max)), value_(value) {}
+
+    constexpr explicit dynamic_bounded_size(value_type &&value, std::size_t min, std::size_t max)
+        requires(!std::is_reference_v<T> && std::move_constructible<value_type>)
+        : min_size_(min), max_size_(checked_max(min, max)), value_(std::move(value)) {}
+
+    constexpr explicit dynamic_bounded_size(value_type &value, std::size_t min, std::size_t max)
+        requires(std::is_lvalue_reference_v<T>)
+        : min_size_(min), max_size_(checked_max(min, max)), value_(value) {}
+
+    [[nodiscard]] constexpr std::size_t min_size() const noexcept { return min_size_; }
+    [[nodiscard]] constexpr std::size_t max_size() const noexcept { return max_size_; }
+
+    [[nodiscard]] constexpr decltype(auto) value() & noexcept { return (value_); }
+    [[nodiscard]] constexpr decltype(auto) value() const & noexcept { return (value_); }
+    [[nodiscard]] constexpr decltype(auto) value() && noexcept {
+        if constexpr (std::is_reference_v<T>) {
+            return (value_);
+        } else {
+            return std::move(value_);
+        }
+    }
+    [[nodiscard]] constexpr decltype(auto) value() const && noexcept {
+        if constexpr (std::is_reference_v<T>) {
+            return (value_);
+        } else {
+            return std::move(value_);
+        }
+    }
 };
 
 template <typename T, std::size_t Max> using max_size = bounded_size<T, 0, Max>;
 template <typename T, std::size_t N> using exact_size = bounded_size<T, N, N>;
 
-template <std::size_t Min, std::size_t Max, typename T> [[nodiscard]] constexpr auto as_bounded_size(T &&value) {
-    using stored_type = std::conditional_t<std::is_lvalue_reference_v<T>, T, std::remove_cvref_t<T>>;
-    return bounded_size<stored_type, Min, Max>{std::forward<T>(value)};
-}
-
 namespace detail {
 
-template <std::size_t Min, std::size_t Max> [[nodiscard]] constexpr status_code bounded_size_status(std::uint64_t size) noexcept {
-    return size >= static_cast<std::uint64_t>(Min) && size <= static_cast<std::uint64_t>(Max) ? status_code::success
+template <typename T> [[nodiscard]] constexpr decltype(auto) unwrap_bounded_size(T &&value) {
+    if constexpr (IsAnyBoundedSizeWrapper<T>) {
+        return unwrap_bounded_size(std::forward<T>(value).value());
+    } else {
+        return std::forward<T>(value);
+    }
+}
+
+template <typename T> using bounded_stored_type_t = std::conditional_t<std::is_lvalue_reference_v<T>, T, std::remove_cvref_t<T>>;
+
+[[nodiscard]] constexpr status_code bounded_size_status(std::uint64_t size, std::size_t min, std::size_t max) noexcept {
+    return size >= static_cast<std::uint64_t>(min) && size <= static_cast<std::uint64_t>(max) ? status_code::success
                                                                                               : status_code::size_limit_exceeded;
 }
 
 } // namespace detail
+
+template <std::size_t Min, std::size_t Max, typename T> [[nodiscard]] constexpr auto as_bounded_size(T &&value) {
+    auto &&unwrapped  = detail::unwrap_bounded_size(std::forward<T>(value));
+    using stored_type = detail::bounded_stored_type_t<decltype(unwrapped)>;
+    return bounded_size<stored_type, Min, Max>{std::forward<decltype(unwrapped)>(unwrapped)};
+}
+
+template <typename T> [[nodiscard]] constexpr auto as_bounded_size(T &&value, std::size_t min, std::size_t max) {
+    auto &&unwrapped  = detail::unwrap_bounded_size(std::forward<T>(value));
+    using stored_type = detail::bounded_stored_type_t<decltype(unwrapped)>;
+    return dynamic_bounded_size<stored_type>{std::forward<decltype(unwrapped)>(unwrapped), min, max};
+}
 
 template <typename... T> struct ReturnTypeHelper {
     static auto get_return_type() {

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -121,6 +121,7 @@ template <typename T> struct as_named_map;
 template <typename T> struct as_named_group;
 template <typename T> struct as_named_extension;
 template <typename T, std::size_t Min, std::size_t Max> struct bounded_size;
+template <typename T> struct dynamic_bounded_size;
 
 struct as_text_any {
     std::uint64_t size;
@@ -293,10 +294,19 @@ template <typename T> inline constexpr bool is_bounded_size_v = false;
 
 template <typename T, std::size_t Min, std::size_t Max> inline constexpr bool is_bounded_size_v<bounded_size<T, Min, Max>> = true;
 
+template <typename T> inline constexpr bool is_dynamic_bounded_size_v = false;
+
+template <typename T> inline constexpr bool is_dynamic_bounded_size_v<dynamic_bounded_size<T>> = true;
 } // namespace detail
 
 template <typename T>
 concept IsBoundedSizeWrapper = detail::is_bounded_size_v<std::remove_cvref_t<T>>;
+
+template <typename T>
+concept IsDynamicBoundedSizeWrapper = detail::is_dynamic_bounded_size_v<std::remove_cvref_t<T>>;
+
+template <typename T>
+concept IsAnyBoundedSizeWrapper = IsBoundedSizeWrapper<T> || IsDynamicBoundedSizeWrapper<T>;
 
 template <typename T>
 concept IsTextChar = std::is_integral_v<std::remove_cv_t<T>> && sizeof(std::remove_cv_t<T>) == 1 &&
@@ -715,7 +725,7 @@ concept IsClassWithDecodingOverload = std::is_class_v<C> && (HasTranscodeMethod<
 
 template <typename T>
 concept IsAggregate = std::is_aggregate_v<T> && !IsVariant<T> && !IsFixedArray<T> && !IsAnyHeader<T> && !IsString<T> &&
-                      !IsNamedWrapper<T> && !IsBoundedSizeWrapper<T>;
+                      !IsNamedWrapper<T> && !IsAnyBoundedSizeWrapper<T>;
 
 // Helper to check if all types in a variant satisfy IsCborMajor
 template <typename T> struct AllTypesAreCborMajor;
@@ -733,7 +743,7 @@ concept IsCborMajor =
     IsAnyHeader<T> || IsUnsigned<T> || IsNegative<T> || IsSigned<T> || IsTextString<T> || IsBinaryString<T> ||
     (IsArray<T> && ContainsCborMajorConcept<T>) || (IsMap<T> && ContainsCborMajorConcept<T>) || IsTag<T> || IsSimple<T> ||
     (IsVariant<T> && AllTypesAreCborMajorConcept<T>) || (IsOptional<T> && ContainsCborMajorConcept<T>) || IsNamedMapWrapper<T> ||
-    (IsBoundedSizeWrapper<T> && ContainsCborMajorConcept<T>) || IsEnum<T> || (IsClassWithTagOverload<T>);
+    (IsAnyBoundedSizeWrapper<T> && ContainsCborMajorConcept<T>) || IsEnum<T> || (IsClassWithTagOverload<T>);
 
 namespace detail {
 
@@ -778,7 +788,7 @@ template <typename T> struct ContainsCborMajor<T, true> {
 };
 
 template <typename T>
-    requires IsBoundedSizeWrapper<T>
+    requires IsAnyBoundedSizeWrapper<T>
 struct ContainsCborMajor<T, false> {
     using bounded_type          = std::remove_cvref_t<T>;
     using wrapped_type          = std::remove_cvref_t<typename bounded_type::value_type>;

--- a/include/cbor_tags/cbor_concepts_checking.h
+++ b/include/cbor_tags/cbor_concepts_checking.h
@@ -257,7 +257,7 @@ constexpr void getMatchCount(std::array<uint64_t, detail::MaxBucketsForVariantCh
         ValidConceptMapping<T>::counts_fn_inner(result, tags, simples);
         return;
     }
-    if constexpr (IsBoundedSizeWrapper<T>) {
+    if constexpr (IsAnyBoundedSizeWrapper<T>) {
         using bounded_type = std::remove_cvref_t<T>;
         using wrapped_type = std::remove_cvref_t<typename bounded_type::value_type>;
         unmatched          = false;
@@ -354,7 +354,7 @@ constexpr void getTagsCounts(std::array<uint64_t, detail::MaxTagsForVariantCheck
         ValidConceptMapping<T>::tags_fn_inner(result, tags, simples);
         return;
     }
-    if constexpr (IsBoundedSizeWrapper<T>) {
+    if constexpr (IsAnyBoundedSizeWrapper<T>) {
         using bounded_type = std::remove_cvref_t<T>;
         using wrapped_type = std::remove_cvref_t<typename bounded_type::value_type>;
         getTagsCounts<wrapped_type>(result, tags, simples);

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -222,22 +222,38 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
     template <IsBinaryString T, std::size_t Min, std::size_t Max>
     constexpr status_code decode(bounded_size<T, Min, Max> &value, major_type major, byte additionalInfo) {
-        return decode_bounded_bstr<Min, Max>(value.value(), major, additionalInfo);
+        return decode_bounded_bstr(value.value(), major, additionalInfo, Min, Max);
     }
 
     template <IsTextString T, std::size_t Min, std::size_t Max>
     constexpr status_code decode(bounded_size<T, Min, Max> &value, major_type major, byte additionalInfo) {
-        return decode_bounded_tstr<Min, Max>(value.value(), major, additionalInfo);
+        return decode_bounded_tstr(value.value(), major, additionalInfo, Min, Max);
     }
 
     template <IsArray T, std::size_t Min, std::size_t Max>
     constexpr status_code decode(bounded_size<T, Min, Max> &value, major_type major, byte additionalInfo) {
-        return decode_bounded_array<Min, Max>(value.value(), major, additionalInfo);
+        return decode_bounded_array(value.value(), major, additionalInfo, Min, Max);
     }
 
     template <IsMap T, std::size_t Min, std::size_t Max>
     constexpr status_code decode(bounded_size<T, Min, Max> &value, major_type major, byte additionalInfo) {
-        return decode_bounded_map<Min, Max>(value.value(), major, additionalInfo);
+        return decode_bounded_map(value.value(), major, additionalInfo, Min, Max);
+    }
+
+    template <IsBinaryString T> constexpr status_code decode(dynamic_bounded_size<T> &value, major_type major, byte additionalInfo) {
+        return decode_bounded_bstr(value.value(), major, additionalInfo, value.min_size(), value.max_size());
+    }
+
+    template <IsTextString T> constexpr status_code decode(dynamic_bounded_size<T> &value, major_type major, byte additionalInfo) {
+        return decode_bounded_tstr(value.value(), major, additionalInfo, value.min_size(), value.max_size());
+    }
+
+    template <IsArray T> constexpr status_code decode(dynamic_bounded_size<T> &value, major_type major, byte additionalInfo) {
+        return decode_bounded_array(value.value(), major, additionalInfo, value.min_size(), value.max_size());
+    }
+
+    template <IsMap T> constexpr status_code decode(dynamic_bounded_size<T> &value, major_type major, byte additionalInfo) {
+        return decode_bounded_map(value.value(), major, additionalInfo, value.min_size(), value.max_size());
     }
 
     template <IsBinaryString T> constexpr status_code decode(T &t, major_type major, byte additionalInfo) {
@@ -996,8 +1012,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         return decode(value, majorType, additionalInfo);
     }
 
-    template <std::size_t Min, std::size_t Max, IsBinaryString T>
-    constexpr status_code decode_bounded_bstr(T &wrapped, major_type major, byte additionalInfo) {
+    template <IsBinaryString T>
+    constexpr status_code decode_bounded_bstr(T &wrapped, major_type major, byte additionalInfo, std::size_t min, std::size_t max) {
         if (major != major_type::ByteString) {
             return status_code::no_match_for_bstr_on_buffer;
         }
@@ -1009,7 +1025,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_bstr<Min, Max>(wrapped.value_);
+            return decode_indef_bstr<true>(wrapped.value_, min, max);
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsConstView<T>) {
@@ -1017,14 +1033,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 } else if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (std::ranges::range<T>) {
-                    return decode_indef_bstr<Min, Max>(wrapped);
+                    return decode_indef_bstr<true>(wrapped, min, max);
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
             }
 
             const auto size   = decode_unsigned(additionalInfo);
-            const auto status = detail::bounded_size_status<Min, Max>(size);
+            const auto status = detail::bounded_size_status(size, min, max);
             if (status != status_code::success) {
                 return status;
             }
@@ -1032,8 +1048,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::size_t Min, std::size_t Max, IsTextString T>
-    constexpr status_code decode_bounded_tstr(T &wrapped, major_type major, byte additionalInfo) {
+    template <IsTextString T>
+    constexpr status_code decode_bounded_tstr(T &wrapped, major_type major, byte additionalInfo, std::size_t min, std::size_t max) {
         static_assert(!IsView<T> || IsConstView<T>, "if T is a view, it must be const, e.g tstr_view<std::deque<char>>");
         if constexpr (IsConstView<T> && (!IsContiguous<InputBuffer> && IsContiguous<T>)) {
             return status_code::contiguous_view_on_non_contiguous_data;
@@ -1049,7 +1065,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_tstr<Min, Max>(wrapped.value_);
+            return decode_indef_tstr<true>(wrapped.value_, min, max);
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsConstView<T>) {
@@ -1057,14 +1073,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 } else if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (std::ranges::range<T>) {
-                    return decode_indef_tstr<Min, Max>(wrapped);
+                    return decode_indef_tstr<true>(wrapped, min, max);
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
             }
 
             const auto size   = decode_unsigned(additionalInfo);
-            const auto status = detail::bounded_size_status<Min, Max>(size);
+            const auto status = detail::bounded_size_status(size, min, max);
             if (status != status_code::success) {
                 return status;
             }
@@ -1072,8 +1088,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::size_t Min, std::size_t Max, IsArray T>
-    constexpr status_code decode_bounded_array(T &wrapped, major_type major, byte additionalInfo) {
+    template <IsArray T>
+    constexpr status_code decode_bounded_array(T &wrapped, major_type major, byte additionalInfo, std::size_t min, std::size_t max) {
         if (major != major_type::Array) {
             return status_code::no_match_for_array_on_buffer;
         }
@@ -1085,20 +1101,20 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_array<Min, Max>(wrapped.value_);
+            return decode_indef_array<true>(wrapped.value_, min, max);
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (IsRangeOfCborValues<T>) {
-                    return decode_indef_array<Min, Max>(wrapped);
+                    return decode_indef_array<true>(wrapped, min, max);
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
             }
 
             const auto size   = decode_unsigned(additionalInfo);
-            const auto status = detail::bounded_size_status<Min, Max>(size);
+            const auto status = detail::bounded_size_status(size, min, max);
             if (status != status_code::success) {
                 return status;
             }
@@ -1111,8 +1127,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::size_t Min, std::size_t Max, IsMap T>
-    constexpr status_code decode_bounded_map(T &wrapped, major_type major, byte additionalInfo) {
+    template <IsMap T>
+    constexpr status_code decode_bounded_map(T &wrapped, major_type major, byte additionalInfo, std::size_t min, std::size_t max) {
         if (major != major_type::Map) {
             return status_code::no_match_for_map_on_buffer;
         }
@@ -1121,18 +1137,18 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if (additionalInfo != static_cast<byte>(31)) {
                 return status_code::no_match_for_map_on_buffer;
             }
-            return decode_indef_map<Min, Max>(wrapped.value_);
+            return decode_indef_map<true>(wrapped.value_, min, max);
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsRangeOfCborValues<T>) {
-                    return decode_indef_map<Min, Max>(wrapped);
+                    return decode_indef_map<true>(wrapped, min, max);
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
             }
 
             const auto size   = decode_unsigned(additionalInfo);
-            const auto status = detail::bounded_size_status<Min, Max>(size);
+            const auto status = detail::bounded_size_status(size, min, max);
             if (status != status_code::success) {
                 return status;
             }
@@ -1203,8 +1219,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::uint64_t MinSize = 0U, std::uint64_t MaxSize = std::numeric_limits<std::uint64_t>::max(), typename T>
-    constexpr status_code decode_indef_bstr(T &out) {
+    template <bool CheckBounds = false, typename T>
+    constexpr status_code decode_indef_bstr(T &out, std::uint64_t min_size = 0U,
+                                            std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1217,10 +1234,10 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             try {
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
-                    if constexpr (MinSize == 0U) {
-                        return status_code::success;
+                    if constexpr (CheckBounds) {
+                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
-                        return size >= MinSize ? status_code::success : status_code::size_limit_exceeded;
+                        return status_code::success;
                     }
                 }
                 if (major != major_type::ByteString || additionalInfo == static_cast<byte>(31)) {
@@ -1228,8 +1245,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 }
 
                 const auto chunk_size = decode_unsigned(additionalInfo);
-                if constexpr (MaxSize != std::numeric_limits<std::uint64_t>::max()) {
-                    if (chunk_size > MaxSize || size > MaxSize - chunk_size) {
+                if constexpr (CheckBounds) {
+                    if (chunk_size > max_size || size > max_size - chunk_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1241,7 +1258,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                         appender_(out, static_cast<typename T::value_type>(b));
                     }
                 }
-                if constexpr (MinSize != 0U || MaxSize != std::numeric_limits<std::uint64_t>::max()) {
+                if constexpr (CheckBounds) {
                     size += chunk_size;
                 }
             } catch (const parse_incomplete_exception &) {
@@ -1254,8 +1271,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::uint64_t MinSize = 0U, std::uint64_t MaxSize = std::numeric_limits<std::uint64_t>::max(), typename T>
-    constexpr status_code decode_indef_tstr(T &out) {
+    template <bool CheckBounds = false, typename T>
+    constexpr status_code decode_indef_tstr(T &out, std::uint64_t min_size = 0U,
+                                            std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1268,10 +1286,10 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             try {
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
-                    if constexpr (MinSize == 0U) {
-                        return status_code::success;
+                    if constexpr (CheckBounds) {
+                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
-                        return size >= MinSize ? status_code::success : status_code::size_limit_exceeded;
+                        return status_code::success;
                     }
                 }
                 if (major != major_type::TextString || additionalInfo == static_cast<byte>(31)) {
@@ -1279,8 +1297,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 }
 
                 const auto chunk_size = decode_unsigned(additionalInfo);
-                if constexpr (MaxSize != std::numeric_limits<std::uint64_t>::max()) {
-                    if (chunk_size > MaxSize || size > MaxSize - chunk_size) {
+                if constexpr (CheckBounds) {
+                    if (chunk_size > max_size || size > max_size - chunk_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1292,7 +1310,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                         appender_(out, static_cast<typename T::value_type>(c));
                     }
                 }
-                if constexpr (MinSize != 0U || MaxSize != std::numeric_limits<std::uint64_t>::max()) {
+                if constexpr (CheckBounds) {
                     size += chunk_size;
                 }
             } catch (const parse_incomplete_exception &) {
@@ -1305,8 +1323,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::uint64_t MinSize = 0U, std::uint64_t MaxSize = std::numeric_limits<std::uint64_t>::max(), typename T>
-    constexpr status_code decode_indef_array(T &value) {
+    template <bool CheckBounds = false, typename T>
+    constexpr status_code decode_indef_array(T &value, std::uint64_t min_size = 0U,
+                                             std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1319,14 +1338,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             try {
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
-                    if constexpr (MinSize == 0U) {
-                        return status_code::success;
+                    if constexpr (CheckBounds) {
+                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
-                        return size >= MinSize ? status_code::success : status_code::size_limit_exceeded;
+                        return status_code::success;
                     }
                 }
-                if constexpr (MaxSize != std::numeric_limits<std::uint64_t>::max()) {
-                    if (size == MaxSize) {
+                if constexpr (CheckBounds) {
+                    if (size == max_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1338,7 +1357,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                     return status;
                 }
                 appender_(value, std::move(result));
-                if constexpr (MinSize != 0U || MaxSize != std::numeric_limits<std::uint64_t>::max()) {
+                if constexpr (CheckBounds) {
                     ++size;
                 }
             } catch (const parse_incomplete_exception &) {
@@ -1351,8 +1370,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <std::uint64_t MinSize = 0U, std::uint64_t MaxSize = std::numeric_limits<std::uint64_t>::max(), typename T>
-    constexpr status_code decode_indef_map(T &value) {
+    template <bool CheckBounds = false, typename T>
+    constexpr status_code decode_indef_map(T &value, std::uint64_t min_size = 0U,
+                                           std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1365,14 +1385,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             try {
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
-                    if constexpr (MinSize == 0U) {
-                        return status_code::success;
+                    if constexpr (CheckBounds) {
+                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
-                        return size >= MinSize ? status_code::success : status_code::size_limit_exceeded;
+                        return status_code::success;
                     }
                 }
-                if constexpr (MaxSize != std::numeric_limits<std::uint64_t>::max()) {
-                    if (size == MaxSize) {
+                if constexpr (CheckBounds) {
+                    if (size == max_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1397,7 +1417,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                     }
                     value_type result{std::move(key), std::move(mapped_value)};
                     appender_(value, std::move(result));
-                    if constexpr (MinSize != 0U || MaxSize != std::numeric_limits<std::uint64_t>::max()) {
+                    if constexpr (CheckBounds) {
                         ++size;
                     }
                 } else {
@@ -1414,7 +1434,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                         return status;
                     }
                     appender_(value, std::move(result));
-                    if constexpr (MinSize != 0U || MaxSize != std::numeric_limits<std::uint64_t>::max()) {
+                    if constexpr (CheckBounds) {
                         ++size;
                     }
                 }
@@ -1624,6 +1644,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     constexpr status_code decode_variant(std::variant<T...> &value, major_type major, byte additionalInfo,
                                          std::optional<std::uint64_t> &tag) {
         using namespace detail;
+        static_assert(
+            (!IsDynamicBoundedSizeWrapper<T> && ...),
+            "dynamic_bounded_size cannot be decoded as a variant alternative because variant decoding creates a new unconfigured value");
         static_assert((IsCborMajor<T> && ...),
                       "All types must be CBOR major types, most likely you have a struct or class without a \"cbor_tag\" in the variant.");
 

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -91,6 +91,13 @@ constexpr status_code skip_sized_string_payload(Reader &reader, const InputBuffe
 template <typename InputBuffer, IsOptions Options, template <typename> typename... Decoders>
     requires CborInputBuffer<InputBuffer>
 struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... {
+  private:
+    struct decode_size_bounds {
+        std::uint64_t min_size{};
+        std::uint64_t max_size{std::numeric_limits<std::uint64_t>::max()};
+    };
+
+  public:
     using self_t = decoder<InputBuffer, Options, Decoders...>;
     using Decoders<self_t>::decode...;
 
@@ -1025,7 +1032,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_bstr<true>(wrapped.value_, min, max);
+            return decode_indef_bstr<true>(wrapped.value_, {.min_size = min, .max_size = max});
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsConstView<T>) {
@@ -1033,7 +1040,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 } else if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (std::ranges::range<T>) {
-                    return decode_indef_bstr<true>(wrapped, min, max);
+                    return decode_indef_bstr<true>(wrapped, {.min_size = min, .max_size = max});
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
@@ -1065,7 +1072,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_tstr<true>(wrapped.value_, min, max);
+            return decode_indef_tstr<true>(wrapped.value_, {.min_size = min, .max_size = max});
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsConstView<T>) {
@@ -1073,7 +1080,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 } else if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (std::ranges::range<T>) {
-                    return decode_indef_tstr<true>(wrapped, min, max);
+                    return decode_indef_tstr<true>(wrapped, {.min_size = min, .max_size = max});
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
@@ -1101,13 +1108,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if constexpr (IsFixedArray<indefinite_value_t<T>>) {
                 return status_code::unexpected_group_size;
             }
-            return decode_indef_array<true>(wrapped.value_, min, max);
+            return decode_indef_array<true>(wrapped.value_, {.min_size = min, .max_size = max});
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsFixedArray<T>) {
                     return status_code::unexpected_group_size;
                 } else if constexpr (IsRangeOfCborValues<T>) {
-                    return decode_indef_array<true>(wrapped, min, max);
+                    return decode_indef_array<true>(wrapped, {.min_size = min, .max_size = max});
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
@@ -1137,11 +1144,11 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if (additionalInfo != static_cast<byte>(31)) {
                 return status_code::no_match_for_map_on_buffer;
             }
-            return decode_indef_map<true>(wrapped.value_, min, max);
+            return decode_indef_map<true>(wrapped.value_, {.min_size = min, .max_size = max});
         } else {
             if (additionalInfo == static_cast<byte>(31)) {
                 if constexpr (IsRangeOfCborValues<T>) {
-                    return decode_indef_map<true>(wrapped, min, max);
+                    return decode_indef_map<true>(wrapped, {.min_size = min, .max_size = max});
                 } else {
                     return decode(wrapped, major, additionalInfo);
                 }
@@ -1219,9 +1226,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <bool CheckBounds = false, typename T>
-    constexpr status_code decode_indef_bstr(T &out, std::uint64_t min_size = 0U,
-                                            std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
+    template <bool CheckBounds = false, typename T> constexpr status_code decode_indef_bstr(T &out, decode_size_bounds bounds = {}) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1235,7 +1240,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
                     if constexpr (CheckBounds) {
-                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
+                        return size >= bounds.min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
                         return status_code::success;
                     }
@@ -1246,7 +1251,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
                 const auto chunk_size = decode_unsigned(additionalInfo);
                 if constexpr (CheckBounds) {
-                    if (chunk_size > max_size || size > max_size - chunk_size) {
+                    if (chunk_size > bounds.max_size || size > bounds.max_size - chunk_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1271,9 +1276,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <bool CheckBounds = false, typename T>
-    constexpr status_code decode_indef_tstr(T &out, std::uint64_t min_size = 0U,
-                                            std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
+    template <bool CheckBounds = false, typename T> constexpr status_code decode_indef_tstr(T &out, decode_size_bounds bounds = {}) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1287,7 +1290,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
                     if constexpr (CheckBounds) {
-                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
+                        return size >= bounds.min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
                         return status_code::success;
                     }
@@ -1298,7 +1301,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
                 const auto chunk_size = decode_unsigned(additionalInfo);
                 if constexpr (CheckBounds) {
-                    if (chunk_size > max_size || size > max_size - chunk_size) {
+                    if (chunk_size > bounds.max_size || size > bounds.max_size - chunk_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1323,9 +1326,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <bool CheckBounds = false, typename T>
-    constexpr status_code decode_indef_array(T &value, std::uint64_t min_size = 0U,
-                                             std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
+    template <bool CheckBounds = false, typename T> constexpr status_code decode_indef_array(T &value, decode_size_bounds bounds = {}) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1339,13 +1340,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
                     if constexpr (CheckBounds) {
-                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
+                        return size >= bounds.min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
                         return status_code::success;
                     }
                 }
                 if constexpr (CheckBounds) {
-                    if (size == max_size) {
+                    if (size == bounds.max_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }
@@ -1370,9 +1371,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    template <bool CheckBounds = false, typename T>
-    constexpr status_code decode_indef_map(T &value, std::uint64_t min_size = 0U,
-                                           std::uint64_t max_size = std::numeric_limits<std::uint64_t>::max()) {
+    template <bool CheckBounds = false, typename T> constexpr status_code decode_indef_map(T &value, decode_size_bounds bounds = {}) {
         detail::appender<T>            appender_;
         [[maybe_unused]] std::uint64_t size{};
         while (true) {
@@ -1386,13 +1385,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 auto [major, additionalInfo] = read_initial_byte();
                 if (major == major_type::Simple && additionalInfo == static_cast<byte>(31)) {
                     if constexpr (CheckBounds) {
-                        return size >= min_size ? status_code::success : status_code::size_limit_exceeded;
+                        return size >= bounds.min_size ? status_code::success : status_code::size_limit_exceeded;
                     } else {
                         return status_code::success;
                     }
                 }
                 if constexpr (CheckBounds) {
-                    if (size == max_size) {
+                    if (size == bounds.max_size) {
                         return status_code::size_limit_exceeded;
                     }
                 }

--- a/include/cbor_tags/cbor_detail.h
+++ b/include/cbor_tags/cbor_detail.h
@@ -60,7 +60,11 @@ template <typename Value, typename Container> constexpr bool can_propagate_conta
 }
 
 template <typename Value, typename Container> constexpr Value make_decode_value_for(Container &container) {
-    if constexpr (uses_container_allocator_for<Value, Container>()) {
+    if constexpr (IsDynamicBoundedSizeWrapper<Value>) {
+        static_assert(
+            always_false<Value>::value,
+            "dynamic_bounded_size requires a preconfigured decode destination; generic container decoding cannot create its bounds");
+    } else if constexpr (uses_container_allocator_for<Value, Container>()) {
         return std::make_from_tuple<Value>(std::uses_allocator_construction_args<Value>(container.get_allocator()));
     } else if constexpr (uses_optional_value_container_allocator_for<Value, Container>()) {
         using value_type = std::remove_cvref_t<Value>;
@@ -72,7 +76,11 @@ template <typename Value, typename Container> constexpr Value make_decode_value_
 }
 
 template <typename Value, typename Optional> constexpr Value make_decode_value_for_optional(Optional &optional) {
-    if constexpr (requires(Value &value) { value.get_allocator(); }) {
+    if constexpr (IsDynamicBoundedSizeWrapper<Value>) {
+        static_assert(
+            always_false<Value>::value,
+            "dynamic_bounded_size requires a preconfigured decode destination; generic optional decoding cannot create its bounds");
+    } else if constexpr (requires(Value &value) { value.get_allocator(); }) {
         if (optional) {
             return std::make_from_tuple<Value>(std::uses_allocator_construction_args<Value>(optional->get_allocator()));
         }

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -96,6 +96,18 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
         encode_bounded_size(value);
     }
 
+    template <IsString T> constexpr void encode(const dynamic_bounded_size<T> &value) {
+        encode_bounded_size(value.value(), value.min_size(), value.max_size());
+    }
+
+    template <IsArray T> constexpr void encode(const dynamic_bounded_size<T> &value) {
+        encode_bounded_size(value.value(), value.min_size(), value.max_size());
+    }
+
+    template <IsMap T> constexpr void encode(const dynamic_bounded_size<T> &value) {
+        encode_bounded_size(value.value(), value.min_size(), value.max_size());
+    }
+
     template <IsString T> constexpr void encode(const T &value) {
         encode_major_and_size(value.size(), static_cast<byte_type>(get_major_3_bit_tag<T>()));
         if constexpr (IsBinaryString<T> && std::ranges::borrowed_range<std::remove_cvref_t<T>> &&
@@ -238,7 +250,10 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
 
   private:
     template <std::size_t Min, std::size_t Max, typename T> constexpr void encode_bounded_size(const bounded_size<T, Min, Max> &value) {
-        const auto &wrapped     = value.value();
+        encode_bounded_size(value.value(), Min, Max);
+    }
+
+    template <typename T> constexpr void encode_bounded_size(const T &wrapped, std::size_t min, std::size_t max) {
         const auto &sized_value = [&]() -> decltype(auto) {
             if constexpr (IsIndefiniteWrapper<std::remove_cvref_t<T>>) {
                 return (wrapped.value_);
@@ -253,7 +268,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
         if (std::cmp_greater(range_size, std::numeric_limits<std::uint64_t>::max())) {
             throw detail::encode_status_exception{status_code::size_limit_exceeded};
         }
-        if (detail::bounded_size_status<Min, Max>(static_cast<std::uint64_t>(range_size)) != status_code::success) {
+        if (detail::bounded_size_status(static_cast<std::uint64_t>(range_size), min, max) != status_code::success) {
             throw detail::encode_status_exception{status_code::size_limit_exceeded};
         }
         encode(wrapped);

--- a/include/cbor_tags/cbor_range_encoder.h
+++ b/include/cbor_tags/cbor_range_encoder.h
@@ -119,12 +119,12 @@ template <typename T> struct cbor_range_encoder : detail::cbor_raw_view_encoder<
         }
     }
 
-    template <std::size_t Min, std::size_t Max, std::ranges::sized_range R> constexpr void require_bounded_range_size(R &&range) {
+    template <std::ranges::sized_range R> constexpr void require_bounded_range_size(R &&range, std::size_t min, std::size_t max) {
         const auto size = std::ranges::size(range);
         if (std::cmp_greater(size, std::numeric_limits<std::uint64_t>::max())) {
             throw detail::encode_status_exception{status_code::size_limit_exceeded};
         }
-        if (detail::bounded_size_status<Min, Max>(static_cast<std::uint64_t>(size)) != status_code::success) {
+        if (detail::bounded_size_status(static_cast<std::uint64_t>(size), min, max) != status_code::success) {
             throw detail::encode_status_exception{status_code::size_limit_exceeded};
         }
     }
@@ -198,23 +198,35 @@ template <typename T> struct cbor_range_encoder : detail::cbor_raw_view_encoder<
 
     template <detail::SizedExplicitRangeWrapper RangeWrapper, std::size_t Min, std::size_t Max>
     constexpr void encode(bounded_size<RangeWrapper, Min, Max> &value) {
-        encode_bounded_explicit_range<Min, Max>(value);
+        encode_bounded_explicit_range(value, Min, Max);
     }
 
     template <detail::ConstSizedExplicitRangeWrapper RangeWrapper, std::size_t Min, std::size_t Max>
     constexpr void encode(const bounded_size<RangeWrapper, Min, Max> &value) {
-        encode_bounded_explicit_range<Min, Max>(value);
+        encode_bounded_explicit_range(value, Min, Max);
     }
 
     template <detail::SizedExplicitRangeWrapper RangeWrapper, std::size_t Min, std::size_t Max>
     constexpr void encode(bounded_size<RangeWrapper, Min, Max> &&value) {
-        encode_bounded_explicit_range<Min, Max>(value);
+        encode_bounded_explicit_range(value, Min, Max);
+    }
+
+    template <detail::SizedExplicitRangeWrapper RangeWrapper> constexpr void encode(dynamic_bounded_size<RangeWrapper> &value) {
+        encode_bounded_explicit_range(value, value.min_size(), value.max_size());
+    }
+
+    template <detail::ConstSizedExplicitRangeWrapper RangeWrapper> constexpr void encode(const dynamic_bounded_size<RangeWrapper> &value) {
+        encode_bounded_explicit_range(value, value.min_size(), value.max_size());
+    }
+
+    template <detail::SizedExplicitRangeWrapper RangeWrapper> constexpr void encode(dynamic_bounded_size<RangeWrapper> &&value) {
+        encode_bounded_explicit_range(value, value.min_size(), value.max_size());
     }
 
   private:
-    template <std::size_t Min, std::size_t Max, typename B> constexpr void encode_bounded_explicit_range(B &value) {
+    template <typename B> constexpr void encode_bounded_explicit_range(B &value, std::size_t min, std::size_t max) {
         auto &&wrapped = value.value();
-        require_bounded_range_size<Min, Max>(wrapped.range_);
+        require_bounded_range_size(wrapped.range_, min, max);
         encode(wrapped);
     }
 };

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -430,7 +430,7 @@ template <typename T, typename Seen> consteval bool cddl_contains_nullable_point
             using traits = cddl_multi_dimensional_array_traits<value_type>;
             return cddl_contains_nullable_pointer<typename traits::dimensions_type, next_seen>() ||
                    cddl_contains_nullable_pointer<typename traits::array_type, next_seen>();
-        } else if constexpr (IsBoundedSizeWrapper<value_type> || IsArrayRangeWrapper<value_type> || IsOptional<value_type> ||
+        } else if constexpr (IsAnyBoundedSizeWrapper<value_type> || IsArrayRangeWrapper<value_type> || IsOptional<value_type> ||
                              (IsArray<value_type> && !IsIndefiniteWrapper<value_type>)) {
             return cddl_contains_nullable_pointer<typename value_type::value_type, next_seen>();
         } else if constexpr (IsVariant<value_type>) {
@@ -1313,6 +1313,10 @@ template <typename T, cddl_shared_pointer_mode PointerMode> std::string cddl_typ
     using value_type = std::remove_cvref_t<T>;
     if constexpr (CDDLScopedType<value_type>) {
         static_assert(always_false<value_type>::value, "CDDL scope wrappers are only valid as cddl_schema_to roots");
+        return {};
+    } else if constexpr (IsDynamicBoundedSizeWrapper<value_type>) {
+        static_assert(always_false<value_type>::value,
+                      "dynamic_bounded_size cannot be represented by type-based CDDL; use bounded_size<T, Min, Max>");
         return {};
     } else if constexpr (IsBoundedSizeWrapper<value_type>) {
         return cddl_bounded_size_expr<value_type, PointerMode>(context, options);

--- a/include/cbor_tags/extensions/rfc8746_typed_arrays.h
+++ b/include/cbor_tags/extensions/rfc8746_typed_arrays.h
@@ -715,16 +715,25 @@ template <typename T, typed_array_byte_order ByteOrder> [[nodiscard]] constexpr 
     return static_cast<std::uint64_t>(sizeof(bit_type));
 }
 
-template <std::size_t Min, std::size_t Max, typename T, typed_array_byte_order ByteOrder>
-[[nodiscard]] constexpr status_code bounded_typed_array_payload_size_status(std::uint64_t payload_size) {
+template <typename T, typed_array_byte_order ByteOrder>
+[[nodiscard]] constexpr status_code bounded_typed_array_payload_size_status(std::uint64_t payload_size, std::size_t min, std::size_t max) {
     constexpr auto element_size = typed_array_element_byte_size<T, ByteOrder>();
-    static_assert(Min <= (std::numeric_limits<std::uint64_t>::max() / element_size),
-                  "bounded_size typed-array minimum byte size overflows uint64_t");
-    static_assert(Max <= (std::numeric_limits<std::uint64_t>::max() / element_size),
-                  "bounded_size typed-array maximum byte size overflows uint64_t");
-    constexpr auto min_bytes = static_cast<std::uint64_t>(Min) * element_size;
-    constexpr auto max_bytes = static_cast<std::uint64_t>(Max) * element_size;
-    return payload_size >= min_bytes && payload_size <= max_bytes ? status_code::success : status_code::size_limit_exceeded;
+    constexpr auto max_elements = std::numeric_limits<std::uint64_t>::max() / element_size;
+    if (std::cmp_greater(min, max_elements)) {
+        return status_code::size_limit_exceeded;
+    }
+
+    const auto min_bytes = static_cast<std::uint64_t>(min) * element_size;
+    if (payload_size < min_bytes) {
+        return status_code::size_limit_exceeded;
+    }
+    if (!std::cmp_greater(max, max_elements)) {
+        const auto max_bytes = static_cast<std::uint64_t>(max) * element_size;
+        if (payload_size > max_bytes) {
+            return status_code::size_limit_exceeded;
+        }
+    }
+    return status_code::success;
 }
 
 template <typename Dimensions, typename Array>
@@ -823,7 +832,14 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     template <typename Array, std::size_t Min, std::size_t Max>
         requires TypedArrayEncodeTarget<Array>
     void encode(const bounded_size<Array, Min, Max> &bounded) {
-        require_bounded_typed_array_element_count<Min, Max>(bounded.value());
+        require_bounded_typed_array_element_count(bounded.value(), Min, Max);
+        encode(bounded.value());
+    }
+
+    template <typename Array>
+        requires TypedArrayEncodeTarget<Array>
+    void encode(const dynamic_bounded_size<Array> &bounded) {
+        require_bounded_typed_array_element_count(bounded.value(), bounded.min_size(), bounded.max_size());
         encode(bounded.value());
     }
 
@@ -907,7 +923,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
 
         return detail::decode_payload<value_type, array_type::byte_order>(
             dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
-                return decode_bounded_owned_typed_array_payload<Min, Max>(bounded.value(), payload_major, payload_info);
+                return decode_bounded_owned_typed_array_payload(bounded.value(), payload_major, payload_info, Min, Max);
             });
     }
 
@@ -919,7 +935,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
 
         return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
             dec, tag, [&](major_type payload_major, std::byte payload_info) {
-                return decode_bounded_owned_typed_array_payload<Min, Max>(bounded.value(), payload_major, payload_info);
+                return decode_bounded_owned_typed_array_payload(bounded.value(), payload_major, payload_info, Min, Max);
             });
     }
 
@@ -932,7 +948,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
 
         return detail::decode_payload<value_type, array_type::byte_order>(
             dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
-                return decode_bounded_typed_array_view_payload<Min, Max>(bounded.value(), payload_major, payload_info);
+                return decode_bounded_typed_array_view_payload(bounded.value(), payload_major, payload_info, Min, Max);
             });
     }
 
@@ -945,7 +961,60 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
 
         return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
             dec, tag, [&](major_type payload_major, std::byte payload_info) {
-                return decode_bounded_typed_array_view_payload<Min, Max>(bounded.value(), payload_major, payload_info);
+                return decode_bounded_typed_array_view_payload(bounded.value(), payload_major, payload_info, Min, Max);
+            });
+    }
+
+    template <OwnedTypedArrayTarget Array>
+    [[nodiscard]] status_code decode(dynamic_bounded_size<Array> &bounded, major_type major, std::byte additional_info) {
+        using array_type = std::remove_cvref_t<Array>;
+        using value_type = typename array_type::value_type;
+        auto &dec        = static_cast<Self &>(*this);
+
+        return detail::decode_payload<value_type, array_type::byte_order>(
+            dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
+                return decode_bounded_owned_typed_array_payload(bounded.value(), payload_major, payload_info, bounded.min_size(),
+                                                                bounded.max_size());
+            });
+    }
+
+    template <OwnedTypedArrayTarget Array> [[nodiscard]] status_code decode(dynamic_bounded_size<Array> &bounded, std::uint64_t tag) {
+        using array_type = std::remove_cvref_t<Array>;
+        using value_type = typename array_type::value_type;
+        auto &dec        = static_cast<Self &>(*this);
+
+        return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
+            dec, tag, [&](major_type payload_major, std::byte payload_info) {
+                return decode_bounded_owned_typed_array_payload(bounded.value(), payload_major, payload_info, bounded.min_size(),
+                                                                bounded.max_size());
+            });
+    }
+
+    template <typename Array>
+        requires DecodableTypedArrayViewTargetFor<Self, Array>
+    [[nodiscard]] status_code decode(dynamic_bounded_size<Array> &bounded, major_type major, std::byte additional_info) {
+        using array_type = std::remove_cvref_t<Array>;
+        using value_type = typename array_type::value_type;
+        auto &dec        = static_cast<Self &>(*this);
+
+        return detail::decode_payload<value_type, array_type::byte_order>(
+            dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
+                return decode_bounded_typed_array_view_payload(bounded.value(), payload_major, payload_info, bounded.min_size(),
+                                                               bounded.max_size());
+            });
+    }
+
+    template <typename Array>
+        requires DecodableTypedArrayViewTargetFor<Self, Array>
+    [[nodiscard]] status_code decode(dynamic_bounded_size<Array> &bounded, std::uint64_t tag) {
+        using array_type = std::remove_cvref_t<Array>;
+        using value_type = typename array_type::value_type;
+        auto &dec        = static_cast<Self &>(*this);
+
+        return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
+            dec, tag, [&](major_type payload_major, std::byte payload_info) {
+                return decode_bounded_typed_array_view_payload(bounded.value(), payload_major, payload_info, bounded.min_size(),
+                                                               bounded.max_size());
             });
     }
 
@@ -1012,9 +1081,9 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         return static_cast<std::uint64_t>(array.values().size());
     }
 
-    template <std::size_t Min, std::size_t Max, typename Array> static void require_bounded_typed_array_element_count(const Array &array) {
+    template <typename Array> static void require_bounded_typed_array_element_count(const Array &array, std::size_t min, std::size_t max) {
         const auto size = typed_array_element_count(array);
-        if (cbor::tags::detail::bounded_size_status<Min, Max>(size) != status_code::success) {
+        if (cbor::tags::detail::bounded_size_status(size, min, max) != status_code::success) {
             throw cbor::tags::detail::encode_status_exception{status_code::size_limit_exceeded};
         }
     }
@@ -1048,8 +1117,9 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         return status_code::success;
     }
 
-    template <std::size_t Min, std::size_t Max, typename Value, typed_array_byte_order ByteOrder, typename Consume>
-    [[nodiscard]] status_code decode_bounded_typed_array_bytes(major_type payload_major, std::byte payload_info, Consume &&consume) {
+    template <typename Value, typed_array_byte_order ByteOrder, typename Consume>
+    [[nodiscard]] status_code decode_bounded_typed_array_bytes(major_type payload_major, std::byte payload_info, std::size_t min,
+                                                               std::size_t max, Consume &&consume) {
         if (payload_major != major_type::ByteString || payload_info == std::byte{31}) {
             return status_code::no_match_for_bstr_on_buffer;
         }
@@ -1060,7 +1130,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         if (status != status_code::success) {
             return status;
         }
-        status = detail::bounded_typed_array_payload_size_status<Min, Max, Value, ByteOrder>(payload_size_u64);
+        status = detail::bounded_typed_array_payload_size_status<Value, ByteOrder>(payload_size_u64, min, max);
         if (status != status_code::success) {
             return status;
         }
@@ -1080,21 +1150,23 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         return status_code::success;
     }
 
-    template <std::size_t Min, std::size_t Max, OwnedTypedArrayTarget Array>
-    [[nodiscard]] status_code decode_bounded_owned_typed_array_payload(Array &array, major_type payload_major, std::byte payload_info) {
+    template <OwnedTypedArrayTarget Array>
+    [[nodiscard]] status_code decode_bounded_owned_typed_array_payload(Array &array, major_type payload_major, std::byte payload_info,
+                                                                       std::size_t min, std::size_t max) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
 
-        return decode_bounded_typed_array_bytes<Min, Max, value_type, array_type::byte_order>(
-            payload_major, payload_info, [&](auto &&raw_payload, std::size_t payload_size) {
+        return decode_bounded_typed_array_bytes<value_type, array_type::byte_order>(
+            payload_major, payload_info, min, max, [&](auto &&raw_payload, std::size_t payload_size) {
                 array.values() = detail::materialize_values<value_type, array_type::byte_order>(
                     std::forward<decltype(raw_payload)>(raw_payload), payload_size);
             });
     }
 
-    template <std::size_t Min, std::size_t Max, typename Array>
+    template <typename Array>
         requires DecodableTypedArrayViewTargetFor<Self, Array>
-    [[nodiscard]] status_code decode_bounded_typed_array_view_payload(Array &view, major_type payload_major, std::byte payload_info) {
+    [[nodiscard]] status_code decode_bounded_typed_array_view_payload(Array &view, major_type payload_major, std::byte payload_info,
+                                                                      std::size_t min, std::size_t max) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
         using byte_range = typename array_type::payload_range_type;
@@ -1102,8 +1174,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         if constexpr (std::ranges::contiguous_range<const byte_range> && !IsContiguous<typename Self::input_buffer_type>) {
             return status_code::contiguous_view_on_non_contiguous_data;
         } else {
-            return decode_bounded_typed_array_bytes<Min, Max, value_type, array_type::byte_order>(
-                payload_major, payload_info, [&](auto &&raw_payload, std::size_t payload_size) {
+            return decode_bounded_typed_array_bytes<value_type, array_type::byte_order>(
+                payload_major, payload_info, min, max, [&](auto &&raw_payload, std::size_t payload_size) {
                     view = array_type{byte_range{std::forward<decltype(raw_payload)>(raw_payload)}, payload_size};
                 });
         }

--- a/include/cbor_tags/extensions/rfc8746_typed_arrays.h
+++ b/include/cbor_tags/extensions/rfc8746_typed_arrays.h
@@ -736,6 +736,15 @@ template <typename T, typed_array_byte_order ByteOrder>
     return status_code::success;
 }
 
+template <std::size_t Min, std::size_t Max, typename T, typed_array_byte_order ByteOrder>
+consteval void validate_static_typed_array_bounds() {
+    constexpr auto element_size = typed_array_element_byte_size<T, ByteOrder>();
+    static_assert(Min <= (std::numeric_limits<std::uint64_t>::max() / element_size),
+                  "bounded_size typed-array minimum byte size overflows uint64_t");
+    static_assert(Max <= (std::numeric_limits<std::uint64_t>::max() / element_size),
+                  "bounded_size typed-array maximum byte size overflows uint64_t");
+}
+
 template <typename Dimensions, typename Array>
 [[nodiscard]] bool valid_multi_dimensional_shape(const Dimensions &dimensions, const Array &array) {
     std::size_t expected_count{};
@@ -832,6 +841,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     template <typename Array, std::size_t Min, std::size_t Max>
         requires TypedArrayEncodeTarget<Array>
     void encode(const bounded_size<Array, Min, Max> &bounded) {
+        using array_type = std::remove_cvref_t<Array>;
+        detail::validate_static_typed_array_bounds<Min, Max, typename array_type::value_type, array_type::byte_order>();
         require_bounded_typed_array_element_count(bounded.value(), Min, Max);
         encode(bounded.value());
     }
@@ -919,7 +930,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     [[nodiscard]] status_code decode(bounded_size<Array, Min, Max> &bounded, major_type major, std::byte additional_info) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
-        auto &dec        = static_cast<Self &>(*this);
+        detail::validate_static_typed_array_bounds<Min, Max, value_type, array_type::byte_order>();
+        auto &dec = static_cast<Self &>(*this);
 
         return detail::decode_payload<value_type, array_type::byte_order>(
             dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
@@ -931,7 +943,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     [[nodiscard]] status_code decode(bounded_size<Array, Min, Max> &bounded, std::uint64_t tag) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
-        auto &dec        = static_cast<Self &>(*this);
+        detail::validate_static_typed_array_bounds<Min, Max, value_type, array_type::byte_order>();
+        auto &dec = static_cast<Self &>(*this);
 
         return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
             dec, tag, [&](major_type payload_major, std::byte payload_info) {
@@ -944,7 +957,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     [[nodiscard]] status_code decode(bounded_size<Array, Min, Max> &bounded, major_type major, std::byte additional_info) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
-        auto &dec        = static_cast<Self &>(*this);
+        detail::validate_static_typed_array_bounds<Min, Max, value_type, array_type::byte_order>();
+        auto &dec = static_cast<Self &>(*this);
 
         return detail::decode_payload<value_type, array_type::byte_order>(
             dec, major, additional_info, [&](major_type payload_major, std::byte payload_info) {
@@ -957,7 +971,8 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
     [[nodiscard]] status_code decode(bounded_size<Array, Min, Max> &bounded, std::uint64_t tag) {
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
-        auto &dec        = static_cast<Self &>(*this);
+        detail::validate_static_typed_array_bounds<Min, Max, value_type, array_type::byte_order>();
+        auto &dec = static_cast<Self &>(*this);
 
         return detail::decode_payload_after_tag<value_type, array_type::byte_order>(
             dec, tag, [&](major_type payload_major, std::byte payload_info) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,13 @@ add_dynamic_bounded_size_compile_fail_test(
   dynamic_bounded_size_nested_compile_fail.cc
   "bounded size wrappers cannot directly contain another bounded size wrapper")
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_dynamic_bounded_size_compile_fail_test(
+    typed_array_static_bounds_compile_fails
+    typed_array_static_bounds_compile_fail.cc
+    "bounded_size typed-array maximum byte size overflows uint64_t")
+endif()
+
 add_executable(cddl_variant_nullable_pointer_compile_fails EXCLUDE_FROM_ALL cddl_variant_nullable_pointer_compile_fail.cc)
 target_link_libraries(cddl_variant_nullable_pointer_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
 add_test(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,21 @@ function(add_incompatible_codec_result_compile_fail_test TEST_NAME COMPILE_DEFIN
       "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 endfunction()
 
+function(add_dynamic_bounded_size_compile_fail_test TEST_NAME SOURCE_FILE PASS_REGEX)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+  target_link_libraries(${TEST_NAME} PRIVATE cbor::tags fmt::fmt nameof::nameof)
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND
+      ${CMAKE_COMMAND}
+      "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+      "-DTEST_TARGET=${TEST_NAME}"
+      "-DCONFIG=$<CONFIG>"
+      "-DPASS_REGEX=${PASS_REGEX}"
+      -P
+      "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+endfunction()
+
 add_incompatible_codec_result_compile_fail_test(
   incompatible_member_encode_result_compile_fails
   CBOR_TAGS_INCOMPATIBLE_MEMBER_ENCODE
@@ -81,6 +96,27 @@ add_incompatible_codec_result_compile_fail_test(
   incompatible_free_decode_result_compile_fails
   CBOR_TAGS_INCOMPATIBLE_FREE_DECODE
   "custom decode/transcode must return a result")
+
+add_dynamic_bounded_size_compile_fail_test(
+  dynamic_bounded_size_cddl_compile_fails
+  dynamic_bounded_size_cddl_compile_fail.cc
+  "dynamic_bounded_size cannot be represented by type-based CDDL")
+add_dynamic_bounded_size_compile_fail_test(
+  dynamic_bounded_size_variant_decode_compile_fails
+  dynamic_bounded_size_variant_decode_compile_fail.cc
+  "dynamic_bounded_size cannot be decoded as a variant alternative")
+add_dynamic_bounded_size_compile_fail_test(
+  dynamic_bounded_size_optional_decode_compile_fails
+  dynamic_bounded_size_optional_decode_compile_fail.cc
+  "generic optional decoding cannot create its bounds")
+add_dynamic_bounded_size_compile_fail_test(
+  dynamic_bounded_size_container_decode_compile_fails
+  dynamic_bounded_size_container_decode_compile_fail.cc
+  "generic container decoding cannot create its bounds")
+add_dynamic_bounded_size_compile_fail_test(
+  dynamic_bounded_size_nested_compile_fails
+  dynamic_bounded_size_nested_compile_fail.cc
+  "bounded size wrappers cannot directly contain another bounded size wrapper")
 
 add_executable(cddl_variant_nullable_pointer_compile_fails EXCLUDE_FROM_ALL cddl_variant_nullable_pointer_compile_fail.cc)
 target_link_libraries(cddl_variant_nullable_pointer_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)

--- a/test/dynamic_bounded_size_cddl_compile_fail.cc
+++ b/test/dynamic_bounded_size_cddl_compile_fail.cc
@@ -1,0 +1,10 @@
+#include "cbor_tags/extensions/cbor_visualization.h"
+
+#include <fmt/format.h>
+#include <vector>
+
+int main() {
+    fmt::memory_buffer output;
+    cbor::tags::cddl_schema_to<cbor::tags::dynamic_bounded_size<std::vector<int>>>(output);
+    return 0;
+}

--- a/test/dynamic_bounded_size_container_decode_compile_fail.cc
+++ b/test/dynamic_bounded_size_container_decode_compile_fail.cc
@@ -1,0 +1,12 @@
+#include "cbor_tags/cbor_decoder.h"
+
+#include <cstddef>
+#include <vector>
+
+int main() {
+    using bounded_value = cbor::tags::dynamic_bounded_size<std::vector<int>>;
+
+    std::vector<std::byte>     input;
+    std::vector<bounded_value> output;
+    return cbor::tags::make_decoder(input)(output).has_value() ? 0 : 1;
+}

--- a/test/dynamic_bounded_size_nested_compile_fail.cc
+++ b/test/dynamic_bounded_size_nested_compile_fail.cc
@@ -1,0 +1,9 @@
+#include "cbor_tags/cbor.h"
+
+#include <vector>
+
+int main() {
+    using inner = cbor::tags::dynamic_bounded_size<std::vector<int>>;
+    cbor::tags::dynamic_bounded_size<inner> value{inner{std::vector<int>{}, 0, 4}, 0, 4};
+    return value.value().value().empty() ? 0 : 1;
+}

--- a/test/dynamic_bounded_size_optional_decode_compile_fail.cc
+++ b/test/dynamic_bounded_size_optional_decode_compile_fail.cc
@@ -1,0 +1,13 @@
+#include "cbor_tags/cbor_decoder.h"
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+int main() {
+    using bounded_value = cbor::tags::dynamic_bounded_size<std::vector<int>>;
+
+    std::vector<std::byte>       input;
+    std::optional<bounded_value> output{std::in_place, std::vector<int>{}, 0, 4};
+    return cbor::tags::make_decoder(input)(output).has_value() ? 0 : 1;
+}

--- a/test/dynamic_bounded_size_variant_decode_compile_fail.cc
+++ b/test/dynamic_bounded_size_variant_decode_compile_fail.cc
@@ -1,0 +1,14 @@
+#include "cbor_tags/cbor_decoder.h"
+
+#include <cstddef>
+#include <string>
+#include <variant>
+#include <vector>
+
+int main() {
+    using bounded_value = cbor::tags::dynamic_bounded_size<std::vector<int>>;
+
+    std::vector<std::byte>                   input;
+    std::variant<bounded_value, std::string> output{std::in_place_index<0>, std::vector<int>{}, 0, 4};
+    return cbor::tags::make_decoder(input)(output).has_value() ? 0 : 1;
+}

--- a/test/interop/glaze_cbor_roundtrip.cc
+++ b/test/interop/glaze_cbor_roundtrip.cc
@@ -246,7 +246,7 @@ TEST_CASE("Glaze collapses duplicate map keys when decoded into std::map") {
     auto result  = glz::read_cbor(decoded, std::string{"\xa2\x61"
                                                        "x\x01\x61"
                                                        "x\x02",
-                                                      7});
+                                                       7});
 
     REQUIRE(!result);
     REQUIRE_EQ(decoded.size(), 1U);

--- a/test/test_bounded_size.cpp
+++ b/test/test_bounded_size.cpp
@@ -14,8 +14,10 @@
 #include <memory_resource>
 #include <optional>
 #include <ranges>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -62,10 +64,18 @@ static_assert(CanEncodeBounded<bounded_size<sized_array_range, 0, 3>>);
 static_assert(CanEncodeBounded<bounded_size<sized_map_range, 0, 3>>);
 static_assert(CanEncodeBounded<bounded_size<sized_bstr_range, 0, 3>>);
 static_assert(CanEncodeBounded<bounded_size<sized_tstr_range, 0, 3>>);
+static_assert(CanEncodeBounded<dynamic_bounded_size<sized_array_range>>);
+static_assert(CanEncodeBounded<dynamic_bounded_size<sized_map_range>>);
+static_assert(CanEncodeBounded<dynamic_bounded_size<sized_bstr_range>>);
+static_assert(CanEncodeBounded<dynamic_bounded_size<sized_tstr_range>>);
 static_assert(!CanEncodeBounded<bounded_size<array_range<filtered_ints>, 0, 3>>);
 static_assert(!CanEncodeBounded<bounded_size<map_range<filtered_pairs>, 0, 3>>);
 static_assert(!CanEncodeBounded<bounded_size<bstr_range<filtered_bytes>, 0, 3>>);
 static_assert(!CanEncodeBounded<bounded_size<tstr_range<filtered_chars>, 0, 3>>);
+static_assert(!CanEncodeBounded<dynamic_bounded_size<array_range<filtered_ints>>>);
+static_assert(!CanEncodeBounded<dynamic_bounded_size<map_range<filtered_pairs>>>);
+static_assert(!CanEncodeBounded<dynamic_bounded_size<bstr_range<filtered_bytes>>>);
+static_assert(!CanEncodeBounded<dynamic_bounded_size<tstr_range<filtered_chars>>>);
 
 struct bounded_document {
     bounded_size<std::string, 1, 16>                         name;
@@ -145,6 +155,13 @@ sensor_report_value semantic_value(const bounded_sensor_report &report) {
     return {report.state, std::move(batches), std::move(result), report.history.value()};
 }
 
+struct dynamic_bounded_document {
+    dynamic_bounded_size<std::string>                          name;
+    dynamic_bounded_size<std::vector<std::byte>>               payload;
+    dynamic_bounded_size<std::vector<int>>                     values;
+    dynamic_bounded_size<std::map<std::string, std::uint64_t>> counters;
+};
+
 struct bounded_extension_value {
     std::vector<int> values;
 };
@@ -168,6 +185,19 @@ template <typename Self> struct bounded_extension_codec : cbor_codec_mixin_base<
         auto values = as_bounded_size<Min, Max>(bounded.value().values);
         return static_cast<Self &>(*this).decode(values, major, additional_info);
     }
+
+    template <typename Value>
+        requires std::same_as<std::remove_cvref_t<Value>, bounded_extension_value>
+    void encode(const dynamic_bounded_size<Value> &bounded) {
+        static_cast<Self &>(*this).encode(as_bounded_size(bounded.value().values, bounded.min_size(), bounded.max_size()));
+    }
+
+    template <typename Value>
+        requires std::same_as<std::remove_cvref_t<Value>, bounded_extension_value>
+    status_code decode(dynamic_bounded_size<Value> &bounded, major_type major, std::byte additional_info) {
+        auto values = as_bounded_size(bounded.value().values, bounded.min_size(), bounded.max_size());
+        return static_cast<Self &>(*this).decode(values, major, additional_info);
+    }
 };
 
 struct counting_memory_resource : std::pmr::memory_resource {
@@ -186,6 +216,243 @@ struct counting_memory_resource : std::pmr::memory_resource {
 };
 
 } // namespace
+
+TEST_CASE("dynamic_bounded_size owns or references and rewrapping replaces bounds") {
+    static_assert(!std::default_initializable<dynamic_bounded_size<std::vector<int>>>);
+
+    std::vector<int> values{1, 2, 3};
+    auto             referenced = as_bounded_size(values, 0, 3);
+    static_assert(std::same_as<decltype(referenced), dynamic_bounded_size<std::vector<int> &>>);
+    CHECK_EQ(&referenced.value_, &values);
+    CHECK_EQ(referenced.min_size(), 0U);
+    CHECK_EQ(referenced.max_size(), 3U);
+
+    auto rebound = as_bounded_size(referenced, 1, 4);
+    static_assert(std::same_as<decltype(rebound), dynamic_bounded_size<std::vector<int> &>>);
+    CHECK_EQ(&rebound.value_, &values);
+    CHECK_EQ(rebound.min_size(), 1U);
+    CHECK_EQ(rebound.max_size(), 4U);
+
+    auto static_rebound = as_bounded_size<2, 5>(rebound);
+    static_assert(std::same_as<decltype(static_rebound), bounded_size<std::vector<int> &, 2, 5>>);
+    CHECK_EQ(&static_rebound.value_, &values);
+
+    auto dynamic_again = as_bounded_size(static_rebound, 0, 6);
+    static_assert(std::same_as<decltype(dynamic_again), dynamic_bounded_size<std::vector<int> &>>);
+    CHECK_EQ(&dynamic_again.value_, &values);
+
+    auto owning = as_bounded_size(std::vector<int>{4, 5}, 0, 2);
+    static_assert(std::same_as<decltype(owning), dynamic_bounded_size<std::vector<int>>>);
+    auto moved = as_bounded_size(std::move(owning), 1, 3);
+    static_assert(std::same_as<decltype(moved), dynamic_bounded_size<std::vector<int>>>);
+    CHECK_EQ(moved.value_, (std::vector<int>{4, 5}));
+    CHECK_EQ(moved.min_size(), 1U);
+    CHECK_EQ(moved.max_size(), 3U);
+
+    CHECK_THROWS_AS((void)as_bounded_size(values, 4, 3), std::invalid_argument);
+}
+
+TEST_CASE("dynamic_bounded_size roundtrips a preconfigured aggregate") {
+    dynamic_bounded_document input{
+        dynamic_bounded_size<std::string>{std::string{"sensor"}, 1, 16},
+        dynamic_bounded_size<std::vector<std::byte>>{std::vector<std::byte>{std::byte{0x01}, std::byte{0x02}}, 0, 4},
+        dynamic_bounded_size<std::vector<int>>{std::vector<int>{1, 2, 3}, 1, 3},
+        dynamic_bounded_size<std::map<std::string, std::uint64_t>>{std::map<std::string, std::uint64_t>{{"ok", 1}}, 0, 2},
+    };
+
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder(buffer);
+    REQUIRE(enc(input));
+
+    dynamic_bounded_document output{
+        dynamic_bounded_size<std::string>{std::string{}, 1, 16},
+        dynamic_bounded_size<std::vector<std::byte>>{std::vector<std::byte>{}, 0, 4},
+        dynamic_bounded_size<std::vector<int>>{std::vector<int>{}, 1, 3},
+        dynamic_bounded_size<std::map<std::string, std::uint64_t>>{std::map<std::string, std::uint64_t>{}, 0, 2},
+    };
+    auto dec = make_decoder(buffer);
+    REQUIRE(dec(output));
+
+    CHECK_EQ(output.name.value(), input.name.value());
+    CHECK_EQ(output.payload.value(), input.payload.value());
+    CHECK_EQ(output.values.value(), input.values.value());
+    CHECK_EQ(output.counters.value(), input.counters.value());
+}
+
+TEST_CASE("dynamic bounded custom codecs opt in with ordinary overloads") {
+    bounded_extension_value input{{1, 2}};
+    std::vector<std::byte>  buffer;
+    auto                    enc = make_encoder<bounded_extension_codec>(buffer);
+
+    REQUIRE(enc(as_bounded_size(input, 1, 2)));
+    CHECK_EQ(to_hex(buffer), "820102");
+
+    bounded_extension_value output;
+    auto                    dec = make_decoder<bounded_extension_codec>(buffer);
+    REQUIRE(dec(as_bounded_size(output, 1, 2)));
+    CHECK_EQ(output.values, input.values);
+
+    auto invalid     = to_bytes("83010203");
+    auto invalid_dec = make_decoder<bounded_extension_codec>(invalid);
+    auto result      = invalid_dec(as_bounded_size(output, 1, 2));
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+    CHECK_EQ(output.values, input.values);
+}
+
+TEST_CASE("dynamic bounds reject definite sizes before output allocation or mutation") {
+    SUBCASE("encode") {
+        std::vector<int>       values{1, 2, 3};
+        std::vector<std::byte> buffer;
+        auto                   enc    = make_encoder(buffer);
+        auto                   result = enc(as_bounded_size(values, 0, 2));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(buffer.empty());
+    }
+
+    SUBCASE("decode") {
+        auto                   buffer = to_bytes("4101");
+        std::vector<std::byte> value{std::byte{0xAA}};
+        auto                   dec    = make_decoder(buffer);
+        auto                   result = dec(as_bounded_size(value, 2, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, (std::vector<std::byte>{std::byte{0xAA}}));
+    }
+
+    SUBCASE("reserve") {
+        auto buffer = to_bytes("9a00010000");
+
+        counting_memory_resource resource;
+        std::pmr::vector<int>    values{&resource};
+        auto                     dec    = make_decoder(buffer);
+        auto                     result = dec(as_bounded_size(values, 0, 2));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(resource.allocations, 0);
+        CHECK(values.empty());
+    }
+}
+
+TEST_CASE("dynamic bounded indefinite decoding retains complete prefixes") {
+    SUBCASE("empty array at zero maximum") {
+        auto             buffer = to_bytes("9fff");
+        std::vector<int> value;
+
+        REQUIRE(make_decoder(buffer)(as_bounded_size(value, 0, 0)));
+        CHECK(value.empty());
+    }
+
+    SUBCASE("array maximum") {
+        auto             buffer = to_bytes("9f010203ff");
+        std::vector<int> value;
+        auto             result = make_decoder(buffer)(as_bounded_size(value, 0, 2));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, (std::vector<int>{1, 2}));
+    }
+
+    SUBCASE("array minimum") {
+        auto             buffer = to_bytes("9f01ff");
+        std::vector<int> value;
+        auto             result = make_decoder(buffer)(as_bounded_size(value, 2, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, (std::vector<int>{1}));
+    }
+
+    SUBCASE("byte string") {
+        auto                   buffer = to_bytes("5f426162426364ff");
+        std::vector<std::byte> value;
+        auto                   result = make_decoder(buffer)(as_bounded_size(value, 0, 3));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, (std::vector<std::byte>{std::byte{'a'}, std::byte{'b'}}));
+    }
+
+    SUBCASE("text string") {
+        auto        buffer = to_bytes("7f626162626364ff");
+        std::string value;
+        auto        result = make_decoder(buffer)(as_bounded_size(value, 0, 3));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, "ab");
+    }
+
+    SUBCASE("map") {
+        auto                       buffer = to_bytes("bf616101616202ff");
+        std::map<std::string, int> value;
+        auto                       result = make_decoder(buffer)(as_bounded_size(value, 0, 1));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, (std::map<std::string, int>{{"a", 1}}));
+    }
+}
+
+TEST_CASE("dynamic bounds preserve fixed container extent") {
+    std::array<int, 2> values{1, 2};
+
+    SUBCASE("encode") {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+
+        REQUIRE(enc(as_bounded_size(values, 2, 2)));
+        CHECK_EQ(to_hex(buffer), "820102");
+
+        buffer.clear();
+        auto result = enc(as_bounded_size(values, 0, 1));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(buffer.empty());
+    }
+
+    SUBCASE("decode") {
+        auto               buffer = to_bytes("820304");
+        std::array<int, 2> decoded{9, 9};
+        auto               dec = make_decoder(buffer);
+
+        REQUIRE(dec(as_bounded_size(decoded, 2, 2)));
+        CHECK_EQ(decoded, (std::array<int, 2>{3, 4}));
+
+        decoded           = {9, 9};
+        auto rejected_dec = make_decoder(buffer);
+        auto result       = rejected_dec(as_bounded_size(decoded, 3, 3));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(decoded, (std::array<int, 2>{9, 9}));
+    }
+}
+
+TEST_CASE("dynamic bounds apply only to the immediate container") {
+    auto buffer = to_bytes("8183010203");
+
+    std::vector<std::vector<int>> value;
+    auto                          dec = make_decoder(buffer);
+
+    REQUIRE(dec(as_bounded_size(value, 0, 1)));
+    CHECK_EQ(value, (std::vector<std::vector<int>>{{1, 2, 3}}));
+}
+
+TEST_CASE("configured dynamic bounds encode safely through variants") {
+    using value_type = std::variant<dynamic_bounded_size<std::vector<int>>, std::string>;
+
+    value_type             value{std::in_place_index<0>, std::vector<int>{1, 2}, 0, 2};
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder(buffer);
+
+    REQUIRE(enc(value));
+    CHECK_EQ(to_hex(buffer), "820102");
+}
 
 TEST_CASE("bounded_size roundtrips a mixed aggregate") {
     bounded_document input{
@@ -756,6 +1023,37 @@ TEST_CASE("bounded explicit range wrappers reject invalid sizes before output") 
     REQUIRE_FALSE(result);
     CHECK_EQ(result.error(), status_code::size_limit_exceeded);
     CHECK(buffer.empty());
+}
+
+TEST_CASE("dynamic bounded explicit range encoding uses runtime limits") {
+    {
+        std::vector<int>       values{1, 2, 3};
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+
+        REQUIRE(enc(as_bounded_size(as_array_range(values), 3, 3)));
+        CHECK_EQ(to_hex(buffer), "83010203");
+    }
+
+    {
+        std::vector<std::pair<int, int>> values{{1, 2}, {3, 4}};
+        std::vector<std::byte>           buffer;
+        auto                             enc    = make_encoder(buffer);
+        auto                             result = enc(as_bounded_size(as_map_range(values), 0, 1));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(buffer.empty());
+    }
+
+    {
+        std::vector<int>       values{1, 2, 3};
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+
+        REQUIRE(enc(as_bounded_size(as_indefinite{values}, 0, 3)));
+        CHECK_EQ(to_hex(buffer), "9f010203ff");
+    }
 }
 
 TEST_CASE("bounded explicit ranges preserve const iteration requirements") {

--- a/test/test_bounded_size.cpp
+++ b/test/test_bounded_size.cpp
@@ -585,6 +585,59 @@ TEST_CASE("dynamic bounds apply only to the immediate container") {
     CHECK_EQ(value, (std::vector<std::vector<int>>{{1, 2, 3}}));
 }
 
+TEST_CASE("dynamic bounds validate item cardinality independently of accumulated destinations") {
+    auto decode_definite = []<typename T>(const T &input, T &destination, std::size_t min, std::size_t max) {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(input));
+
+        auto dec = make_decoder(buffer);
+        return dec(as_bounded_size(destination, min, max));
+    };
+
+    std::vector<int> values{9, 8, 7};
+    REQUIRE(decode_definite(std::vector<int>{1, 2}, values, 2, 2));
+    CHECK_EQ(values, (std::vector<int>{9, 8, 7, 1, 2}));
+
+    std::map<std::string, int> mapping{{"existing", 0}};
+    REQUIRE(decode_definite(std::map<std::string, int>{{"a", 1}, {"b", 2}}, mapping, 2, 2));
+    CHECK_EQ(mapping, (std::map<std::string, int>{{"a", 1}, {"b", 2}, {"existing", 0}}));
+
+    std::vector<std::byte> bytes{std::byte{0x00}};
+    REQUIRE(decode_definite(std::vector<std::byte>{std::byte{0xAA}, std::byte{0xBB}}, bytes, 2, 2));
+    CHECK_EQ(bytes, (std::vector<std::byte>{std::byte{0x00}, std::byte{0xAA}, std::byte{0xBB}}));
+
+    std::string text{"prefix:"};
+    REQUIRE(decode_definite(std::string{"ok"}, text, 2, 2));
+    CHECK_EQ(text, "prefix:ok");
+
+    auto one_item_buffer = std::vector<std::byte>{};
+    auto one_item_enc    = make_encoder(one_item_buffer);
+    REQUIRE(one_item_enc(std::vector<int>{1}));
+    auto min_dec    = make_decoder(one_item_buffer);
+    auto min_result = min_dec(as_bounded_size(values, 2, 3));
+    REQUIRE_FALSE(min_result);
+    CHECK_EQ(min_result.error(), status_code::size_limit_exceeded);
+    CHECK_EQ(values, (std::vector<int>{9, 8, 7, 1, 2}));
+
+    std::vector<int>       indefinite_input{3, 4};
+    std::vector<std::byte> indefinite_buffer;
+    auto                   indefinite_enc = make_encoder(indefinite_buffer);
+    REQUIRE(indefinite_enc(as_indefinite{indefinite_input}));
+    auto indefinite_dec = make_decoder(indefinite_buffer);
+    REQUIRE(indefinite_dec(as_bounded_size(values, 2, 2)));
+    CHECK_EQ(values, (std::vector<int>{9, 8, 7, 1, 2, 3, 4}));
+
+    std::vector<std::byte> output{std::byte{0x00}};
+    auto                   output_enc = make_encoder(output);
+    REQUIRE(output_enc(as_bounded_size(std::vector<int>{1, 2}, 2, 2)));
+    const auto before_failure = output;
+    auto       encode_result  = output_enc(as_bounded_size(std::vector<int>{1, 2, 3}, 2, 2));
+    REQUIRE_FALSE(encode_result);
+    CHECK_EQ(encode_result.error(), status_code::size_limit_exceeded);
+    CHECK_EQ(output, before_failure);
+}
+
 TEST_CASE("configured dynamic bounds encode safely through variants") {
     using input_type  = std::variant<dynamic_bounded_size<std::vector<int>>, std::string>;
     using output_type = std::variant<std::vector<int>, std::string>;

--- a/test/test_bounded_size.cpp
+++ b/test/test_bounded_size.cpp
@@ -162,6 +162,58 @@ struct dynamic_bounded_document {
     dynamic_bounded_size<std::map<std::string, std::uint64_t>> counters;
 };
 
+enum class dynamic_sensor_state : std::uint8_t { idle, active, fault };
+
+struct dynamic_sample_batch {
+    static constexpr std::uint64_t cbor_tag = 60001;
+
+    std::string                                                 source;
+    std::optional<std::vector<int>>                             readings;
+    std::variant<std::string, std::map<std::string, int>, bool> result;
+
+    bool operator==(const dynamic_sample_batch &) const = default;
+};
+
+struct dynamic_sensor_report {
+    dynamic_sensor_state                                          state{};
+    dynamic_bounded_size<std::string>                             name;
+    dynamic_bounded_size<std::vector<dynamic_sample_batch>>       batches;
+    dynamic_bounded_size<std::map<std::string, std::vector<int>>> history;
+    std::optional<std::string>                                    note;
+};
+
+struct plain_dynamic_sensor_report {
+    dynamic_sensor_state                    state{};
+    std::string                             name;
+    std::vector<dynamic_sample_batch>       batches;
+    std::map<std::string, std::vector<int>> history;
+    std::optional<std::string>              note;
+};
+
+struct dynamic_sensor_report_value {
+    dynamic_sensor_state                    state{};
+    std::string                             name;
+    std::vector<dynamic_sample_batch>       batches;
+    std::map<std::string, std::vector<int>> history;
+    std::optional<std::string>              note;
+
+    bool operator==(const dynamic_sensor_report_value &) const = default;
+};
+
+dynamic_sensor_report make_dynamic_sensor_report_output() {
+    return {
+        dynamic_sensor_state::idle,
+        dynamic_bounded_size<std::string>{std::string{}, 1, 16},
+        dynamic_bounded_size<std::vector<dynamic_sample_batch>>{std::vector<dynamic_sample_batch>{}, 1, 3},
+        dynamic_bounded_size<std::map<std::string, std::vector<int>>>{std::map<std::string, std::vector<int>>{}, 0, 2},
+        std::nullopt,
+    };
+}
+
+dynamic_sensor_report_value semantic_value(const dynamic_sensor_report &report) {
+    return {report.state, report.name.value(), report.batches.value(), report.history.value(), report.note};
+}
+
 struct bounded_extension_value {
     std::vector<int> values;
 };
@@ -260,18 +312,13 @@ TEST_CASE("dynamic_bounded_size roundtrips a preconfigured aggregate") {
         dynamic_bounded_size<std::map<std::string, std::uint64_t>>{std::map<std::string, std::uint64_t>{{"ok", 1}}, 0, 2},
     };
 
-    std::vector<std::byte> buffer;
-    auto                   enc = make_encoder(buffer);
-    REQUIRE(enc(input));
-
     dynamic_bounded_document output{
         dynamic_bounded_size<std::string>{std::string{}, 1, 16},
         dynamic_bounded_size<std::vector<std::byte>>{std::vector<std::byte>{}, 0, 4},
         dynamic_bounded_size<std::vector<int>>{std::vector<int>{}, 1, 3},
         dynamic_bounded_size<std::map<std::string, std::uint64_t>>{std::map<std::string, std::uint64_t>{}, 0, 2},
     };
-    auto dec = make_decoder(buffer);
-    REQUIRE(dec(output));
+    test_support::roundtrip_into(input, output);
 
     CHECK_EQ(output.name.value(), input.name.value());
     CHECK_EQ(output.payload.value(), input.payload.value());
@@ -279,17 +326,109 @@ TEST_CASE("dynamic_bounded_size roundtrips a preconfigured aggregate") {
     CHECK_EQ(output.counters.value(), input.counters.value());
 }
 
+TEST_CASE("dynamic_bounded_size roundtrips nested preconfigured aggregate composition") {
+    auto check_roundtrip = [](const dynamic_sensor_report &input) {
+        auto output = make_dynamic_sensor_report_output();
+        test_support::roundtrip_into(input, output);
+
+        CHECK(semantic_value(output) == semantic_value(input));
+        CHECK_EQ(output.name.min_size(), 1U);
+        CHECK_EQ(output.name.max_size(), 16U);
+        CHECK_EQ(output.batches.min_size(), 1U);
+        CHECK_EQ(output.batches.max_size(), 3U);
+        CHECK_EQ(output.history.min_size(), 0U);
+        CHECK_EQ(output.history.max_size(), 2U);
+    };
+
+    SUBCASE("map alternative and engaged optionals") {
+        dynamic_sensor_report input{
+            dynamic_sensor_state::active,
+            dynamic_bounded_size<std::string>{std::string{"sensor-a"}, 1, 16},
+            dynamic_bounded_size<std::vector<dynamic_sample_batch>>{
+                std::vector<dynamic_sample_batch>{
+                    {"front", std::vector<int>{1, 2, 3, 4, 5, 6}, std::map<std::string, int>{{"accepted", 6}}},
+                    {"rear", std::nullopt, std::string{"offline"}},
+                },
+                1, 3},
+            dynamic_bounded_size<std::map<std::string, std::vector<int>>>{
+                std::map<std::string, std::vector<int>>{{"recent", {1, 2, 3, 4, 5}}, {"older", {6}}}, 0, 2},
+            std::string{"calibrated"},
+        };
+
+        check_roundtrip(input);
+    }
+
+    SUBCASE("text and bool alternatives at outer bounds") {
+        dynamic_sensor_report input{
+            dynamic_sensor_state::fault,
+            dynamic_bounded_size<std::string>{std::string{"x"}, 1, 16},
+            dynamic_bounded_size<std::vector<dynamic_sample_batch>>{std::vector<dynamic_sample_batch>{
+                                                                        {"a", std::vector<int>{}, std::string{"ok"}},
+                                                                        {"b", std::nullopt, false},
+                                                                        {"c", std::vector<int>{7}, true},
+                                                                    },
+                                                                    1, 3},
+            dynamic_bounded_size<std::map<std::string, std::vector<int>>>{std::map<std::string, std::vector<int>>{}, 0, 2},
+            std::nullopt,
+        };
+
+        check_roundtrip(input);
+    }
+}
+
+TEST_CASE("dynamic_bounded_size rejects typed aggregate values outside configured bounds") {
+    auto decode = [](const plain_dynamic_sensor_report &input, dynamic_sensor_report &output) {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(input));
+
+        auto dec = make_decoder(buffer);
+        return dec(output);
+    };
+
+    SUBCASE("name exceeds its configured maximum") {
+        plain_dynamic_sensor_report input{
+            dynamic_sensor_state::idle, std::string(17, 'x'), {{"front", std::nullopt, true}}, {}, std::nullopt,
+        };
+        auto output = make_dynamic_sensor_report_output();
+        auto result = decode(input, output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(output.name.value().empty());
+    }
+
+    SUBCASE("outer record array is below its configured minimum") {
+        plain_dynamic_sensor_report input{dynamic_sensor_state::idle, "sensor", {}, {}, std::nullopt};
+        auto                        output = make_dynamic_sensor_report_output();
+        auto                        result = decode(input, output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(output.batches.value().empty());
+    }
+
+    SUBCASE("outer history map exceeds its configured maximum") {
+        plain_dynamic_sensor_report input{
+            dynamic_sensor_state::active,         "sensor",     {{"front", std::vector<int>{1}, std::string{"ok"}}},
+            {{"a", {1}}, {"b", {2}}, {"c", {3}}}, std::nullopt,
+        };
+        auto output = make_dynamic_sensor_report_output();
+        auto result = decode(input, output);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(output.history.value().empty());
+    }
+}
+
 TEST_CASE("dynamic bounded custom codecs opt in with ordinary overloads") {
     bounded_extension_value input{{1, 2}};
-    std::vector<std::byte>  buffer;
-    auto                    enc = make_encoder<bounded_extension_codec>(buffer);
-
-    REQUIRE(enc(as_bounded_size(input, 1, 2)));
-    CHECK_EQ(to_hex(buffer), "820102");
-
     bounded_extension_value output;
-    auto                    dec = make_decoder<bounded_extension_codec>(buffer);
-    REQUIRE(dec(as_bounded_size(output, 1, 2)));
+    auto                    bounded_input  = as_bounded_size(input, 1, 2);
+    auto                    bounded_output = as_bounded_size(output, 1, 2);
+
+    test_support::roundtrip_into<bounded_extension_codec>(bounded_input, bounded_output);
     CHECK_EQ(output.values, input.values);
 
     auto invalid     = to_bytes("83010203");
@@ -434,7 +573,10 @@ TEST_CASE("dynamic bounds preserve fixed container extent") {
 }
 
 TEST_CASE("dynamic bounds apply only to the immediate container") {
-    auto buffer = to_bytes("8183010203");
+    const std::vector<std::vector<int>> input{{1, 2, 3}};
+    std::vector<std::byte>              buffer;
+    auto                                enc = make_encoder(buffer);
+    REQUIRE(enc(input));
 
     std::vector<std::vector<int>> value;
     auto                          dec = make_decoder(buffer);
@@ -444,14 +586,15 @@ TEST_CASE("dynamic bounds apply only to the immediate container") {
 }
 
 TEST_CASE("configured dynamic bounds encode safely through variants") {
-    using value_type = std::variant<dynamic_bounded_size<std::vector<int>>, std::string>;
+    using input_type  = std::variant<dynamic_bounded_size<std::vector<int>>, std::string>;
+    using output_type = std::variant<std::vector<int>, std::string>;
 
-    value_type             value{std::in_place_index<0>, std::vector<int>{1, 2}, 0, 2};
-    std::vector<std::byte> buffer;
-    auto                   enc = make_encoder(buffer);
+    input_type  input{std::in_place_index<0>, std::vector<int>{1, 2}, 0, 2};
+    output_type output;
+    test_support::roundtrip_into(input, output);
 
-    REQUIRE(enc(value));
-    CHECK_EQ(to_hex(buffer), "820102");
+    REQUIRE(std::holds_alternative<std::vector<int>>(output));
+    CHECK_EQ(std::get<std::vector<int>>(output), (std::vector<int>{1, 2}));
 }
 
 TEST_CASE("bounded_size roundtrips a mixed aggregate") {
@@ -1025,35 +1168,62 @@ TEST_CASE("bounded explicit range wrappers reject invalid sizes before output") 
     CHECK(buffer.empty());
 }
 
-TEST_CASE("dynamic bounded explicit range encoding uses runtime limits") {
+TEST_CASE("dynamic bounded explicit range wrappers roundtrip semantic values") {
     {
-        std::vector<int>       values{1, 2, 3};
-        std::vector<std::byte> buffer;
-        auto                   enc = make_encoder(buffer);
+        std::vector<int> values{1, 2, 3};
+        std::vector<int> decoded;
 
-        REQUIRE(enc(as_bounded_size(as_array_range(values), 3, 3)));
-        CHECK_EQ(to_hex(buffer), "83010203");
+        auto input = as_bounded_size(as_array_range(values), 3, 3);
+        test_support::roundtrip_into(input, decoded);
+        CHECK_EQ(decoded, values);
     }
 
     {
         std::vector<std::pair<int, int>> values{{1, 2}, {3, 4}};
-        std::vector<std::byte>           buffer;
-        auto                             enc    = make_encoder(buffer);
-        auto                             result = enc(as_bounded_size(as_map_range(values), 0, 1));
+        std::map<int, int>               decoded;
 
-        REQUIRE_FALSE(result);
-        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
-        CHECK(buffer.empty());
+        auto input = as_bounded_size(as_map_range(values), 2, 2);
+        test_support::roundtrip_into(input, decoded);
+        CHECK_EQ(decoded, (std::map<int, int>{{1, 2}, {3, 4}}));
     }
 
     {
-        std::vector<int>       values{1, 2, 3};
-        std::vector<std::byte> buffer;
-        auto                   enc = make_encoder(buffer);
+        std::vector<std::byte> values{std::byte{0x01}, std::byte{0x02}};
+        std::vector<std::byte> decoded;
 
-        REQUIRE(enc(as_bounded_size(as_indefinite{values}, 0, 3)));
-        CHECK_EQ(to_hex(buffer), "9f010203ff");
+        auto input = as_bounded_size(as_bstr_range(values), 2, 2);
+        test_support::roundtrip_into(input, decoded);
+        CHECK_EQ(decoded, values);
     }
+
+    {
+        std::string values{"hello"};
+        std::string decoded;
+
+        auto input = as_bounded_size(as_tstr_range(values), 1, 5);
+        test_support::roundtrip_into(input, decoded);
+        CHECK_EQ(decoded, values);
+    }
+}
+
+TEST_CASE("dynamic bounded explicit range wrappers reject invalid sizes before output") {
+    std::vector<std::pair<int, int>> values{{1, 2}, {3, 4}};
+    std::vector<std::byte>           buffer;
+    auto                             enc    = make_encoder(buffer);
+    auto                             result = enc(as_bounded_size(as_map_range(values), 0, 1));
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+    CHECK(buffer.empty());
+}
+
+TEST_CASE("dynamic bounded indefinite wrappers preserve their wire shape") {
+    std::vector<int>       values{1, 2, 3};
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder(buffer);
+
+    REQUIRE(enc(as_bounded_size(as_indefinite{values}, 0, 3)));
+    CHECK_EQ(to_hex(buffer), "9f010203ff");
 }
 
 TEST_CASE("bounded explicit ranges preserve const iteration requirements") {

--- a/test/test_cbor_typed_arrays.cpp
+++ b/test/test_cbor_typed_arrays.cpp
@@ -1382,6 +1382,107 @@ TEST_CASE("rfc8746 bounded typed arrays roundtrip aggregate composition") {
     }
 }
 
+TEST_CASE("rfc8746 dynamically bounded typed arrays enforce runtime element counts") {
+    const auto encoded_three = to_bytes("d84e4c010000000200000003000000");
+
+    SUBCASE("borrowed encode") {
+        std::vector<std::int32_t> values{1, 2, 3};
+        std::vector<std::byte>    buffer;
+        auto                      enc = make_encoder<typed_array_codec>(buffer);
+
+        REQUIRE(enc(as_bounded_size(as_typed_array(values), 1, 3)));
+        CHECK_EQ(buffer, encoded_three);
+    }
+
+    SUBCASE("encode rejects before output") {
+        typed_array<std::int32_t> values{{1, 2, 3, 4}};
+        std::vector<std::byte>    buffer;
+        auto                      enc    = make_encoder<typed_array_codec>(buffer);
+        auto                      result = enc(as_bounded_size(values, 1, 3));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(buffer.empty());
+    }
+
+    SUBCASE("owned decode") {
+        typed_array<std::int32_t> decoded;
+        auto                      dec = make_decoder<typed_array_codec>(encoded_three);
+
+        REQUIRE(dec(as_bounded_size(decoded, 1, 3)));
+        CHECK_EQ(decoded.values(), (std::vector<std::int32_t>{1, 2, 3}));
+    }
+
+    SUBCASE("owned decode rejects before mutation") {
+        auto                      input = to_bytes("d84e5001000000020000000300000004000000");
+        typed_array<std::int32_t> decoded{{9}};
+        auto                      dec    = make_decoder<typed_array_codec>(input);
+        auto                      result = dec(as_bounded_size(decoded, 1, 3));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(decoded.values(), (std::vector<std::int32_t>{9}));
+    }
+
+    SUBCASE("view decode") {
+        typed_array_view<std::int32_t> decoded;
+        auto                           dec = make_decoder<typed_array_codec>(encoded_three);
+
+        REQUIRE(dec(as_bounded_size(decoded, 1, 3)));
+        CHECK_EQ(decoded.size(), 3U);
+        CHECK_EQ(decoded.copy_values(), (std::vector<std::int32_t>{1, 2, 3}));
+    }
+
+    SUBCASE("non-contiguous view decode") {
+        std::deque<std::byte> input(encoded_three.begin(), encoded_three.end());
+        auto                  dec = make_decoder<typed_array_codec>(input);
+        using view_type           = typed_array_view_for<std::int32_t, decltype(dec)>;
+        view_type decoded;
+
+        REQUIRE(dec(as_bounded_size(decoded, 1, 3)));
+        CHECK_EQ(decoded.size(), 3U);
+        CHECK_EQ(decoded.copy_values(), (std::vector<std::int32_t>{1, 2, 3}));
+    }
+
+    SUBCASE("misaligned payload preserves structural error") {
+        auto                      input = to_bytes("d84e450100000000");
+        typed_array<std::int32_t> decoded;
+        auto                      dec    = make_decoder<typed_array_codec>(input);
+        auto                      result = dec(as_bounded_size(decoded, 1, 3));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::unexpected_group_size);
+        CHECK(decoded.values().empty());
+    }
+
+    SUBCASE("element-to-byte bound conversion does not overflow") {
+        typed_array<std::int32_t> decoded;
+        auto                      dec = make_decoder<typed_array_codec>(encoded_three);
+
+        REQUIRE(dec(as_bounded_size(decoded, 0, std::numeric_limits<std::size_t>::max())));
+        CHECK_EQ(decoded.values(), (std::vector<std::int32_t>{1, 2, 3}));
+
+        constexpr auto max_representable_elements = std::numeric_limits<std::uint64_t>::max() / sizeof(std::int32_t);
+        if constexpr (std::numeric_limits<std::size_t>::max() > max_representable_elements) {
+            const auto impossible_min = static_cast<std::size_t>(max_representable_elements + 1U);
+            auto       rejected_dec   = make_decoder<typed_array_codec>(encoded_three);
+            auto       result         = rejected_dec(as_bounded_size(decoded, impossible_min, impossible_min));
+
+            REQUIRE_FALSE(result);
+            CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        }
+    }
+
+    SUBCASE("big-endian decode") {
+        auto                         input = to_bytes("d84a4c00000001fffffffe00000003");
+        typed_array_be<std::int32_t> decoded;
+        auto                         dec = make_decoder<typed_array_codec>(input);
+
+        REQUIRE(dec(as_bounded_size(decoded, 3, 3)));
+        CHECK_EQ(decoded.values(), (std::vector<std::int32_t>{1, -2, 3}));
+    }
+}
+
 TEST_CASE("rfc8746 typed array decode rejects malformed inputs") {
     check_decode_error<std::int32_t>("d84f4400000000", status_code::no_match_for_tag);
     check_decode_error<std::int32_t>("d84e44010203", status_code::incomplete);

--- a/test/test_cbor_typed_arrays.cpp
+++ b/test/test_cbor_typed_arrays.cpp
@@ -76,6 +76,45 @@ bounded_typed_report_value semantic_value(const bounded_typed_report &report) {
     return {report.state, std::move(samples), std::move(result), report.groups};
 }
 
+struct dynamic_bounded_typed_report {
+    bounded_typed_report_state                           state{};
+    dynamic_bounded_size<typed_array<std::int32_t>>      samples;
+    std::optional<std::string>                           note;
+    std::variant<typed_array<double>, std::string>       result;
+    std::map<std::string, std::vector<std::vector<int>>> groups;
+};
+
+struct dynamic_bounded_typed_report_value {
+    bounded_typed_report_state                           state{};
+    std::vector<std::int32_t>                            samples;
+    std::optional<std::string>                           note;
+    std::variant<std::vector<double>, std::string>       result;
+    std::map<std::string, std::vector<std::vector<int>>> groups;
+
+    bool operator==(const dynamic_bounded_typed_report_value &) const = default;
+};
+
+dynamic_bounded_typed_report make_dynamic_bounded_typed_report_output() {
+    return {
+        bounded_typed_report_state::idle,
+        dynamic_bounded_size<typed_array<std::int32_t>>{typed_array<std::int32_t>{}, 1, 3},
+        std::nullopt,
+        typed_array<double>{},
+        {},
+    };
+}
+
+dynamic_bounded_typed_report_value semantic_value(const dynamic_bounded_typed_report &report) {
+    std::variant<std::vector<double>, std::string> result;
+    if (report.result.index() == 0) {
+        result = std::get<0>(report.result).values();
+    } else {
+        result = std::get<1>(report.result);
+    }
+
+    return {report.state, report.samples.value().values(), report.note, std::move(result), report.groups};
+}
+
 template <typename Self> struct toy_codec : cbor_codec_mixin_base<Self> {
     using cbor_codec_mixin_base<Self>::decode;
     using cbor_codec_mixin_base<Self>::encode;
@@ -1383,7 +1422,8 @@ TEST_CASE("rfc8746 bounded typed arrays roundtrip aggregate composition") {
 }
 
 TEST_CASE("rfc8746 dynamically bounded typed arrays enforce runtime element counts") {
-    const auto encoded_three = to_bytes("d84e4c010000000200000003000000");
+    const std::array<std::int32_t, 3> encoded_values{1, 2, 3};
+    const auto                        encoded_three = encode_normal<std::int32_t>(std::span<const std::int32_t>{encoded_values});
 
     SUBCASE("borrowed encode") {
         std::vector<std::int32_t> values{1, 2, 3};
@@ -1414,10 +1454,11 @@ TEST_CASE("rfc8746 dynamically bounded typed arrays enforce runtime element coun
     }
 
     SUBCASE("owned decode rejects before mutation") {
-        auto                      input = to_bytes("d84e5001000000020000000300000004000000");
-        typed_array<std::int32_t> decoded{{9}};
-        auto                      dec    = make_decoder<typed_array_codec>(input);
-        auto                      result = dec(as_bounded_size(decoded, 1, 3));
+        const std::array<std::int32_t, 4> input_values{1, 2, 3, 4};
+        auto                              input = encode_normal<std::int32_t>(std::span<const std::int32_t>{input_values});
+        typed_array<std::int32_t>         decoded{9};
+        auto                              dec    = make_decoder<typed_array_codec>(input);
+        auto                              result = dec(as_bounded_size(decoded, 1, 3));
 
         REQUIRE_FALSE(result);
         CHECK_EQ(result.error(), status_code::size_limit_exceeded);
@@ -1480,6 +1521,41 @@ TEST_CASE("rfc8746 dynamically bounded typed arrays enforce runtime element coun
 
         REQUIRE(dec(as_bounded_size(decoded, 3, 3)));
         CHECK_EQ(decoded.values(), (std::vector<std::int32_t>{1, -2, 3}));
+    }
+}
+
+TEST_CASE("rfc8746 dynamically bounded typed arrays roundtrip preconfigured aggregate composition") {
+    auto check_roundtrip = [](const dynamic_bounded_typed_report &input) {
+        auto output = make_dynamic_bounded_typed_report_output();
+        test_support::roundtrip_into<typed_array_codec>(input, output);
+
+        CHECK(semantic_value(output) == semantic_value(input));
+        CHECK_EQ(output.samples.min_size(), 1U);
+        CHECK_EQ(output.samples.max_size(), 3U);
+    };
+
+    SUBCASE("typed variant and engaged optional") {
+        dynamic_bounded_typed_report input{
+            bounded_typed_report_state::active,
+            dynamic_bounded_size<typed_array<std::int32_t>>{typed_array<std::int32_t>{{1, -2, 3}}, 1, 3},
+            std::string{"calibrated"},
+            typed_array<double>{{1.5, -2.25}},
+            {{"primary", {{1, 2}, {3}}}, {"secondary", {{4, 5, 6}}}},
+        };
+
+        check_roundtrip(input);
+    }
+
+    SUBCASE("text variant and disengaged optional") {
+        dynamic_bounded_typed_report input{
+            bounded_typed_report_state::idle,
+            dynamic_bounded_size<typed_array<std::int32_t>>{typed_array<std::int32_t>{0}, 1, 3},
+            std::nullopt,
+            std::string{"offline"},
+            {{"empty", {}}},
+        };
+
+        check_roundtrip(input);
     }
 }
 

--- a/test/test_cddl.cpp
+++ b/test/test_cddl.cpp
@@ -1272,7 +1272,7 @@ TEST_CASE("named-map codec scopes nested map extensions") {
     CDDLNestedMapScopedExtensionRoot  input{.rootId = 1,
                                             .child  = as_named_map{child},
                                             .extensions =
-                                               as_named_extension<std::map<std::string, std::string>>{{{"rootExtra", "outside"}}}};
+                                                as_named_extension<std::map<std::string, std::string>>{{{"rootExtra", "outside"}}}};
 
     std::vector<std::byte> buffer;
     auto                   enc = make_encoder(buffer);
@@ -1300,8 +1300,8 @@ TEST_CASE("named-map codec scopes nested map extensions") {
 TEST_CASE("named-map codec handles nested named groups with unique flattened keys") {
     CDDLNestedInlineRoot input{.middle = as_named_group<CDDLNestedInlineMiddle>{CDDLNestedInlineMiddle{
                                    .leaf   = as_named_group<CDDLNestedInlineLeaf>{CDDLNestedInlineLeaf{
-                                         .one = std::string{"first"},
-                                         .two = std::string{"second"},
+                                       .one = std::string{"first"},
+                                       .two = std::string{"second"},
                                    }},
                                    .middle = std::string{"middle"},
                                }},

--- a/test/test_dynamic_bounded_views.cpp
+++ b/test/test_dynamic_bounded_views.cpp
@@ -1,0 +1,126 @@
+#include "test_util.h"
+
+#include <array>
+#include <cbor_tags/cbor_decoder.h>
+#include <cbor_tags/cbor_encoder.h>
+#include <cbor_tags/cbor_ranges.h>
+#include <cstddef>
+#include <deque>
+#include <doctest/doctest.h>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace cbor::tags;
+
+TEST_CASE("dynamic bounded borrowed string views decode definite payloads without ownership") {
+    SUBCASE("empty text view") {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(std::string{}));
+
+        std::string_view value{"before"};
+        auto             dec = make_decoder(buffer);
+        REQUIRE(dec(as_bounded_size(value, 0, 0)));
+        CHECK(value.empty());
+    }
+
+    SUBCASE("text view at maximum size") {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(std::string{"name"}));
+
+        std::string_view value{"before"};
+        auto             dec = make_decoder(buffer);
+        REQUIRE(dec(as_bounded_size(value, 1, 4)));
+
+        CHECK_EQ(value, "name");
+        CHECK(reinterpret_cast<const std::byte *>(value.data()) == buffer.data() + 1);
+    }
+
+    SUBCASE("binary view at maximum size") {
+        const std::vector<std::byte> payload{std::byte{0xaa}, std::byte{0xbb}};
+        std::vector<std::byte>       buffer;
+        auto                         enc = make_encoder(buffer);
+        REQUIRE(enc(payload));
+
+        const std::array<std::byte, 1>    sentinel{std::byte{0xcc}};
+        std::basic_string_view<std::byte> value{sentinel.data(), sentinel.size()};
+        auto                              dec = make_decoder(buffer);
+        REQUIRE(dec(as_bounded_size(value, 0, 2)));
+
+        CHECK_EQ(value.size(), payload.size());
+        CHECK(std::ranges::equal(value, payload));
+        CHECK(value.data() == buffer.data() + 1);
+    }
+}
+
+TEST_CASE("dynamic bounded borrowed string views reject invalid wire shapes without rebinding") {
+    SUBCASE("minimum size") {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(std::string{}));
+
+        std::string_view value{"before"};
+        auto             dec    = make_decoder(buffer);
+        auto             result = dec(as_bounded_size(value, 1, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, "before");
+    }
+
+    SUBCASE("maximum size") {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(std::string{"names"}));
+
+        std::string_view value{"before"};
+        auto             dec    = make_decoder(buffer);
+        auto             result = dec(as_bounded_size(value, 1, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK_EQ(value, "before");
+    }
+
+    SUBCASE("indefinite text") {
+        auto             buffer = to_bytes("7f6161ff");
+        std::string_view value{"before"};
+        auto             dec    = make_decoder(buffer);
+        auto             result = dec(as_bounded_size(value, 0, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::no_match_for_tstr_on_buffer);
+        CHECK_EQ(value, "before");
+    }
+
+    SUBCASE("indefinite binary") {
+        auto                              buffer = to_bytes("5f41aaff");
+        const std::array<std::byte, 1>    sentinel{std::byte{0xcc}};
+        std::basic_string_view<std::byte> value{sentinel.data(), sentinel.size()};
+        auto                              dec    = make_decoder(buffer);
+        auto                              result = dec(as_bounded_size(value, 0, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::no_match_for_bstr_on_buffer);
+        CHECK(value.data() == sentinel.data());
+        CHECK_EQ(value.size(), sentinel.size());
+    }
+
+    SUBCASE("non-contiguous input") {
+        std::vector<std::byte> encoded;
+        auto                   enc = make_encoder(encoded);
+        REQUIRE(enc(std::string{"name"}));
+        std::deque<std::byte> input(encoded.begin(), encoded.end());
+
+        std::string_view value{"before"};
+        auto             dec    = make_decoder(input);
+        auto             result = dec(as_bounded_size(value, 1, 4));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::contiguous_view_on_non_contiguous_data);
+        CHECK_EQ(value, "before");
+    }
+}

--- a/test/test_range_roundtrip.cpp
+++ b/test/test_range_roundtrip.cpp
@@ -103,8 +103,8 @@ TEST_CASE("explicit map range wrappers roundtrip pair-like views") {
     }
 
     {
-        auto odd_pairs = std::views::iota(0, 5) | std::views::filter([](int value) { return value % 2 == 1; }) |
-                         std::views::transform([](int value) { return std::pair{value, value * 10}; });
+        auto               odd_pairs = std::views::iota(0, 5) | std::views::filter([](int value) { return value % 2 == 1; }) |
+                                       std::views::transform([](int value) { return std::pair{value, value * 10}; });
         std::map<int, int> decoded;
 
         auto buffer = roundtrip_through_vector(as_map_range(odd_pairs), decoded);

--- a/test/test_range_support_regressions.cpp
+++ b/test/test_range_support_regressions.cpp
@@ -389,7 +389,7 @@ TEST_CASE("contiguous sized text string ranges match direct text string encoding
         std::vector<std::byte> buffer;
         auto                   enc   = make_encoder(buffer);
         auto                   upper = text | std::views::transform(
-                                [](char value) { return static_cast<char>(value >= 'a' && value <= 'z' ? value - 'a' + 'A' : value); });
+                                                  [](char value) { return static_cast<char>(value >= 'a' && value <= 'z' ? value - 'a' + 'A' : value); });
 
         REQUIRE(enc(as_tstr_range(upper)));
         CHECK_EQ(to_hex(buffer), "6548454c4c4f");
@@ -614,15 +614,21 @@ TEST_CASE("typed decode reads non-contiguous input once without a structural pre
 }
 
 TEST_CASE("bounded indefinite decoding traverses non-contiguous input once") {
-    counting_sized_bidirectional_bytes input{4};
-    input.bytes = to_bytes("9f0000ff");
+    counting_sized_bidirectional_bytes static_input{4};
+    static_input.bytes = to_bytes("9f0000ff");
+    auto dynamic_input = static_input;
 
-    std::vector<std::uint64_t> values;
-    auto                       dec = make_decoder(input);
+    std::vector<std::uint64_t> static_values;
+    auto                       static_dec = make_decoder(static_input);
+    REQUIRE(static_dec(as_bounded_size<0, 2>(static_values)));
 
-    REQUIRE(dec(as_bounded_size<0, 2>(values)));
-    CHECK_EQ(values, (std::vector<std::uint64_t>{0, 0}));
-    CHECK_EQ(input.increments, input.bytes.size());
+    std::vector<std::uint64_t> dynamic_values;
+    auto                       dynamic_dec = make_decoder(dynamic_input);
+    REQUIRE(dynamic_dec(as_bounded_size(dynamic_values, 0, 2)));
+
+    CHECK_EQ(dynamic_values, static_values);
+    CHECK_EQ(static_input.increments, static_input.bytes.size());
+    CHECK_EQ(dynamic_input.increments, static_input.increments);
 }
 
 TEST_CASE("bounded definite decoding adds no input traversal") {
@@ -631,7 +637,8 @@ TEST_CASE("bounded definite decoding adds no input traversal") {
         bounded_input.bytes[0] = std::byte{0x98};
         bounded_input.bytes[1] = std::byte{0x18};
         std::ranges::fill(bounded_input.bytes.begin() + 2, bounded_input.bytes.end(), std::byte{0x00});
-        auto direct_input = bounded_input;
+        auto direct_input  = bounded_input;
+        auto dynamic_input = bounded_input;
 
         std::vector<std::uint64_t> direct_values;
         auto                       direct_dec = make_decoder(direct_input);
@@ -641,8 +648,14 @@ TEST_CASE("bounded definite decoding adds no input traversal") {
         auto                       bounded_dec = make_decoder(bounded_input);
         REQUIRE(bounded_dec(as_bounded_size<24, 24>(bounded_values)));
 
+        std::vector<std::uint64_t> dynamic_values;
+        auto                       dynamic_dec = make_decoder(dynamic_input);
+        REQUIRE(dynamic_dec(as_bounded_size(dynamic_values, 24, 24)));
+
         CHECK_EQ(bounded_values, direct_values);
+        CHECK_EQ(dynamic_values, direct_values);
         CHECK_EQ(bounded_input.increments, direct_input.increments);
+        CHECK_EQ(dynamic_input.increments, direct_input.increments);
         CHECK_EQ(bounded_input.increments, bounded_input.bytes.size());
     }
 
@@ -651,7 +664,8 @@ TEST_CASE("bounded definite decoding adds no input traversal") {
         bounded_input.bytes[0] = std::byte{0x58};
         bounded_input.bytes[1] = std::byte{0x18};
         std::ranges::fill(bounded_input.bytes.begin() + 2, bounded_input.bytes.end(), std::byte{0x2a});
-        auto direct_input = bounded_input;
+        auto direct_input  = bounded_input;
+        auto dynamic_input = bounded_input;
 
         std::vector<std::byte> direct_value;
         auto                   direct_dec = make_decoder(direct_input);
@@ -661,8 +675,14 @@ TEST_CASE("bounded definite decoding adds no input traversal") {
         auto                   bounded_dec = make_decoder(bounded_input);
         REQUIRE(bounded_dec(as_bounded_size<24, 24>(bounded_value)));
 
+        std::vector<std::byte> dynamic_value;
+        auto                   dynamic_dec = make_decoder(dynamic_input);
+        REQUIRE(dynamic_dec(as_bounded_size(dynamic_value, 24, 24)));
+
         CHECK_EQ(bounded_value, direct_value);
+        CHECK_EQ(dynamic_value, direct_value);
         CHECK_EQ(bounded_input.increments, direct_input.increments);
+        CHECK_EQ(dynamic_input.increments, direct_input.increments);
     }
 }
 

--- a/test/typed_array_static_bounds_compile_fail.cc
+++ b/test/typed_array_static_bounds_compile_fail.cc
@@ -1,0 +1,17 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/extensions/rfc8746_typed_arrays.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::rfc8746;
+
+    std::vector<std::byte>                                                              input;
+    auto                                                                                dec = make_decoder<typed_array_codec>(input);
+    bounded_size<typed_array<std::int32_t>, 0, std::numeric_limits<std::size_t>::max()> value;
+    return dec(value).has_value() ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- add `dynamic_bounded_size<T>` and `as_bounded_size(value, min, max)` for per-instance limits
- enforce runtime bounds in one pass for core strings, arrays, maps, sized explicit ranges, custom codecs, and RFC 8746 scalar typed arrays
- add focused diagnostics, documentation, compile-failure coverage, traversal regressions, and a runtime-bound benchmark lane

## Semantics

- lvalues are referenced and rvalues are owned
- rewrapping replaces the previous policy instead of nesting wrappers
- bounds apply only to the immediately wrapped value; nested unwrapped containers remain intentionally unbounded
- definite lengths are checked before reserve or output; indefinite values are checked during the existing decode pass
- decoding requires a preconfigured destination; variant alternatives and values created by generic optional/container decoding are rejected
- runtime bounds are object state and are intentionally unavailable to type-based CDDL

## Test coverage

- preconfigured aggregate roundtrips preserve runtime bound objects
- realistic aggregates cover enums, engaged/disengaged optionals, every compatible variant alternative, tagged nested records, nested unbounded containers, and boundary-sized outer containers
- RFC 8746 runtime bounds compose with aggregate reflection and typed/text variant alternatives
- invalid values are generated from typed source objects where the input is valid CBOR
- explicit array/map/bstr/tstr range wrappers have semantic roundtrips; indefinite wire-shape assertions remain separate
- compile-fail tests pin unsupported nested, optional, container, variant, and CDDL construction

This PR is stacked on #52 and should be reviewed after that static-bound work.

## Performance

GCC 16 Release, 4096-element arrays:

| Wire form | Base direct | Base static | This PR direct | This PR static | This PR runtime |
| --- | ---: | ---: | ---: | ---: | ---: |
| definite | 0.85 ns/byte | 0.79 ns/byte | 0.94 ns/byte | 0.94 ns/byte | 0.92 ns/byte |
| indefinite | 0.85 ns/byte | 0.98 ns/byte | 0.85 ns/byte | 0.98 ns/byte | 0.97 ns/byte |

The host used frequency scaling and the powersave governor, so absolute cross-run differences are noisy. Within the final run, runtime bounds track static bounds. Counting-range tests also verify exact one-pass input traversal.

## Validation

Current head:

- GCC 16 Debug dynamic-focused tests: 28 cases, 211 assertions passed
- GCC 16 Debug bounded-focused tests: 37 cases, 344 assertions passed
- GCC 16 Debug full CTest suite: 36/36 passed
- `git diff --check`: passed

Implementation validation before the test-only follow-up:

- Clang 22 Debug full CTest suite: 36/36 passed
- GCC 16 Release bounded traversal benchmark: passed
