### PR TITLE
Fix expected error typing and smart-pointer leak test

### DIFF
--- a/include/cbor_tags/cbor.h
+++ b/include/cbor_tags/cbor.h
@@ -124,10 +124,10 @@ template <typename T> struct Option {
 };
 
 #if CBOR_TAGS_USE_STD_EXPECTED
-template <typename T, typename E> using expected = std::expected<T, status_code>;
+template <typename T, typename E> using expected = std::expected<T, E>;
 template <typename E> using unexpected           = std::unexpected<E>;
 #else
-template <typename T, typename E> using expected = tl::expected<T, status_code>;
+template <typename T, typename E> using expected = tl::expected<T, E>;
 template <typename E> using unexpected           = tl::unexpected<E>;
 #endif
 using default_expected = Option<expected<void, status_code>>;

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -79,17 +79,26 @@ template <typename T> constexpr auto cbor_tag() {
 
 // Free function variants of coding functions
 template <typename T, typename Class>
-concept HasTranscodeFreeFunction = requires(T t, Class c) {
+concept HasRawTranscodeFreeFunction = requires(T t, Class c) { transcode(t, std::forward<Class>(c)); };
+
+template <typename T, typename Class>
+concept HasRawEncodeFreeFunction = requires(T t, Class c) { encode(t, std::forward<Class>(c)); };
+
+template <typename T, typename Class>
+concept HasRawDecodeFreeFunction = requires(T t, Class c) { decode(t, std::forward<Class>(c)); };
+
+template <typename T, typename Class>
+concept HasTranscodeFreeFunction = HasRawTranscodeFreeFunction<T, Class> && requires(T t, Class c) {
     { transcode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
-concept HasEncodeFreeFunction = requires(T t, Class c) {
+concept HasEncodeFreeFunction = HasRawEncodeFreeFunction<T, Class> && requires(T t, Class c) {
     { encode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
-concept HasDecodeFreeFunction = requires(T t, Class c) {
+concept HasDecodeFreeFunction = HasRawDecodeFreeFunction<T, Class> && requires(T t, Class c) {
     { decode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
@@ -456,9 +465,7 @@ concept HasInlineTag = requires {
 struct Access {
     // Transcode function
     template <typename T, typename Class> static constexpr auto transcode(T &transcoder, Class &&obj) {
-        if constexpr (requires {
-                          { obj.transcode(transcoder) } -> detail::CodecStatusResult;
-                      }) {
+        if constexpr (requires { obj.transcode(transcoder); }) {
             return obj.transcode(transcoder);
         } else {
             return detail::FalseType{};
@@ -467,9 +474,7 @@ struct Access {
 
     // Encode function
     template <typename T, typename Class> static constexpr auto encode(T &encoder, Class &&obj) {
-        if constexpr (requires {
-                          { obj.encode(encoder) } -> detail::CodecStatusResult;
-                      }) {
+        if constexpr (requires { obj.encode(encoder); }) {
             return obj.encode(encoder);
         } else {
             return detail::FalseType{};
@@ -478,9 +483,7 @@ struct Access {
 
     // Decode function
     template <typename T, typename Class> static constexpr auto decode(T &decoder, Class &&obj) {
-        if constexpr (requires {
-                          { obj.decode(decoder) } -> detail::CodecStatusResult;
-                      }) {
+        if constexpr (requires { obj.decode(decoder); }) {
             return obj.decode(decoder);
         } else {
             return detail::FalseType{};
@@ -517,6 +520,18 @@ struct Access {
 
 // Overload of coding functions, as member function
 template <typename T, typename Class>
+concept HasRawTranscodeMethod =
+    !std::same_as<std::remove_cvref_t<decltype(Access::transcode(std::declval<T &>(), std::declval<Class &>()))>, detail::FalseType>;
+
+template <typename T, typename Class>
+concept HasRawEncodeMethod =
+    !std::same_as<std::remove_cvref_t<decltype(Access::encode(std::declval<T &>(), std::declval<Class &>()))>, detail::FalseType>;
+
+template <typename T, typename Class>
+concept HasRawDecodeMethod =
+    !std::same_as<std::remove_cvref_t<decltype(Access::decode(std::declval<T &>(), std::declval<Class &>()))>, detail::FalseType>;
+
+template <typename T, typename Class>
 concept HasTranscodeMethod = requires(T t, Class c) {
     { Access::transcode(t, c) } -> detail::CodecStatusResult;
 };
@@ -530,6 +545,20 @@ template <typename T, typename Class>
 concept HasDecodeMethod = requires(T t, Class c) {
     { Access::decode(t, c) } -> detail::CodecStatusResult;
 };
+
+template <typename T, typename Class>
+concept HasIncompatibleEncodingCustomization =
+    std::is_class_v<Class> &&
+    ((HasRawTranscodeMethod<T, Class> && !HasTranscodeMethod<T, Class>) || (HasRawEncodeMethod<T, Class> && !HasEncodeMethod<T, Class>) ||
+     (HasRawTranscodeFreeFunction<T, Class> && !HasTranscodeFreeFunction<T, Class>) ||
+     (HasRawEncodeFreeFunction<T, Class> && !HasEncodeFreeFunction<T, Class>));
+
+template <typename T, typename Class>
+concept HasIncompatibleDecodingCustomization =
+    std::is_class_v<Class> &&
+    ((HasRawTranscodeMethod<T, Class> && !HasTranscodeMethod<T, Class>) || (HasRawDecodeMethod<T, Class> && !HasDecodeMethod<T, Class>) ||
+     (HasRawTranscodeFreeFunction<T, Class> && !HasTranscodeFreeFunction<T, Class>) ||
+     (HasRawDecodeFreeFunction<T, Class> && !HasDecodeFreeFunction<T, Class>));
 
 template <typename T>
 concept HasTagNonConstructible = requires(T) {

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -16,6 +16,8 @@
 
 namespace cbor::tags {
 
+enum class status_code : std::uint8_t;
+
 enum class major_type : std::uint8_t {
     UnsignedInteger = 0,
     NegativeInteger = 1,
@@ -47,6 +49,12 @@ template <typename T> struct strict_integer_decode_option<T, true> : std::bool_c
 
 template <typename T> inline constexpr bool strict_integer_decode_option_v = strict_integer_decode_option<T>::value;
 
+template <typename T>
+concept CodecStatusResult = requires(T result) {
+    { result.has_value() } -> std::convertible_to<bool>;
+    { result.error() } -> std::convertible_to<status_code>;
+};
+
 } // namespace detail
 
 template <typename T>
@@ -72,17 +80,17 @@ template <typename T> constexpr auto cbor_tag() {
 // Free function variants of coding functions
 template <typename T, typename Class>
 concept HasTranscodeFreeFunction = requires(T t, Class c) {
-    { transcode(t, std::forward<Class>(c)).has_value() } -> std::convertible_to<bool>;
+    { transcode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
 concept HasEncodeFreeFunction = requires(T t, Class c) {
-    { encode(t, std::forward<Class>(c)).has_value() } -> std::convertible_to<bool>;
+    { encode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
 concept HasDecodeFreeFunction = requires(T t, Class c) {
-    { decode(t, std::forward<Class>(c)).has_value() } -> std::convertible_to<bool>;
+    { decode(t, std::forward<Class>(c)) } -> detail::CodecStatusResult;
 };
 
 template <typename T>
@@ -448,7 +456,9 @@ concept HasInlineTag = requires {
 struct Access {
     // Transcode function
     template <typename T, typename Class> static constexpr auto transcode(T &transcoder, Class &&obj) {
-        if constexpr (requires { obj.transcode(transcoder).has_value(); }) {
+        if constexpr (requires {
+                          { obj.transcode(transcoder) } -> detail::CodecStatusResult;
+                      }) {
             return obj.transcode(transcoder);
         } else {
             return detail::FalseType{};
@@ -457,7 +467,9 @@ struct Access {
 
     // Encode function
     template <typename T, typename Class> static constexpr auto encode(T &encoder, Class &&obj) {
-        if constexpr (requires { obj.encode(encoder).has_value(); }) {
+        if constexpr (requires {
+                          { obj.encode(encoder) } -> detail::CodecStatusResult;
+                      }) {
             return obj.encode(encoder);
         } else {
             return detail::FalseType{};
@@ -466,7 +478,9 @@ struct Access {
 
     // Decode function
     template <typename T, typename Class> static constexpr auto decode(T &decoder, Class &&obj) {
-        if constexpr (requires { obj.decode(decoder).has_value(); }) {
+        if constexpr (requires {
+                          { obj.decode(decoder) } -> detail::CodecStatusResult;
+                      }) {
             return obj.decode(decoder);
         } else {
             return detail::FalseType{};
@@ -504,17 +518,17 @@ struct Access {
 // Overload of coding functions, as member function
 template <typename T, typename Class>
 concept HasTranscodeMethod = requires(T t, Class c) {
-    { Access::transcode(t, c).has_value() } -> std::convertible_to<bool>;
+    { Access::transcode(t, c) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
 concept HasEncodeMethod = requires(T t, Class c) {
-    { Access::encode(t, c).has_value() } -> std::convertible_to<bool>;
+    { Access::encode(t, c) } -> detail::CodecStatusResult;
 };
 
 template <typename T, typename Class>
 concept HasDecodeMethod = requires(T t, Class c) {
-    { Access::decode(t, c).has_value() } -> std::convertible_to<bool>;
+    { Access::decode(t, c) } -> detail::CodecStatusResult;
 };
 
 template <typename T>

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -548,14 +548,14 @@ concept HasDecodeMethod = requires(T t, Class c) {
 
 template <typename T, typename Class>
 concept HasIncompatibleEncodingCustomization =
-    std::is_class_v<Class> &&
+    std::is_class_v<Class> && (!std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<Class>>) &&
     ((HasRawTranscodeMethod<T, Class> && !HasTranscodeMethod<T, Class>) || (HasRawEncodeMethod<T, Class> && !HasEncodeMethod<T, Class>) ||
      (HasRawTranscodeFreeFunction<T, Class> && !HasTranscodeFreeFunction<T, Class>) ||
      (HasRawEncodeFreeFunction<T, Class> && !HasEncodeFreeFunction<T, Class>));
 
 template <typename T, typename Class>
 concept HasIncompatibleDecodingCustomization =
-    std::is_class_v<Class> &&
+    std::is_class_v<Class> && (!std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<Class>>) &&
     ((HasRawTranscodeMethod<T, Class> && !HasTranscodeMethod<T, Class>) || (HasRawDecodeMethod<T, Class> && !HasDecodeMethod<T, Class>) ||
      (HasRawTranscodeFreeFunction<T, Class> && !HasTranscodeFreeFunction<T, Class>) ||
      (HasRawDecodeFreeFunction<T, Class> && !HasDecodeFreeFunction<T, Class>));

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -459,7 +459,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     }
 
     template <typename T>
-        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T>)
+        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T> && !HasIncompatibleDecodingCustomization<self_t, T>)
     constexpr status_code decode(T &value) {
         auto &&tuple = to_tuple(value);
 
@@ -497,7 +497,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     }
 
     template <typename T>
-        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T>)
+        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T> && !HasIncompatibleDecodingCustomization<self_t, T>)
     constexpr status_code decode(T &value, major_type major, byte additionalInfo) {
         if (major != major_type::Tag) {
             return status_code::no_match_for_tag_on_buffer;
@@ -509,14 +509,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     }
 
     template <typename T>
-        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T>)
+        requires(IsAggregate<T> && !IsClassWithDecodingOverload<self_t, T> && !HasIncompatibleDecodingCustomization<self_t, T>)
     constexpr status_code decode(T &value, std::uint64_t tag) {
         auto &&tuple = to_tuple(value);
         return this->decode_tagged_aggregate(value, tag, tuple);
     }
 
     template <typename T>
-        requires IsClassWithTagOverload<T> && IsClassWithDecodingOverload<self_t, T>
+        requires IsClassWithTagOverload<T> && IsClassWithDecodingOverload<self_t, T> && (!HasIncompatibleDecodingCustomization<self_t, T>)
     constexpr status_code decode(T &value, std::uint64_t tag) {
         std::uint64_t class_tag;
         if constexpr (HasTagMember<T>) {
@@ -823,7 +823,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     }
 
     template <typename C, bool DecodeTag = true>
-        requires(IsClassWithDecodingOverload<self_t, C>)
+        requires(IsClassWithDecodingOverload<self_t, C> && !HasIncompatibleDecodingCustomization<self_t, C>)
     constexpr status_code decode_class_impl(C &value) {
         constexpr bool has_transcode      = HasTranscodeMethod<self_t, C>;
         constexpr bool has_decode         = HasDecodeMethod<self_t, C>;
@@ -849,18 +849,18 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
         if constexpr (has_transcode) {
             auto result = Access::transcode(*this, value);
-            return result ? status_code::success : result.error();
+            return result.has_value() ? status_code::success : result.error();
         } else if constexpr (has_decode) {
             auto result = Access::decode(*this, value);
-            return result ? status_code::success : result.error();
+            return result.has_value() ? status_code::success : result.error();
         } else if constexpr (has_free_decode) {
             /* This requires an indirect call in order for some compilers to find the overload. */
             auto result = detail::adl_indirect_decode(*this, std::forward<C>(value));
-            return result ? status_code::success : result.error();
+            return result.has_value() ? status_code::success : result.error();
         } else if (has_free_transcode) {
             /* Transcode does not require an indirect call, because no other methods exist with the same name (decode) */
             auto result = transcode(*this, std::forward<C>(value));
-            return result ? status_code::success : result.error();
+            return result.has_value() ? status_code::success : result.error();
         }
 
         // throw std::runtime_error("This should never happen");
@@ -868,22 +868,49 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     }
 
     template <typename C>
-        requires(IsClassWithDecodingOverload<self_t, C>)
+        requires(IsClassWithDecodingOverload<self_t, C> && !HasIncompatibleDecodingCustomization<self_t, C>)
     constexpr status_code decode(C &value) {
         return decode_class_impl<C, true>(value);
     }
 
     template <typename C>
-        requires(IsClassWithDecodingOverload<self_t, C>)
+        requires(IsClassWithDecodingOverload<self_t, C> && !HasIncompatibleDecodingCustomization<self_t, C>)
     constexpr status_code decode_without_tag(C &value) {
         return decode_class_impl<C, false>(value);
     }
 
     template <typename C>
-        requires(IsClassWithDecodingOverload<self_t, C>)
+        requires(IsClassWithDecodingOverload<self_t, C> && !HasIncompatibleDecodingCustomization<self_t, C>)
     constexpr status_code decode(C &value, major_type, byte) {
         reader_.seek(-1);
         return this->decode(value);
+    }
+
+    template <typename C>
+        requires HasIncompatibleDecodingCustomization<self_t, C>
+    constexpr status_code decode(C &) {
+        static_assert(always_false<C>::value,
+                      "custom decode/transcode must return a result with has_value() convertible to bool and error() convertible to "
+                      "cbor::tags::status_code");
+        return status_code::error;
+    }
+
+    template <typename C>
+        requires HasIncompatibleDecodingCustomization<self_t, C>
+    constexpr status_code decode(C &, major_type, byte) {
+        static_assert(always_false<C>::value,
+                      "custom decode/transcode must return a result with has_value() convertible to bool and error() convertible to "
+                      "cbor::tags::status_code");
+        return status_code::error;
+    }
+
+    template <typename C>
+        requires HasIncompatibleDecodingCustomization<self_t, C>
+    constexpr status_code decode(C &, std::uint64_t) {
+        static_assert(always_false<C>::value,
+                      "custom decode/transcode must return a result with has_value() convertible to bool and error() convertible to "
+                      "cbor::tags::status_code");
+        return status_code::error;
     }
 
     template <typename T> constexpr status_code decode(T &value) {

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -127,7 +127,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
     }
 
     template <typename T>
-        requires(IsAggregate<T> && !IsClassWithEncodingOverload<self_t, T>)
+        requires(IsAggregate<T> && !IsClassWithEncodingOverload<self_t, T> && !HasIncompatibleEncodingCustomization<self_t, T>)
     constexpr void encode(const T &value) {
         if constexpr (HasInlineTag<T>) {
             const auto &&tuple = to_tuple(value);
@@ -157,7 +157,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
     template <IsUntaggedTuple T> constexpr void encode(const T &value) { aggregate_encode(value); }
 
     template <typename C>
-        requires(IsClassWithEncodingOverload<self_t, C>)
+        requires(IsClassWithEncodingOverload<self_t, C> && !HasIncompatibleEncodingCustomization<self_t, C>)
     constexpr void encode(const C &value) {
         constexpr bool has_transcode      = HasTranscodeMethod<self_t, C>;
         constexpr bool has_encode         = HasEncodeMethod<self_t, C>;
@@ -184,6 +184,14 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
             /* Transcode does not require an indirect call, because no other methods exist with the same name (encode)*/
             detail::throw_on_encode_error(transcode(*this, value));
         }
+    }
+
+    template <typename C>
+        requires HasIncompatibleEncodingCustomization<self_t, C>
+    constexpr void encode(const C &) {
+        static_assert(always_false<C>::value,
+                      "custom encode/transcode must return a result with has_value() convertible to bool and error() convertible to "
+                      "cbor::tags::status_code");
     }
 
     template <IsEnum T> constexpr void encode(T value) { this->encode(static_cast<std::underlying_type_t<T>>(value)); }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,39 @@ endif()
 # add tests for ctest
 add_test(NAME tests COMMAND tests)
 
+function(add_incompatible_codec_result_compile_fail_test TEST_NAME COMPILE_DEFINITION PASS_REGEX)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL incompatible_codec_result_compile_fail.cc)
+  target_compile_definitions(${TEST_NAME} PRIVATE ${COMPILE_DEFINITION})
+  target_link_libraries(${TEST_NAME} PRIVATE cbor::tags)
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND
+      ${CMAKE_COMMAND}
+      "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+      "-DTEST_TARGET=${TEST_NAME}"
+      "-DCONFIG=$<CONFIG>"
+      "-DPASS_REGEX=${PASS_REGEX}"
+      -P
+      "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+endfunction()
+
+add_incompatible_codec_result_compile_fail_test(
+  incompatible_member_encode_result_compile_fails
+  CBOR_TAGS_INCOMPATIBLE_MEMBER_ENCODE
+  "custom encode/transcode must return a result")
+add_incompatible_codec_result_compile_fail_test(
+  incompatible_member_decode_result_compile_fails
+  CBOR_TAGS_INCOMPATIBLE_MEMBER_DECODE
+  "custom decode/transcode must return a result")
+add_incompatible_codec_result_compile_fail_test(
+  incompatible_free_encode_result_compile_fails
+  CBOR_TAGS_INCOMPATIBLE_FREE_ENCODE
+  "custom encode/transcode must return a result")
+add_incompatible_codec_result_compile_fail_test(
+  incompatible_free_decode_result_compile_fails
+  CBOR_TAGS_INCOMPATIBLE_FREE_DECODE
+  "custom decode/transcode must return a result")
+
 add_executable(cddl_variant_nullable_pointer_compile_fails EXCLUDE_FROM_ALL cddl_variant_nullable_pointer_compile_fail.cc)
 target_link_libraries(cddl_variant_nullable_pointer_compile_fails PRIVATE cbor::tags fmt::fmt nameof::nameof)
 add_test(

--- a/test/incompatible_codec_result_compile_fail.cc
+++ b/test/incompatible_codec_result_compile_fail.cc
@@ -1,0 +1,51 @@
+#include "cbor_tags/cbor.h"
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/cbor_encoder.h"
+
+#include <cstddef>
+#include <vector>
+
+using cbor::tags::expected;
+
+#if defined(CBOR_TAGS_INCOMPATIBLE_MEMBER_ENCODE)
+struct incompatible_codec {
+    int value{};
+
+    template <typename Encoder> auto encode(Encoder &) const { return expected<void, int>{}; }
+};
+#elif defined(CBOR_TAGS_INCOMPATIBLE_MEMBER_DECODE)
+struct incompatible_codec {
+    int value{};
+
+    template <typename Decoder> auto decode(Decoder &) { return expected<void, int>{}; }
+};
+#elif defined(CBOR_TAGS_INCOMPATIBLE_FREE_ENCODE)
+struct incompatible_codec {
+    int value{};
+};
+
+template <typename Encoder> auto encode(Encoder &, const incompatible_codec &) { return expected<void, int>{}; }
+#elif defined(CBOR_TAGS_INCOMPATIBLE_FREE_DECODE)
+struct incompatible_codec {
+    int value{};
+};
+
+template <typename Decoder> auto decode(Decoder &, incompatible_codec &&) { return expected<void, int>{}; }
+#else
+#error "expected an incompatible-codec compile-fail mode"
+#endif
+
+int main() {
+#if defined(CBOR_TAGS_INCOMPATIBLE_MEMBER_ENCODE) || defined(CBOR_TAGS_INCOMPATIBLE_FREE_ENCODE)
+    std::vector<std::byte> buffer;
+    auto                   enc    = cbor::tags::make_encoder(buffer);
+    auto                   result = enc(incompatible_codec{});
+#else
+    const std::vector<std::byte> input{std::byte{0x00}};
+    incompatible_codec           value{};
+    auto                         dec    = cbor::tags::make_decoder(input);
+    auto                         result = dec(value);
+#endif
+    (void)result;
+    return 0;
+}

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -1035,6 +1035,8 @@ TEST_SUITE("Classes") {
         static_assert(HasRawDecodeFreeFunction<decltype(decoder), incompatible_free_codec>);
         static_assert(HasIncompatibleEncodingCustomization<decltype(encoder), incompatible_free_codec>);
         static_assert(HasIncompatibleDecodingCustomization<decltype(decoder), incompatible_free_codec>);
+        static_assert(!HasIncompatibleEncodingCustomization<decltype(encoder), decltype(encoder)>);
+        static_assert(!HasIncompatibleDecodingCustomization<decltype(decoder), decltype(decoder)>);
     }
 
     TEST_CASE("IsClass") {

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -973,9 +973,23 @@ struct struct2 {
 
 // Also works
 template <typename T> constexpr auto transcode([[maybe_unused]] T &transcoder, [[maybe_unused]] struct2 &&obj) {
-    return expected<void, int>{};
+    return expected<void, status_code>{};
 }
 template <typename T> constexpr auto encode([[maybe_unused]] T &encoder, [[maybe_unused]] const struct1 &obj) {
+    return expected<void, status_code>{};
+}
+
+struct incompatible_free_codec {};
+
+template <typename T> constexpr auto transcode([[maybe_unused]] T &transcoder, [[maybe_unused]] incompatible_free_codec &&obj) {
+    return expected<void, int>{};
+}
+
+template <typename T> constexpr auto encode([[maybe_unused]] T &encoder, [[maybe_unused]] const incompatible_free_codec &obj) {
+    return expected<void, int>{};
+}
+
+template <typename T> constexpr auto decode([[maybe_unused]] T &decoder, [[maybe_unused]] incompatible_free_codec &&obj) {
     return expected<void, int>{};
 }
 
@@ -987,6 +1001,14 @@ TEST_SUITE("Classes") {
     struct class1 {
         class1() = default;
 
+      private:
+        friend cbor::tags::Access;
+        template <typename T> constexpr auto transcode([[maybe_unused]] T &transcoder) { return expected<void, status_code>{}; }
+        template <typename T> constexpr auto encode([[maybe_unused]] T &encoder) { return expected<void, status_code>{}; }
+        template <typename T> constexpr auto decode([[maybe_unused]] T &decoder) { return expected<void, status_code>{}; }
+    };
+
+    struct incompatible_member_codec {
       private:
         friend cbor::tags::Access;
         template <typename T> constexpr auto transcode([[maybe_unused]] T &transcoder) { return expected<void, int>{}; }
@@ -1005,6 +1027,9 @@ TEST_SUITE("Classes") {
         static_assert(HasTranscodeFreeFunction<decltype(encoder), struct2>);
 
         static_assert(HasEncodeFreeFunction<decltype(encoder), struct1>);
+        static_assert(!HasTranscodeFreeFunction<decltype(encoder), incompatible_free_codec>);
+        static_assert(!HasEncodeFreeFunction<decltype(encoder), incompatible_free_codec>);
+        static_assert(!HasDecodeFreeFunction<decltype(decoder), incompatible_free_codec>);
     }
 
     TEST_CASE("IsClass") {
@@ -1035,6 +1060,9 @@ TEST_SUITE("Classes") {
         static_assert(!HasTranscodeMethod<decltype(encoder), struct1>);
         static_assert(HasEncodeFreeFunction<decltype(encoder), struct1>);
         static_assert(!HasDecodeMethod<decltype(decoder), struct1>); // Should not work, returns void
+        static_assert(!HasTranscodeMethod<decltype(encoder), incompatible_member_codec>);
+        static_assert(!HasEncodeMethod<decltype(encoder), incompatible_member_codec>);
+        static_assert(!HasDecodeMethod<decltype(decoder), incompatible_member_codec>);
     }
 
     struct TrulyTagged0 {

--- a/test/test_concepts.cpp
+++ b/test/test_concepts.cpp
@@ -1030,6 +1030,11 @@ TEST_SUITE("Classes") {
         static_assert(!HasTranscodeFreeFunction<decltype(encoder), incompatible_free_codec>);
         static_assert(!HasEncodeFreeFunction<decltype(encoder), incompatible_free_codec>);
         static_assert(!HasDecodeFreeFunction<decltype(decoder), incompatible_free_codec>);
+        static_assert(HasRawTranscodeFreeFunction<decltype(encoder), incompatible_free_codec>);
+        static_assert(HasRawEncodeFreeFunction<decltype(encoder), incompatible_free_codec>);
+        static_assert(HasRawDecodeFreeFunction<decltype(decoder), incompatible_free_codec>);
+        static_assert(HasIncompatibleEncodingCustomization<decltype(encoder), incompatible_free_codec>);
+        static_assert(HasIncompatibleDecodingCustomization<decltype(decoder), incompatible_free_codec>);
     }
 
     TEST_CASE("IsClass") {
@@ -1063,6 +1068,11 @@ TEST_SUITE("Classes") {
         static_assert(!HasTranscodeMethod<decltype(encoder), incompatible_member_codec>);
         static_assert(!HasEncodeMethod<decltype(encoder), incompatible_member_codec>);
         static_assert(!HasDecodeMethod<decltype(decoder), incompatible_member_codec>);
+        static_assert(HasRawTranscodeMethod<decltype(encoder), incompatible_member_codec>);
+        static_assert(HasRawEncodeMethod<decltype(encoder), incompatible_member_codec>);
+        static_assert(HasRawDecodeMethod<decltype(decoder), incompatible_member_codec>);
+        static_assert(HasIncompatibleEncodingCustomization<decltype(encoder), incompatible_member_codec>);
+        static_assert(HasIncompatibleDecodingCustomization<decltype(decoder), incompatible_member_codec>);
     }
 
     struct TrulyTagged0 {

--- a/test/test_expected_backend.cpp
+++ b/test/test_expected_backend.cpp
@@ -24,6 +24,30 @@ struct alternate_error {
     int value;
 };
 
+struct codec_error {
+    status_code value;
+
+    constexpr operator status_code() const noexcept { return value; }
+};
+
+struct failing_encoder_codec {
+  private:
+    friend cbor::tags::Access;
+
+    template <typename Encoder> auto encode(Encoder &) const {
+        return expected<void, codec_error>{cbor::tags::unexpected<codec_error>{codec_error{status_code::unexpected_group_size}}};
+    }
+};
+
+struct failing_decoder_codec {
+  private:
+    friend cbor::tags::Access;
+
+    template <typename Decoder> auto decode(Decoder &) {
+        return expected<void, codec_error>{cbor::tags::unexpected<codec_error>{codec_error{status_code::invalid_utf8_sequence}}};
+    }
+};
+
 #if CBOR_TAGS_USE_STD_EXPECTED
 template <typename T> inline constexpr bool             is_configured_expected_v                       = false;
 template <typename T> inline constexpr bool             is_configured_unexpected_v                     = false;
@@ -85,4 +109,24 @@ TEST_CASE("configured expected backend supports value-returning helpers") {
     static_assert(is_configured_expected_v<decltype(encoded)>);
     REQUIRE(encoded);
     CHECK_EQ(to_hex(encoded->segments().front().bytes()), "182a");
+}
+
+TEST_CASE("custom codecs accept errors convertible to status code") {
+    std::vector<std::byte> output;
+    auto                   enc           = make_encoder(output);
+    auto                   encode_result = enc(failing_encoder_codec{});
+
+    static_assert(HasEncodeMethod<decltype(enc), failing_encoder_codec>);
+    REQUIRE_FALSE(encode_result);
+    CHECK_EQ(encode_result.error(), status_code::unexpected_group_size);
+    CHECK(output.empty());
+
+    const auto input = to_bytes("00");
+    auto       dec   = make_decoder(input);
+    auto       value = failing_decoder_codec{};
+
+    static_assert(HasDecodeMethod<decltype(dec), failing_decoder_codec>);
+    auto decode_result = dec(value);
+    REQUIRE_FALSE(decode_result);
+    CHECK_EQ(decode_result.error(), status_code::invalid_utf8_sequence);
 }

--- a/test/test_expected_backend.cpp
+++ b/test/test_expected_backend.cpp
@@ -44,7 +44,7 @@ TEST_CASE("configured expected backend preserves requested error type") {
     static_assert(is_configured_expected_v<result_type>);
     static_assert(std::is_same_v<typename result_type::error_type, alternate_error>);
 
-    result_type result = unexpected<alternate_error>{alternate_error{7}};
+    result_type result = cbor::tags::unexpected<alternate_error>{alternate_error{7}};
 
     REQUIRE_FALSE(result);
     CHECK_EQ(result.error().value, 7);

--- a/test/test_expected_backend.cpp
+++ b/test/test_expected_backend.cpp
@@ -30,6 +30,14 @@ struct codec_error {
     constexpr operator status_code() const noexcept { return value; }
 };
 
+struct status_result_without_bool {
+    bool        success;
+    status_code status;
+
+    [[nodiscard]] constexpr bool        has_value() const noexcept { return success; }
+    [[nodiscard]] constexpr status_code error() const noexcept { return status; }
+};
+
 struct failing_encoder_codec {
   private:
     friend cbor::tags::Access;
@@ -47,6 +55,33 @@ struct failing_decoder_codec {
         return expected<void, codec_error>{cbor::tags::unexpected<codec_error>{codec_error{status_code::invalid_utf8_sequence}}};
     }
 };
+
+struct status_only_encoder_codec {
+  private:
+    friend cbor::tags::Access;
+
+    template <typename Encoder> auto encode(Encoder &) const { return status_result_without_bool{true, status_code::success}; }
+};
+
+struct status_only_member_transcode {
+    template <typename Decoder> auto transcode(Decoder &) { return status_result_without_bool{false, status_code::unexpected_group_size}; }
+};
+
+struct status_only_member_decode {
+    template <typename Decoder> auto decode(Decoder &) { return status_result_without_bool{false, status_code::invalid_utf8_sequence}; }
+};
+
+struct status_only_free_decode {};
+
+template <typename Decoder> auto decode(Decoder &, status_only_free_decode &&) {
+    return status_result_without_bool{false, status_code::no_match_for_tstr_on_buffer};
+}
+
+struct status_only_free_transcode {};
+
+template <typename Decoder> auto transcode(Decoder &, status_only_free_transcode &&) {
+    return status_result_without_bool{true, status_code::success};
+}
 
 #if CBOR_TAGS_USE_STD_EXPECTED
 template <typename T> inline constexpr bool             is_configured_expected_v                       = false;
@@ -129,4 +164,36 @@ TEST_CASE("custom codecs accept errors convertible to status code") {
     auto decode_result = dec(value);
     REQUIRE_FALSE(decode_result);
     CHECK_EQ(decode_result.error(), status_code::invalid_utf8_sequence);
+}
+
+TEST_CASE("custom codec results do not require contextual bool conversion") {
+    static_assert(!std::convertible_to<status_result_without_bool, bool>);
+
+    std::vector<std::byte> output;
+    auto                   enc = make_encoder(output);
+    REQUIRE(enc(status_only_encoder_codec{}));
+
+    const auto input = to_bytes("00");
+
+    status_only_member_transcode member_transcode;
+    auto                         member_transcode_dec    = make_decoder(input);
+    auto                         member_transcode_result = member_transcode_dec(member_transcode);
+    REQUIRE_FALSE(member_transcode_result);
+    CHECK_EQ(member_transcode_result.error(), status_code::unexpected_group_size);
+
+    status_only_member_decode member_decode;
+    auto                      member_decode_dec    = make_decoder(input);
+    auto                      member_decode_result = member_decode_dec(member_decode);
+    REQUIRE_FALSE(member_decode_result);
+    CHECK_EQ(member_decode_result.error(), status_code::invalid_utf8_sequence);
+
+    status_only_free_decode free_decode;
+    auto                    free_decode_dec    = make_decoder(input);
+    auto                    free_decode_result = free_decode_dec(free_decode);
+    REQUIRE_FALSE(free_decode_result);
+    CHECK_EQ(free_decode_result.error(), status_code::no_match_for_tstr_on_buffer);
+
+    status_only_free_transcode free_transcode;
+    auto                       free_transcode_dec = make_decoder(input);
+    REQUIRE(free_transcode_dec(free_transcode));
 }

--- a/test/test_expected_backend.cpp
+++ b/test/test_expected_backend.cpp
@@ -20,6 +20,10 @@ using namespace cbor::tags;
 
 namespace {
 
+struct alternate_error {
+    int value;
+};
+
 #if CBOR_TAGS_USE_STD_EXPECTED
 template <typename T> inline constexpr bool             is_configured_expected_v                       = false;
 template <typename T> inline constexpr bool             is_configured_unexpected_v                     = false;
@@ -33,6 +37,18 @@ template <typename E> inline constexpr bool             is_configured_unexpected
 #endif
 
 } // namespace
+
+TEST_CASE("configured expected backend preserves requested error type") {
+    using result_type = expected<int, alternate_error>;
+
+    static_assert(is_configured_expected_v<result_type>);
+    static_assert(std::is_same_v<typename result_type::error_type, alternate_error>);
+
+    result_type result = unexpected<alternate_error>{alternate_error{7}};
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error().value, 7);
+}
 
 TEST_CASE("default return type uses configured expected backend") {
     static_assert(is_configured_expected_v<expected<void, status_code>>);

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -652,13 +652,15 @@ TEST_CASE("shared graph codec rejects cycles") {
     std::shared_ptr<smart_ptr_test::graph_link> decoded;
     auto                                        dec = make_decoder<shared_graph_codec>(cycle_bytes);
     shared_graph_decode_session                 decode_graph;
-    const auto                                  decode_result = dec(as_shared_graph(decode_graph, decoded));
+    const auto                                  decode_result      = dec(as_shared_graph(decode_graph, decoded));
+    const bool                                  decoded_cycle_root = static_cast<bool>(decoded);
     if (decoded) {
         decoded->next.reset();
     }
 
     REQUIRE_FALSE(decode_result);
     CHECK_EQ(decode_result.error(), status_code::error);
+    CHECK_FALSE(decoded_cycle_root);
 }
 
 TEST_CASE("shared graph codec rejects malformed wrappers before consuming following items") {

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -638,6 +638,7 @@ TEST_CASE("shared graph codec rejects cycles") {
     auto                        enc = make_encoder<shared_graph_codec>(buffer);
     shared_graph_encode_session encode_graph;
     const auto                  encode_result = enc(as_shared_graph(encode_graph, link));
+    link->next.reset();
 
     REQUIRE_FALSE(encode_result);
     CHECK_EQ(encode_result.error(), status_code::error);
@@ -652,6 +653,9 @@ TEST_CASE("shared graph codec rejects cycles") {
     auto                                        dec = make_decoder<shared_graph_codec>(cycle_bytes);
     shared_graph_decode_session                 decode_graph;
     const auto                                  decode_result = dec(as_shared_graph(decode_graph, decoded));
+    if (decoded) {
+        decoded->next.reset();
+    }
 
     REQUIRE_FALSE(decode_result);
     CHECK_EQ(decode_result.error(), status_code::error);


### PR DESCRIPTION
## Summary

- preserve the caller-provided error type in the public `expected<T, E>` alias for both standard-library and `tl::expected` backends
- add compile-time and runtime coverage for a non-default error type
- break deliberately cyclic smart-pointer fixtures after decoding so sanitizer runs test the decoder without leaking test-owned cycles

## Validation

- C++20 (`tl::expected`): 31/31 CTest tests passed
- C++23 (`std::expected`): 31/31 CTest tests passed
- ASan/LSan/UBSan: 871 test cases and 805428 assertions passed with leak detection enabled