### PR TITLE
test(core): add semantic roundtrip coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,7 @@ Additional docs:
 - [Smart Pointer Codecs](doc/smart_pointers.md)
 - [Decoder Resource Limits](doc/decoder_resource_limits.md)
 - [Experimental Range And Segment APIs](doc/experimental_ranges.md)
+- [Testing](doc/testing.md)
 
 There are many types of cbor objects defined, the major types are:
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,35 @@
+# Testing
+
+Tests should separate semantic serialization behavior from CBOR wire-format behavior. This keeps most test data reusable when an encoder or decoder plugin changes the wire protocol.
+
+## Semantic tests
+
+Start from typed C++ values, encode them, decode them, and compare the resulting value with the input. Use `cbor::tags::test::roundtrip` for default-constructible output types and `roundtrip_into` when the destination must be preconfigured.
+
+A feature-focused test should still use a realistic aggregate when the feature composes with reflection. Include relevant enums, engaged and disengaged optionals, every variant alternative, nested containers, and tagged records. Empty and boundary-sized values belong beside the normal case.
+
+For a valid input that should fail only at decode time, prefer encoding a less-constrained typed source value over writing its CBOR representation as hex. Check the status code and any documented destination-state guarantees.
+
+## Wire tests
+
+Use exact bytes or hex when the bytes are the behavior under test, including:
+
+- RFC or interoperability vectors;
+- canonical or non-canonical representation choices;
+- tag, length, byte-order, or indefinite-form encoding;
+- malformed, truncated, or otherwise unrepresentable input.
+
+Keep exact-wire assertions separate from semantic roundtrip assertions. A serializer and decoder can agree on the same wrong representation, while an exact-byte test cannot prove that decoded values survive a refactor.
+
+## Negative tests
+
+Negative coverage should identify the failed contract and expected destination state. Cover wrong major types, invalid tags, truncation at structural boundaries, invalid lengths or indexes, configured limits, and trailing bytes where relevant. Prefer deterministic tables for related malformed cases; fuzzing may supplement but does not replace named regression cases.
+
+## Review checklist
+
+- Does the success path compare decoded values rather than only encoded bytes?
+- Are all variant alternatives and both optional states exercised?
+- Does at least one larger aggregate cover realistic nesting?
+- Are empty, minimum, maximum, and one-past-limit cases covered where limits exist?
+- Are CBOR literals limited to wire conformance or malformed-input cases?
+- Do extension tests run through the public encoder and decoder factories with the required codec mixins?

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -6,6 +6,8 @@ Tests should separate semantic serialization behavior from CBOR wire-format beha
 
 Start from typed C++ values, encode them, decode them, and compare the resulting value with the input. Use `cbor::tags::test::roundtrip` for default-constructible output types and `roundtrip_into` when the destination must be preconfigured.
 
+`roundtrip_into` uses the decoder's ordinary destination semantics. In particular, sequence containers append to existing values; the helper does not clear a preconfigured output unless the decoder for that type normally replaces it.
+
 A feature-focused test should still use a realistic aggregate when the feature composes with reflection. Include relevant enums, engaged and disengaged optionals, every variant alternative, nested containers, and tagged records. Empty and boundary-sized values belong beside the normal case.
 
 For a valid input that should fail only at decode time, prefer encoding a less-constrained typed source value over writing its CBOR representation as hex. Check the status code and any documented destination-state guarantees.

--- a/test/test_semantic_roundtrip.cpp
+++ b/test/test_semantic_roundtrip.cpp
@@ -1,0 +1,128 @@
+#include "cbor_roundtrip.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <doctest/doctest.h>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace test_support = cbor::tags::test;
+
+namespace {
+
+enum class telemetry_state : std::uint8_t { starting, active, degraded };
+
+struct diagnostic_snapshot {
+    static constexpr std::uint64_t cbor_tag = 60100;
+
+    std::uint32_t                           code{};
+    std::string                             message;
+    std::map<std::string, std::vector<int>> channels;
+
+    bool operator==(const diagnostic_snapshot &) const = default;
+};
+
+using sample_value = std::variant<std::int64_t, std::string, bool>;
+
+struct telemetry_sample {
+    static constexpr std::uint64_t cbor_tag = 60101;
+
+    std::string                   source;
+    sample_value                  value;
+    std::optional<std::string>    unit;
+    std::vector<std::vector<int>> windows;
+
+    bool operator==(const telemetry_sample &) const = default;
+};
+
+using telemetry_payload = std::variant<std::int64_t, std::string, std::vector<std::byte>, diagnostic_snapshot>;
+
+struct telemetry_frame {
+    std::uint64_t                                               sequence{};
+    telemetry_state                                             state{};
+    std::optional<std::string>                                  device_name;
+    std::vector<telemetry_sample>                               samples;
+    telemetry_payload                                           payload;
+    std::map<std::string, std::variant<int, std::string, bool>> attributes;
+    std::array<std::uint16_t, 3>                                calibration{};
+    std::optional<diagnostic_snapshot>                          diagnostic;
+
+    bool operator==(const telemetry_frame &) const = default;
+};
+
+telemetry_frame make_frame(telemetry_payload payload) {
+    return {
+        42,
+        telemetry_state::degraded,
+        std::string{"line-controller"},
+        {
+            {"temperature", std::int64_t{-12}, std::string{"C"}, {{1, 2, 3}, {4}}},
+            {"mode", std::string{"maintenance"}, std::nullopt, {{5, 6}}},
+            {"interlock", true, std::nullopt, {}},
+        },
+        std::move(payload),
+        {
+            {"attempt", 3},
+            {"operator", std::string{"night-shift"}},
+            {"verified", true},
+        },
+        {11, 22, 33},
+        diagnostic_snapshot{7, "sensor drift", {{"raw", {8, 9}}, {"filtered", {10}}}},
+    };
+}
+
+} // namespace
+
+TEST_CASE("core roundtrips every payload alternative in a realistic aggregate") {
+    SUBCASE("integer payload") {
+        const auto input  = make_frame(std::int64_t{-9001});
+        const auto output = test_support::roundtrip(input);
+        CHECK(output == input);
+    }
+
+    SUBCASE("text payload") {
+        const auto input  = make_frame(std::string{"manual override"});
+        const auto output = test_support::roundtrip(input);
+        CHECK(output == input);
+    }
+
+    SUBCASE("binary payload") {
+        const auto input  = make_frame(std::vector<std::byte>{std::byte{0x00}, std::byte{0x7f}, std::byte{0xff}});
+        const auto output = test_support::roundtrip(input);
+        CHECK(output == input);
+    }
+
+    SUBCASE("tagged aggregate payload") {
+        const auto input  = make_frame(diagnostic_snapshot{19, "over current", {{"phase-a", {1, 3, 5}}, {"phase-b", {2, 4, 6}}}});
+        const auto output = test_support::roundtrip(input);
+        CHECK(output == input);
+    }
+}
+
+TEST_CASE("core roundtrips empty containers and disengaged optionals in aggregate composition") {
+    telemetry_frame input{
+        0, telemetry_state::starting, std::nullopt, {}, std::vector<std::byte>{}, {}, {0, 0, 0}, std::nullopt,
+    };
+
+    const auto output = test_support::roundtrip(input);
+    CHECK(output == input);
+}
+
+TEST_CASE("core roundtrip replaces preseeded scalar optional and variant state") {
+    const auto      input = make_frame(std::string{"fresh"});
+    telemetry_frame output;
+    output.sequence    = 999;
+    output.state       = telemetry_state::active;
+    output.device_name = std::string{"stale"};
+    output.payload     = diagnostic_snapshot{999, "stale", {{"old", {99}}}};
+    output.calibration = {99, 99, 99};
+    output.diagnostic  = diagnostic_snapshot{998, "stale", {}};
+
+    test_support::roundtrip_into(input, output);
+    CHECK(output == input);
+}

--- a/test/test_semantic_roundtrip.cpp
+++ b/test/test_semantic_roundtrip.cpp
@@ -114,7 +114,9 @@ TEST_CASE("core roundtrips empty containers and disengaged optionals in aggregat
 }
 
 TEST_CASE("core roundtrip replaces preseeded scalar optional and variant state") {
-    const auto      input = make_frame(std::string{"fresh"});
+    auto input = make_frame(std::string{"fresh"});
+    input.device_name.reset();
+    input.diagnostic.reset();
     telemetry_frame output;
     output.sequence    = 999;
     output.state       = telemetry_state::active;


### PR DESCRIPTION
## Summary

- add a hex-free core roundtrip suite built from a realistic telemetry aggregate
- cover enums, engaged/disengaged optionals, tagged nested records, nested containers, fixed arrays, binary/text values, and every payload variant alternative
- verify preseeded scalar, optional, fixed-array, and variant state is replaced on decode
- document the repository testing policy: semantic roundtrips by default, exact bytes for wire behavior, deterministic named negatives

## Test design

The semantic model and expected values contain no CBOR literals. Exact hex remains reserved for RFC/interoperability vectors, representation choices, and malformed input.

The shared test helper stays limited to two operations introduced by #52:

- `roundtrip`
- `roundtrip_into`

## Stack

This PR is based directly on #59, and therefore also depends on #52. It is independent of the other testing follow-ups.

## Validation

- GCC 16 Debug focused semantic tests: 3 cases, 24 assertions passed
- GCC 16 Debug full CTest suite: 36/36 passed
- `git diff --check`: passed
