### PR TITLE
test(ranges): add composed roundtrip coverage

### DIFF
--- a/test/test_cbor_segments.cpp
+++ b/test/test_cbor_segments.cpp
@@ -10,11 +10,14 @@
 #include <cstdint>
 #include <doctest/doctest.h>
 #include <list>
+#include <map>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace cbor::tags;
@@ -62,6 +65,42 @@ concept CanBuildByteSegments = requires { typename basic_byte_segments<Storage>;
 
 template <typename T>
 concept CanWrapSegmentItemAsBstr = requires(T &&value) { as_bstr(std::forward<T>(value)); };
+
+enum class segmented_report_state : std::uint8_t { idle, active };
+
+struct segmented_sample {
+    static constexpr std::uint64_t cbor_tag = 60120;
+
+    std::string                                   name;
+    std::variant<std::int64_t, std::string, bool> value;
+    std::optional<std::string>                    unit;
+
+    bool operator==(const segmented_sample &) const = default;
+};
+
+template <typename Payload> struct segmented_report_input {
+    segmented_report_state                  state{};
+    std::optional<std::string>              note;
+    std::vector<segmented_sample>           samples;
+    std::variant<std::string, bool>         result;
+    std::map<std::string, std::vector<int>> metrics;
+    Payload                                 payload;
+};
+
+template <typename Payload>
+segmented_report_input(segmented_report_state, std::optional<std::string>, std::vector<segmented_sample>, std::variant<std::string, bool>,
+                       std::map<std::string, std::vector<int>>, Payload) -> segmented_report_input<Payload>;
+
+struct segmented_report_output {
+    segmented_report_state                  state{};
+    std::optional<std::string>              note;
+    std::vector<segmented_sample>           samples;
+    std::variant<std::string, bool>         result;
+    std::map<std::string, std::vector<int>> metrics;
+    std::vector<std::byte>                  payload;
+
+    bool operator==(const segmented_report_output &) const = default;
+};
 
 struct copyable_owning_byte_view : std::ranges::view_interface<copyable_owning_byte_view> {
     std::vector<std::byte> bytes;
@@ -318,6 +357,39 @@ TEST_CASE("cbor segments can be used as the normal encoder output backend") {
     CHECK_EQ(to_hex(segmented.flatten()), to_hex(contiguous));
     CHECK(has_borrowed_segment(segmented, blob0.data(), blob0.size()));
     CHECK(has_borrowed_segment(segmented, blob1.data(), blob1.size()));
+}
+
+TEST_CASE("segmented output roundtrips realistic aggregate composition") {
+    std::vector<std::byte>        payload{std::byte{0x00}, std::byte{0x7f}, std::byte{0xff}};
+    std::vector<segmented_sample> samples{
+        {"temperature", std::int64_t{-12}, std::string{"C"}},
+        {"mode", std::string{"maintenance"}, std::nullopt},
+        {"interlock", true, std::nullopt},
+    };
+    std::map<std::string, std::vector<int>> metrics{{"recent", {1, 2, 3}}, {"older", {4}}};
+
+    auto check_roundtrip = [&](std::variant<std::string, bool> result, std::optional<std::string> note) {
+        auto input = segmented_report_input{
+            segmented_report_state::active, note, samples, result, metrics, as_bstr_range(std::span<const std::byte>{payload}),
+        };
+
+        cbor_segments segmented;
+        auto          enc = make_encoder(segmented);
+        REQUIRE(enc(input));
+        CHECK(has_borrowed_segment(segmented, payload.data(), payload.size()));
+
+        const auto              flattened = segmented.flatten();
+        segmented_report_output output;
+        auto                    dec = make_decoder(flattened);
+        REQUIRE(dec(output));
+        REQUIRE(dec.tell() == flattened.end());
+
+        const segmented_report_output expected{segmented_report_state::active, note, samples, result, metrics, payload};
+        CHECK(output == expected);
+    };
+
+    SUBCASE("text result with engaged optional") { check_roundtrip(std::string{"ready"}, std::string{"calibrated"}); }
+    SUBCASE("simple result with disengaged optional") { check_roundtrip(false, std::nullopt); }
 }
 
 TEST_CASE("byte segments support custom inline storage as encoder backend") {

--- a/test/test_lazy_tags.cpp
+++ b/test/test_lazy_tags.cpp
@@ -14,10 +14,12 @@
 #include <iterator>
 #include <map>
 #include <new>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <string>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 using namespace cbor::tags;
@@ -48,6 +50,39 @@ struct lazy_compact_payload {
     std::vector<int> values;
 
     bool operator==(const lazy_compact_payload &) const = default;
+};
+
+enum class lazy_report_state : std::uint8_t { idle, active, degraded };
+
+struct lazy_report_event {
+    static constexpr std::uint64_t cbor_tag = 60130;
+
+    std::string                                   name;
+    std::variant<std::int64_t, std::string, bool> value;
+    std::optional<std::string>                    unit;
+
+    bool operator==(const lazy_report_event &) const = default;
+};
+
+struct lazy_report_detail {
+    static constexpr std::uint64_t cbor_tag = 60131;
+
+    std::uint32_t                           code{};
+    std::map<std::string, std::vector<int>> channels;
+
+    bool operator==(const lazy_report_detail &) const = default;
+};
+
+using lazy_report_result = std::variant<std::int64_t, std::string, std::vector<std::byte>, lazy_report_detail>;
+
+struct lazy_report {
+    lazy_report_state                       state{};
+    std::optional<std::string>              note;
+    std::vector<lazy_report_event>          events;
+    lazy_report_result                      result;
+    std::map<std::string, std::vector<int>> history;
+
+    bool operator==(const lazy_report &) const = default;
 };
 
 std::vector<std::byte> make_deeply_nested_tag(std::size_t depth) {
@@ -490,6 +525,62 @@ TEST_CASE("lazy tag scanner decodes nested aggregate payloads after no-allocatio
     CHECK(!threw);
     CHECK_EQ(matches, 1);
     CHECK_EQ(full_view.status(), status_code::success);
+}
+
+TEST_CASE("lazy tag scanner roundtrips realistic aggregate matches") {
+    auto make_report = [](lazy_report_state state, lazy_report_result result, std::optional<std::string> note) {
+        return lazy_report{
+            state,
+            std::move(note),
+            {
+                {"temperature", std::int64_t{-12}, std::string{"C"}},
+                {"mode", std::string{"maintenance"}, std::nullopt},
+                {"interlock", true, std::nullopt},
+            },
+            std::move(result),
+            {{"recent", {1, 2, 3}}, {"older", {4}}},
+        };
+    };
+
+    std::vector<lazy_report> expected{
+        make_report(lazy_report_state::active, std::int64_t{-9001}, std::string{"calibrated"}),
+        make_report(lazy_report_state::idle, std::string{"offline"}, std::nullopt),
+        make_report(lazy_report_state::active, std::vector<std::byte>{std::byte{0x00}, std::byte{0x7f}, std::byte{0xff}},
+                    std::string{"binary"}),
+        make_report(lazy_report_state::degraded, lazy_report_detail{19, {{"phase-a", {1, 3}}, {"phase-b", {2, 4}}}}, std::nullopt),
+    };
+
+    using tagged_report = tagged_object<static_tag<902>, lazy_report>;
+    std::vector<tagged_report> tagged;
+    tagged.reserve(expected.size());
+    for (const auto &report : expected) {
+        tagged.push_back(make_tag_pair(static_tag<902>{}, report));
+    }
+
+    std::vector<std::byte> buffer;
+    auto                   enc = make_encoder(buffer);
+    REQUIRE(enc(as_array{2}, make_tag_pair(static_tag<999>{}, std::string{"unrelated"}),
+                std::map<std::string, std::vector<tagged_report>>{{"reports", tagged}}));
+
+    auto check_matches = [&](auto &input) {
+        std::vector<lazy_report> decoded;
+        auto                     view = find_tags<902>(input);
+        for (auto it = view.begin(); it != view.end(); ++it) {
+            lazy_report report;
+            REQUIRE(it->decode(report));
+            decoded.push_back(std::move(report));
+        }
+
+        CHECK_EQ(view.status(), status_code::success);
+        CHECK(decoded == expected);
+    };
+
+    SUBCASE("contiguous input") { check_matches(buffer); }
+
+    SUBCASE("non-contiguous input") {
+        std::deque<std::byte> input(buffer.begin(), buffer.end());
+        check_matches(input);
+    }
 }
 
 TEST_CASE("lazy tag scanner stress scans deeply nested definite containers without heap allocation") {

--- a/test/test_range_roundtrip.cpp
+++ b/test/test_range_roundtrip.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <optional>
 #include <ranges>
+#include <sstream>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -131,6 +132,41 @@ TEST_CASE("explicit array range wrappers roundtrip sized and unsized views") {
         roundtrip_through_vector(as_array_range(evens), decoded);
         CHECK_EQ(decoded, (std::vector<int>{0, 2, 4}));
     }
+}
+
+TEST_CASE("explicit array range wrappers consume single-pass non-common ranges once") {
+    std::istringstream stream{"1 2 3"};
+    auto               values = std::ranges::istream_view<int>(stream);
+    static_assert(std::ranges::input_range<decltype(values)>);
+    static_assert(!std::ranges::forward_range<decltype(values)>);
+    static_assert(!std::ranges::common_range<decltype(values)>);
+
+    std::vector<int> decoded;
+    const auto       buffer = roundtrip_through_vector(as_array_range(values), decoded);
+
+    CHECK_EQ(to_hex(buffer), "9f010203ff");
+    CHECK_EQ(decoded, (std::vector<int>{1, 2, 3}));
+}
+
+TEST_CASE("explicit range wrappers roundtrip empty semantic values") {
+    std::vector<int>                 array_values;
+    std::vector<std::pair<int, int>> map_values;
+    std::vector<std::byte>           byte_values;
+    std::string                      text_values;
+
+    std::vector<int>       decoded_array;
+    std::map<int, int>     decoded_map;
+    std::vector<std::byte> decoded_bytes;
+    std::string            decoded_text;
+
+    CHECK_EQ(to_hex(roundtrip_through_vector(as_array_range(array_values), decoded_array)), "80");
+    CHECK_EQ(to_hex(roundtrip_through_vector(as_map_range(map_values), decoded_map)), "a0");
+    CHECK_EQ(to_hex(roundtrip_through_vector(as_bstr_range(byte_values), decoded_bytes)), "40");
+    CHECK_EQ(to_hex(roundtrip_through_vector(as_tstr_range(text_values), decoded_text)), "60");
+    CHECK(decoded_array.empty());
+    CHECK(decoded_map.empty());
+    CHECK(decoded_bytes.empty());
+    CHECK(decoded_text.empty());
 }
 
 TEST_CASE("explicit array range wrappers roundtrip owning and proxy ranges") {

--- a/test/test_range_roundtrip.cpp
+++ b/test/test_range_roundtrip.cpp
@@ -1,3 +1,4 @@
+#include "cbor_roundtrip.h"
 #include "test_util.h"
 
 #include <array>
@@ -10,19 +11,59 @@
 #include <deque>
 #include <doctest/doctest.h>
 #include <map>
+#include <optional>
 #include <ranges>
 #include <string>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 using namespace cbor::tags;
+namespace test_support = cbor::tags::test;
 
 namespace {
 
 struct roundtrip_member_pair {
     int first;
     int second;
+};
+
+enum class ranged_report_state : std::uint8_t { idle, active };
+
+struct ranged_sample {
+    static constexpr std::uint64_t cbor_tag = 60110;
+
+    std::string                                   name;
+    std::variant<std::int64_t, std::string, bool> value;
+    std::optional<std::string>                    unit;
+    std::vector<std::vector<int>>                 windows;
+
+    bool operator==(const ranged_sample &) const = default;
+};
+
+template <typename Samples, typename Metrics, typename Payload, typename Label> struct ranged_report_input {
+    ranged_report_state        state{};
+    std::optional<std::string> note;
+    Samples                    samples;
+    Metrics                    metrics;
+    Payload                    payload;
+    Label                      label;
+};
+
+template <typename Samples, typename Metrics, typename Payload, typename Label>
+ranged_report_input(ranged_report_state, std::optional<std::string>, Samples, Metrics, Payload, Label)
+    -> ranged_report_input<Samples, Metrics, Payload, Label>;
+
+struct ranged_report_output {
+    ranged_report_state                     state{};
+    std::optional<std::string>              note;
+    std::vector<ranged_sample>              samples;
+    std::map<std::string, std::vector<int>> metrics;
+    std::vector<std::byte>                  payload;
+    std::string                             label;
+
+    bool operator==(const ranged_report_output &) const = default;
 };
 
 template <typename Encoded, typename Decoded> std::vector<std::byte> roundtrip_through_vector(Encoded &&encoded, Decoded &decoded) {
@@ -48,14 +89,38 @@ template <typename Encoded, typename Decoded> std::vector<std::byte> roundtrip_t
 
 } // namespace
 
+TEST_CASE("explicit range wrappers roundtrip realistic aggregate composition") {
+    std::vector<ranged_sample> samples{
+        {"temperature", std::int64_t{-12}, std::string{"C"}, {{1, 2, 3}, {4}}},
+        {"mode", std::string{"maintenance"}, std::nullopt, {{5, 6}}},
+        {"interlock", true, std::nullopt, {}},
+    };
+    std::vector<std::pair<std::string, std::vector<int>>> metrics{
+        {"recent", {1, 2, 3}},
+        {"older", {4}},
+    };
+    std::vector<std::byte> payload{std::byte{0x00}, std::byte{0x7f}, std::byte{0xff}};
+    std::string            label{"line-controller"};
+
+    auto input = ranged_report_input{
+        ranged_report_state::active, std::optional<std::string>{"calibrated"},
+        as_array_range(samples),     as_map_range(metrics),
+        as_bstr_range(payload),      as_tstr_range(label),
+    };
+    ranged_report_output output;
+    ranged_report_output expected{
+        ranged_report_state::active, std::string{"calibrated"}, samples, {{"older", {4}}, {"recent", {1, 2, 3}}}, payload, label};
+
+    test_support::roundtrip_into(input, output);
+    CHECK(output == expected);
+}
+
 TEST_CASE("explicit array range wrappers roundtrip sized and unsized views") {
     {
         auto             sized = std::views::iota(1, 4);
         std::vector<int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_array_range(sized), decoded);
-
-        CHECK_EQ(to_hex(buffer), "83010203");
+        roundtrip_through_vector(as_array_range(sized), decoded);
         CHECK_EQ(decoded, (std::vector<int>{1, 2, 3}));
     }
 
@@ -63,9 +128,7 @@ TEST_CASE("explicit array range wrappers roundtrip sized and unsized views") {
         auto             evens = std::views::iota(0, 6) | std::views::filter([](int value) { return value % 2 == 0; });
         std::vector<int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_array_range(evens), decoded);
-
-        CHECK_EQ(to_hex(buffer), "9f000204ff");
+        roundtrip_through_vector(as_array_range(evens), decoded);
         CHECK_EQ(decoded, (std::vector<int>{0, 2, 4}));
     }
 }
@@ -74,9 +137,7 @@ TEST_CASE("explicit array range wrappers roundtrip owning and proxy ranges") {
     {
         std::vector<int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_array_range(std::vector<int>{4, 5}), decoded);
-
-        CHECK_EQ(to_hex(buffer), "820405");
+        roundtrip_through_vector(as_array_range(std::vector<int>{4, 5}), decoded);
         CHECK_EQ(decoded, (std::vector<int>{4, 5}));
     }
 
@@ -84,9 +145,7 @@ TEST_CASE("explicit array range wrappers roundtrip owning and proxy ranges") {
         std::vector<bool> flags{true, false, true};
         std::vector<bool> decoded;
 
-        auto buffer = roundtrip_through_vector(as_array_range(flags), decoded);
-
-        CHECK_EQ(to_hex(buffer), "83f5f4f5");
+        roundtrip_through_vector(as_array_range(flags), decoded);
         CHECK(decoded == flags);
     }
 }
@@ -96,9 +155,7 @@ TEST_CASE("explicit map range wrappers roundtrip pair-like views") {
         auto               pairs = std::views::iota(1, 4) | std::views::transform([](int value) { return std::pair{value, value + 10}; });
         std::map<int, int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_map_range(pairs), decoded);
-
-        CHECK_EQ(to_hex(buffer), "a3010b020c030d");
+        roundtrip_through_vector(as_map_range(pairs), decoded);
         CHECK(decoded == (std::map<int, int>{{1, 11}, {2, 12}, {3, 13}}));
     }
 
@@ -107,9 +164,7 @@ TEST_CASE("explicit map range wrappers roundtrip pair-like views") {
                                        std::views::transform([](int value) { return std::pair{value, value * 10}; });
         std::map<int, int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_map_range(odd_pairs), decoded);
-
-        CHECK_EQ(to_hex(buffer), "bf010a03181eff");
+        roundtrip_through_vector(as_map_range(odd_pairs), decoded);
         CHECK(decoded == (std::map<int, int>{{1, 10}, {3, 30}}));
     }
 }
@@ -119,9 +174,7 @@ TEST_CASE("explicit map range wrappers roundtrip tuple, member, and nested value
         auto               tuple_pairs = std::array{std::tuple{1, 2}, std::tuple{3, 4}};
         std::map<int, int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_map_range(tuple_pairs), decoded);
-
-        CHECK_EQ(to_hex(buffer), "a201020304");
+        roundtrip_through_vector(as_map_range(tuple_pairs), decoded);
         CHECK(decoded == (std::map<int, int>{{1, 2}, {3, 4}}));
     }
 
@@ -129,9 +182,7 @@ TEST_CASE("explicit map range wrappers roundtrip tuple, member, and nested value
         auto               member_pairs = std::array{roundtrip_member_pair{1, 2}, roundtrip_member_pair{3, 4}};
         std::map<int, int> decoded;
 
-        auto buffer = roundtrip_through_vector(as_map_range(member_pairs), decoded);
-
-        CHECK_EQ(to_hex(buffer), "a201020304");
+        roundtrip_through_vector(as_map_range(member_pairs), decoded);
         CHECK(decoded == (std::map<int, int>{{1, 2}, {3, 4}}));
     }
 
@@ -140,9 +191,7 @@ TEST_CASE("explicit map range wrappers roundtrip tuple, member, and nested value
         auto nested_entries = std::array{std::pair{1, as_array_range(nested_values)}, std::pair{2, as_array_range(nested_values)}};
         std::map<int, std::vector<int>> decoded;
 
-        auto buffer = roundtrip_through_vector(as_map_range(nested_entries), decoded);
-
-        CHECK_EQ(to_hex(buffer), "a20182010202820102");
+        roundtrip_through_vector(as_map_range(nested_entries), decoded);
         CHECK(decoded == (std::map<int, std::vector<int>>{{1, {1, 2}}, {2, {1, 2}}}));
     }
 }
@@ -152,10 +201,8 @@ TEST_CASE("explicit byte string range wrappers roundtrip byte-like views") {
         auto bytes = std::views::iota(1, 4) | std::views::transform([](int value) { return static_cast<std::uint8_t>(value); });
         std::vector<std::byte> decoded;
 
-        auto buffer = roundtrip_through_vector(as_bstr_range(bytes), decoded);
-
-        CHECK_EQ(to_hex(buffer), "43010203");
-        CHECK_EQ(to_hex(decoded), "010203");
+        roundtrip_through_vector(as_bstr_range(bytes), decoded);
+        CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x01}, std::byte{0x02}, std::byte{0x03}}));
     }
 
     {
@@ -163,10 +210,8 @@ TEST_CASE("explicit byte string range wrappers roundtrip byte-like views") {
         auto                     bytes = source | std::views::filter([](std::byte) { return true; });
         std::vector<std::byte>   decoded;
 
-        auto buffer = roundtrip_through_vector(as_bstr_range(bytes, 2), decoded);
-
-        CHECK_EQ(to_hex(buffer), "5f4200014202034104ff");
-        CHECK_EQ(to_hex(decoded), "0001020304");
+        roundtrip_through_vector(as_bstr_range(bytes, 2), decoded);
+        CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x00}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}}));
     }
 }
 
@@ -176,9 +221,7 @@ TEST_CASE("explicit text string range wrappers roundtrip char views") {
         auto        chars = text | std::views::transform([](char value) { return value; });
         std::string decoded;
 
-        auto buffer = roundtrip_through_vector(as_tstr_range(chars), decoded);
-
-        CHECK_EQ(to_hex(buffer), "6568656c6c6f");
+        roundtrip_through_vector(as_tstr_range(chars), decoded);
         CHECK_EQ(decoded, "hello");
     }
 
@@ -187,10 +230,41 @@ TEST_CASE("explicit text string range wrappers roundtrip char views") {
         auto        chars = text | std::views::filter([](char) { return true; });
         std::string decoded;
 
-        auto buffer = roundtrip_through_vector(as_tstr_range(chars, 2), decoded);
-
-        CHECK_EQ(to_hex(buffer), "7f626865626c6c616fff");
+        roundtrip_through_vector(as_tstr_range(chars, 2), decoded);
         CHECK_EQ(decoded, "hello");
+    }
+}
+
+TEST_CASE("explicit range wrappers pin representative CBOR wire forms") {
+    SUBCASE("definite and indefinite arrays") {
+        auto             sized = std::views::iota(1, 4);
+        std::vector<int> decoded;
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_array_range(sized), decoded)), "83010203");
+
+        auto filtered = sized | std::views::filter([](int value) { return value != 2; });
+        decoded.clear();
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_array_range(filtered), decoded)), "9f0103ff");
+    }
+
+    SUBCASE("definite and indefinite maps") {
+        std::array         pairs{std::pair{1, 2}, std::pair{3, 4}};
+        std::map<int, int> decoded;
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_map_range(pairs), decoded)), "a201020304");
+
+        auto filtered = pairs | std::views::filter([](const auto &entry) { return entry.first == 3; });
+        decoded.clear();
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_map_range(filtered), decoded)), "bf0304ff");
+    }
+
+    SUBCASE("definite and chunked strings") {
+        std::array<std::byte, 3> bytes{std::byte{0x01}, std::byte{0x02}, std::byte{0x03}};
+        std::vector<std::byte>   decoded_bytes;
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_bstr_range(bytes), decoded_bytes)), "43010203");
+
+        std::string decoded_text;
+        std::string text{"hello"};
+        auto        filtered = text | std::views::filter([](char) { return true; });
+        CHECK_EQ(to_hex(roundtrip_through_vector(as_tstr_range(filtered, 2), decoded_text)), "7f626865626c6c616fff");
     }
 }
 
@@ -198,9 +272,7 @@ TEST_CASE("explicit range wrapper output decodes from non-contiguous input buffe
     auto             values = std::views::iota(0, 6) | std::views::filter([](int value) { return value % 2 == 0; });
     std::vector<int> decoded;
 
-    auto buffer = roundtrip_through_deque(as_array_range(values), decoded);
-
-    CHECK_EQ(to_hex(buffer), "9f000204ff");
+    roundtrip_through_deque(as_array_range(values), decoded);
     CHECK_EQ(decoded, (std::vector<int>{0, 2, 4}));
 }
 

--- a/test/test_views.cpp
+++ b/test/test_views.cpp
@@ -13,14 +13,99 @@
 #include <fmt/format.h>
 #include <iterator>
 #include <list>
+#include <optional>
 #include <random>
 #include <span>
 #include <string>
 #include <string_view>
+#include <variant>
+#include <vector>
 
 using namespace cbor::tags;
 using namespace cbor::tags::literals;
 using namespace std::string_view_literals;
+
+namespace {
+
+enum class view_report_state : std::uint8_t { idle, active };
+
+struct owning_view_report {
+    view_report_state                                       state{};
+    std::string                                             name;
+    std::vector<std::byte>                                  payload;
+    std::optional<std::string>                              note;
+    std::variant<std::string, std::vector<std::byte>, bool> result;
+    std::array<int, 3>                                      samples{};
+};
+
+struct borrowed_view_report {
+    view_report_state                                                state{};
+    std::string_view                                                 name;
+    std::span<const std::byte>                                       payload;
+    std::optional<std::string_view>                                  note;
+    std::variant<std::string_view, std::span<const std::byte>, bool> result;
+    std::array<int, 3>                                               samples{};
+};
+
+} // namespace
+
+TEST_CASE("contiguous borrowed views roundtrip aggregate composition") {
+    auto check_roundtrip = [](const owning_view_report &input) {
+        std::vector<std::byte> buffer;
+        auto                   enc = make_encoder(buffer);
+        REQUIRE(enc(input));
+
+        borrowed_view_report output;
+        auto                 dec = make_decoder(buffer);
+        REQUIRE(dec(output));
+        REQUIRE(dec.tell() == buffer.end());
+
+        CHECK_EQ(output.state, input.state);
+        CHECK_EQ(output.name, input.name);
+        CHECK(std::ranges::equal(output.payload, input.payload));
+        CHECK_EQ(output.note.has_value(), input.note.has_value());
+        if (input.note) {
+            REQUIRE(output.note);
+            CHECK_EQ(*output.note, *input.note);
+        }
+        REQUIRE_EQ(output.result.index(), input.result.index());
+        switch (input.result.index()) {
+        case 0: CHECK_EQ(std::get<0>(output.result), std::get<0>(input.result)); break;
+        case 1: CHECK(std::ranges::equal(std::get<1>(output.result), std::get<1>(input.result))); break;
+        default: CHECK_EQ(std::get<2>(output.result), std::get<2>(input.result)); break;
+        }
+        CHECK_EQ(output.samples, input.samples);
+
+        const auto begin = reinterpret_cast<std::uintptr_t>(buffer.data());
+        const auto end   = begin + buffer.size();
+        CHECK_GE(reinterpret_cast<std::uintptr_t>(output.name.data()), begin);
+        CHECK_LT(reinterpret_cast<std::uintptr_t>(output.name.data()), end);
+        CHECK_GE(reinterpret_cast<std::uintptr_t>(output.payload.data()), begin);
+        CHECK_LT(reinterpret_cast<std::uintptr_t>(output.payload.data()), end);
+    };
+
+    SUBCASE("text variant and engaged optional") {
+        check_roundtrip({view_report_state::active,
+                         "line-controller",
+                         {std::byte{0x00}, std::byte{0x7f}, std::byte{0xff}},
+                         std::string{"calibrated"},
+                         std::string{"ready"},
+                         {1, 2, 3}});
+    }
+
+    SUBCASE("binary variant and disengaged optional") {
+        check_roundtrip({view_report_state::idle,
+                         "sensor",
+                         {std::byte{0x01}, std::byte{0x02}},
+                         std::nullopt,
+                         std::vector<std::byte>{std::byte{0xaa}, std::byte{0xbb}},
+                         {4, 5, 6}});
+    }
+
+    SUBCASE("simple variant") {
+        check_roundtrip({view_report_state::active, "interlock", {std::byte{0x10}}, std::string{"armed"}, true, {7, 8, 9}});
+    }
+}
 
 TEST_CASE("Test view contiguous, tstr") {
     auto data = std::vector<std::byte>{};

--- a/test/test_views.cpp
+++ b/test/test_views.cpp
@@ -15,9 +15,11 @@
 #include <list>
 #include <optional>
 #include <random>
+#include <ranges>
 #include <span>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -60,28 +62,47 @@ TEST_CASE("contiguous borrowed views roundtrip aggregate composition") {
         REQUIRE(dec(output));
         REQUIRE(dec.tell() == buffer.end());
 
+        auto require_borrowed_from_buffer = [&](const auto &view) {
+            if (view.empty()) {
+                return;
+            }
+
+            using view_type = std::remove_cvref_t<decltype(view)>;
+
+            const auto buffer_begin = reinterpret_cast<std::uintptr_t>(buffer.data());
+            const auto buffer_end   = buffer_begin + buffer.size();
+            const auto view_begin   = reinterpret_cast<std::uintptr_t>(std::ranges::data(view));
+            const auto view_bytes   = std::ranges::size(view) * sizeof(std::ranges::range_value_t<view_type>);
+
+            REQUIRE_GE(view_begin, buffer_begin);
+            REQUIRE_LE(view_begin, buffer_end);
+            CHECK_LE(view_bytes, buffer_end - view_begin);
+        };
+
         CHECK_EQ(output.state, input.state);
         CHECK_EQ(output.name, input.name);
         CHECK(std::ranges::equal(output.payload, input.payload));
+        require_borrowed_from_buffer(output.name);
+        require_borrowed_from_buffer(output.payload);
         CHECK_EQ(output.note.has_value(), input.note.has_value());
         if (input.note) {
             REQUIRE(output.note);
             CHECK_EQ(*output.note, *input.note);
+            require_borrowed_from_buffer(*output.note);
         }
         REQUIRE_EQ(output.result.index(), input.result.index());
         switch (input.result.index()) {
-        case 0: CHECK_EQ(std::get<0>(output.result), std::get<0>(input.result)); break;
-        case 1: CHECK(std::ranges::equal(std::get<1>(output.result), std::get<1>(input.result))); break;
+        case 0:
+            CHECK_EQ(std::get<0>(output.result), std::get<0>(input.result));
+            require_borrowed_from_buffer(std::get<0>(output.result));
+            break;
+        case 1:
+            CHECK(std::ranges::equal(std::get<1>(output.result), std::get<1>(input.result)));
+            require_borrowed_from_buffer(std::get<1>(output.result));
+            break;
         default: CHECK_EQ(std::get<2>(output.result), std::get<2>(input.result)); break;
         }
         CHECK_EQ(output.samples, input.samples);
-
-        const auto begin = reinterpret_cast<std::uintptr_t>(buffer.data());
-        const auto end   = begin + buffer.size();
-        CHECK_GE(reinterpret_cast<std::uintptr_t>(output.name.data()), begin);
-        CHECK_LT(reinterpret_cast<std::uintptr_t>(output.name.data()), end);
-        CHECK_GE(reinterpret_cast<std::uintptr_t>(output.payload.data()), begin);
-        CHECK_LT(reinterpret_cast<std::uintptr_t>(output.payload.data()), end);
     };
 
     SUBCASE("text variant and engaged optional") {

--- a/test/test_views.cpp
+++ b/test/test_views.cpp
@@ -80,25 +80,25 @@ TEST_CASE("contiguous borrowed views roundtrip aggregate composition") {
         };
 
         CHECK_EQ(output.state, input.state);
-        CHECK_EQ(output.name, input.name);
-        CHECK(std::ranges::equal(output.payload, input.payload));
         require_borrowed_from_buffer(output.name);
         require_borrowed_from_buffer(output.payload);
+        CHECK_EQ(output.name, input.name);
+        CHECK(std::ranges::equal(output.payload, input.payload));
         CHECK_EQ(output.note.has_value(), input.note.has_value());
         if (input.note) {
             REQUIRE(output.note);
-            CHECK_EQ(*output.note, *input.note);
             require_borrowed_from_buffer(*output.note);
+            CHECK_EQ(*output.note, *input.note);
         }
         REQUIRE_EQ(output.result.index(), input.result.index());
         switch (input.result.index()) {
         case 0:
-            CHECK_EQ(std::get<0>(output.result), std::get<0>(input.result));
             require_borrowed_from_buffer(std::get<0>(output.result));
+            CHECK_EQ(std::get<0>(output.result), std::get<0>(input.result));
             break;
         case 1:
-            CHECK(std::ranges::equal(std::get<1>(output.result), std::get<1>(input.result)));
             require_borrowed_from_buffer(std::get<1>(output.result));
+            CHECK(std::ranges::equal(std::get<1>(output.result), std::get<1>(input.result)));
             break;
         default: CHECK_EQ(std::get<2>(output.result), std::get<2>(input.result)); break;
         }


### PR DESCRIPTION
## Summary

- separate semantic range tests from representative CBOR wire-shape assertions
- add an aggregate that encodes through array/map/bstr/tstr range wrappers and decodes into owning fields
- roundtrip borrowed text/binary views through every compatible variant alternative and verify their buffer lifetimes
- encode a realistic aggregate through segmented output, confirm payload borrowing, flatten, and decode to owning values
- scan and decode multiple realistic lazy-tag payloads from contiguous and non-contiguous buffers

## Test design

The new semantic cases use typed inputs and value comparison. Exact bytes remain in one focused range-wire test for definite and indefinite representation choices.

## Stack

This PR is based directly on #59, and therefore also depends on #52. It is independent of the other testing follow-ups.

## Validation

- GCC 16 Debug realistic aggregate tests: 3 cases, 28 assertions passed
- GCC 16 Debug borrowed-view aggregate: 1 case, 46 assertions passed
- GCC 16 Debug refactored explicit-range focus: 3 cases, 25 assertions passed
- GCC 16 Debug full CTest suite: 36/36 passed
- `git diff --check`: passed
