### PR TITLE
Fix decoder string append semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,13 @@ dec(destination);
 assert(destination == "prefix:payload");
 ```
 
-A truncated definite string is validated before its destination is modified. For
-an indefinite string or container, successfully decoded chunks or elements remain
-in the destination if a later chunk or element fails. Fixed-size destinations and
-borrowed views retain their exact-size or assignment semantics.
+A definite string validates its complete payload and any required capacity before
+appending. If a later target allocation fails, its semantic value is restored.
+Mutable destinations that overlap the decoder input are rejected with
+`status_code::error`; use separate input and output storage. For an indefinite
+string or container, successfully decoded chunks or elements remain in the
+destination if a later chunk or element fails. Fixed-size destinations and borrowed
+views retain their exact-size or assignment semantics.
 
 Equivalent to manually encoding the struct in the following example:
 ```cpp

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ enc(tagged);
 > [!NOTE]
 > The definition of a tag is a CBOR major type 6 encoded uint, with a concise data definition format of #6.321(any). This allows generic parsers to decode tags without knowing their semantic meaning or the exact order of internal items. It also means the struct implicitly define a cbor array of exact types following the tag, i.e #6.321([int, float64, tstr]). See tuning options for more details.
 
+The core CBOR decoder accumulates into mutable owning sequence destinations. Arrays,
+maps, byte strings, and text strings are appended to or inserted into; it does not
+clear an existing destination. Initialize the destination empty when replacement
+semantics are wanted. Codec extensions can define a different destination contract.
+
+```cpp
+std::string source = "payload";
+std::vector<std::byte> buffer;
+auto enc = make_encoder(buffer);
+enc(source);
+
+std::string destination = "prefix:";
+auto dec = make_decoder(buffer);
+dec(destination);
+assert(destination == "prefix:payload");
+```
+
+A truncated definite string is validated before its destination is modified. For
+an indefinite string or container, successfully decoded chunks or elements remain
+in the destination if a later chunk or element fails. Fixed-size destinations and
+borrowed views retain their exact-size or assignment semantics.
+
 Equivalent to manually encoding the struct in the following example:
 ```cpp
 Tagged tagged{.a = 2, .b = 3.14, .c = "Hello, World!"};

--- a/README.md
+++ b/README.md
@@ -144,13 +144,18 @@ dec(destination);
 assert(destination == "prefix:payload");
 ```
 
-A definite string validates its complete payload and any required capacity before
-appending. If a later target allocation fails, its semantic value is restored.
-Mutable destinations that overlap the decoder input are rejected with
-`status_code::error`; use separate input and output storage. For an indefinite
-string or container, successfully decoded chunks or elements remain in the
-destination if a later chunk or element fails. Fixed-size destinations and borrowed
-views retain their exact-size or assignment semantics.
+A definite string validates its complete payload before appending, so malformed or
+truncated input leaves the destination unchanged. Reservable destinations request
+the final capacity before mutation. Once appending begins, successfully appended
+values are not rolled back if the destination itself throws, matching the
+incremental behavior of indefinite strings and containers. A destination may
+provide a stronger insertion guarantee of its own.
+
+Mutable contiguous destinations whose exposed storage overlaps the decoder input
+are rejected with `status_code::error`; use separate input and output storage.
+Custom destinations must not write into decoder input storage that is not exposed
+by their range. Fixed-size destinations and borrowed views retain their exact-size
+or assignment semantics.
 
 Equivalent to manually encoding the struct in the following example:
 ```cpp

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -795,7 +795,6 @@ template <IsUnsigned T> struct dynamic_tag {
 
 template <typename T>
 concept HasReserve = requires(T t) {
-    { t.size() } -> std::convertible_to<typename T::size_type>;
     { t.reserve(std::declval<typename T::size_type>()) };
 };
 

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -795,6 +795,7 @@ template <IsUnsigned T> struct dynamic_tag {
 
 template <typename T>
 concept HasReserve = requires(T t) {
+    { t.size() } -> std::convertible_to<typename T::size_type>;
     { t.reserve(std::declval<typename T::size_type>()) };
 };
 

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -51,6 +51,25 @@ template <typename T> constexpr bool negative_argument_fits(std::uint64_t value)
     return value <= max_cbor_argument;
 }
 
+template <HasReserve T> constexpr void reserve_for_append(T &value, std::uint64_t additional_size) {
+    using size_type = typename T::size_type;
+
+    const auto current_size = value.size();
+    const auto maximum_size = [&]() {
+        if constexpr (requires { value.max_size(); }) {
+            return value.max_size();
+        } else {
+            return std::numeric_limits<size_type>::max();
+        }
+    }();
+
+    if (std::cmp_greater(current_size, maximum_size) || std::cmp_greater(additional_size, maximum_size - current_size)) {
+        throw std::length_error("CBOR string length exceeds target container max_size");
+    }
+
+    value.reserve(static_cast<size_type>(current_size + static_cast<size_type>(additional_size)));
+}
+
 template <typename InputBuffer, typename Reader>
 constexpr status_code skip_sized_string_payload(Reader &reader, const InputBuffer &data, std::uint64_t length) {
     using size_type = typename Reader::size_type;
@@ -265,22 +284,17 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         } else if constexpr (IsFixedArray<T>) {
             std::ranges::copy(bstring, t.begin());
         } else {
-            auto decoded = detail::make_decode_value_for<T>(t);
             if constexpr (HasReserve<T>) {
-                if (std::cmp_greater(bstring_size, std::numeric_limits<typename T::size_type>::max())) {
-                    throw std::length_error("CBOR byte string length exceeds target container size_type");
-                }
-                decoded.reserve(static_cast<typename T::size_type>(bstring_size));
+                detail::reserve_for_append(t, bstring_size);
             }
             detail::appender<T> appender_;
             if constexpr (IsContiguous<decltype(bstring)>) {
-                appender_(decoded, bstring);
+                appender_(t, bstring);
             } else {
                 for (auto byte_value : bstring) {
-                    appender_(decoded, static_cast<typename T::value_type>(byte_value));
+                    appender_(t, static_cast<typename T::value_type>(byte_value));
                 }
             }
-            t = std::move(decoded);
         }
 
         return status_code::success;
@@ -309,8 +323,23 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         }
 
-        // Decode the text string
-        t = decode_text(additionalInfo);
+        // Decode the complete payload before mutating an owning target.
+        auto text = decode_text(additionalInfo);
+        if constexpr (IsConstView<T>) {
+            t = std::move(text);
+        } else {
+            if constexpr (HasReserve<T> && std::ranges::sized_range<decltype(text)>) {
+                detail::reserve_for_append(t, std::ranges::size(text));
+            }
+            detail::appender<T> appender_;
+            if constexpr (IsContiguous<decltype(text)>) {
+                appender_(t, text);
+            } else {
+                for (auto character : text) {
+                    appender_(t, static_cast<typename T::value_type>(character));
+                }
+            }
+        }
 
         return status_code::success;
     }
@@ -630,7 +659,17 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return decode_indef_tstr(value);
         }
         auto text = decode_text(additionalInfo);
-        value     = std::string(text);
+        if constexpr (std::ranges::sized_range<decltype(text)>) {
+            detail::reserve_for_append(value, std::ranges::size(text));
+        }
+        detail::appender<std::string> appender_;
+        if constexpr (IsContiguous<decltype(text)>) {
+            appender_(value, text);
+        } else {
+            for (auto character : text) {
+                appender_(value, static_cast<char>(character));
+            }
+        }
         return status_code::success;
     }
 

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -18,6 +18,7 @@
 // #include <fmt/base.h>
 // #include <fmt/ranges.h>
 #include <exception>
+#include <functional>
 // #include <fmt/base.h>
 #include <iterator>
 #include <new>
@@ -37,7 +38,6 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
-#include <vector>
 
 namespace cbor::tags {
 
@@ -53,7 +53,12 @@ template <typename T> constexpr bool negative_argument_fits(std::uint64_t value)
     return value <= max_cbor_argument;
 }
 
-template <HasReserve T> constexpr void reserve_for_append(T &value, std::uint64_t additional_size) {
+template <typename T>
+concept AppendReservable = HasReserve<T> && requires(const T &value) {
+    { value.size() } -> std::convertible_to<typename T::size_type>;
+};
+
+template <AppendReservable T> constexpr void reserve_for_append(T &value, std::uint64_t additional_size) {
     using size_type = typename T::size_type;
 
     const auto current_size = value.size();
@@ -272,7 +277,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 return status_code::error;
             }
         }
-        if constexpr (!IsConstView<T> && !IsFixedArray<T> && HasReserve<T>) {
+        if constexpr (!IsConstView<T> && !IsFixedArray<T> && detail::AppendReservable<T>) {
             detail::reserve_for_append(t, bstring_size);
         }
 
@@ -297,7 +302,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         } else if constexpr (IsFixedArray<T>) {
             std::ranges::copy(bstring, t.begin());
         } else {
-            append_definite_string(t, bstring, bstring_size);
+            append_definite_string(t, bstring);
         }
 
         return status_code::success;
@@ -332,16 +337,16 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             if (string_target_aliases_input(t)) {
                 return status_code::error;
             }
-            if constexpr (HasReserve<T>) {
-                detail::reserve_for_append(t, text_size);
-            }
+        }
+        if constexpr (!IsConstView<T> && detail::AppendReservable<T>) {
+            detail::reserve_for_append(t, text_size);
         }
 
         auto text = decode_text_payload(text_size);
         if constexpr (IsConstView<T>) {
             t = std::move(text);
         } else {
-            append_definite_string(t, text, text_size);
+            append_definite_string(t, text);
         }
 
         return status_code::success;
@@ -668,7 +673,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
         detail::reserve_for_append(value, text_size);
         auto text = decode_text_payload(text_size);
-        append_definite_string(value, text, text_size);
+        append_definite_string(value, text);
         return status_code::success;
     }
 
@@ -1360,49 +1365,30 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 return false;
             }
 
-            const auto *target_begin = std::ranges::data(target);
-            const auto *target_end   = target_begin + std::ranges::size(target);
-            const auto *input_begin  = std::ranges::data(data_);
-            const auto *input_end    = input_begin + std::ranges::size(data_);
+            const auto *target_data = std::ranges::data(target);
+            const auto *input_data  = std::ranges::data(data_);
+            const auto *target_end  = target_data + std::ranges::size(target);
+            const auto *input_end   = input_data + std::ranges::size(data_);
 
-            const auto target_begin_address = reinterpret_cast<std::uintptr_t>(target_begin);
-            const auto target_end_address   = reinterpret_cast<std::uintptr_t>(target_end);
-            const auto input_begin_address  = reinterpret_cast<std::uintptr_t>(input_begin);
-            const auto input_end_address    = reinterpret_cast<std::uintptr_t>(input_end);
-            return input_begin_address < target_end_address && target_begin_address < input_end_address;
+            const auto before = std::less<const void *>{};
+            return before(input_data, target_end) && before(target_data, input_end);
         }
 
         return false;
     }
 
-    template <typename T, std::ranges::input_range R>
-    constexpr void append_definite_string(T &target, R &&payload, std::uint64_t payload_size) {
-        detail::appender<T> appender_;
-        if constexpr (HasReserve<T>) {
-            if constexpr (IsContiguous<R>) {
-                appender_(target, payload);
-            } else {
-                for (auto value : payload) {
-                    appender_(target, static_cast<typename T::value_type>(value));
-                }
-            }
+    template <typename T, std::ranges::input_range R> constexpr void append_definite_string(T &target, R &&payload) {
+        detail::appender<T> append;
+        if constexpr (detail::AppendReservable<T>) {
+            detail::append_byte_range(append, target, std::forward<R>(payload));
         } else {
             static_assert(
                 requires(T &value) { value.pop_back(); }, "non-reservable string targets must support pop_back for failure rollback");
 
-            std::vector<typename T::value_type> staged;
-            if (std::cmp_greater(payload_size, staged.max_size())) {
-                throw std::length_error("CBOR string length exceeds staging container max_size");
-            }
-            staged.reserve(static_cast<std::size_t>(payload_size));
-            for (auto value : payload) {
-                staged.push_back(static_cast<typename T::value_type>(value));
-            }
-
             std::size_t appended = 0;
             try {
-                for (const auto value : staged) {
-                    appender_(target, value);
+                for (auto &&value : payload) {
+                    append(target, static_cast<typename T::value_type>(value));
                     ++appended;
                 }
             } catch (...) {

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -26,6 +26,7 @@
 #include "cbor_tags/cbor_tags_config.h"
 
 #include <limits>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <span>
@@ -36,6 +37,7 @@
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 namespace cbor::tags {
 
@@ -262,7 +264,18 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         }
 
-        // Decode to intermediate form
+        // Validate the complete payload and any allocation before exposing a
+        // borrowed payload that target growth could invalidate.
+        require_bytes(bstring_size);
+        if constexpr (!IsConstView<T>) {
+            if (string_target_aliases_input(t)) {
+                return status_code::error;
+            }
+        }
+        if constexpr (!IsConstView<T> && !IsFixedArray<T> && HasReserve<T>) {
+            detail::reserve_for_append(t, bstring_size);
+        }
+
         auto bstring = decode_bstring_payload(bstring_size);
 
         // Now handle the target assignment based on contiguity constraints
@@ -284,17 +297,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         } else if constexpr (IsFixedArray<T>) {
             std::ranges::copy(bstring, t.begin());
         } else {
-            if constexpr (HasReserve<T>) {
-                detail::reserve_for_append(t, bstring_size);
-            }
-            detail::appender<T> appender_;
-            if constexpr (IsContiguous<decltype(bstring)>) {
-                appender_(t, bstring);
-            } else {
-                for (auto byte_value : bstring) {
-                    appender_(t, static_cast<typename T::value_type>(byte_value));
-                }
-            }
+            append_definite_string(t, bstring, bstring_size);
         }
 
         return status_code::success;
@@ -323,22 +326,22 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         }
 
-        // Decode the complete payload before mutating an owning target.
-        auto text = decode_text(additionalInfo);
+        const auto text_size = decode_unsigned(additionalInfo);
+        require_bytes(text_size);
+        if constexpr (!IsConstView<T>) {
+            if (string_target_aliases_input(t)) {
+                return status_code::error;
+            }
+            if constexpr (HasReserve<T>) {
+                detail::reserve_for_append(t, text_size);
+            }
+        }
+
+        auto text = decode_text_payload(text_size);
         if constexpr (IsConstView<T>) {
             t = std::move(text);
         } else {
-            if constexpr (HasReserve<T> && std::ranges::sized_range<decltype(text)>) {
-                detail::reserve_for_append(t, std::ranges::size(text));
-            }
-            detail::appender<T> appender_;
-            if constexpr (IsContiguous<decltype(text)>) {
-                appender_(t, text);
-            } else {
-                for (auto character : text) {
-                    appender_(t, static_cast<typename T::value_type>(character));
-                }
-            }
+            append_definite_string(t, text, text_size);
         }
 
         return status_code::success;
@@ -658,18 +661,14 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         if (additionalInfo == static_cast<byte>(31)) {
             return decode_indef_tstr(value);
         }
-        auto text = decode_text(additionalInfo);
-        if constexpr (std::ranges::sized_range<decltype(text)>) {
-            detail::reserve_for_append(value, std::ranges::size(text));
+        const auto text_size = decode_unsigned(additionalInfo);
+        require_bytes(text_size);
+        if (string_target_aliases_input(value)) {
+            return status_code::error;
         }
-        detail::appender<std::string> appender_;
-        if constexpr (IsContiguous<decltype(text)>) {
-            appender_(value, text);
-        } else {
-            for (auto character : text) {
-                appender_(value, static_cast<char>(character));
-            }
-        }
+        detail::reserve_for_append(value, text_size);
+        auto text = decode_text_payload(text_size);
+        append_definite_string(value, text, text_size);
         return status_code::success;
     }
 
@@ -995,8 +994,9 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
     }
 
-    constexpr auto decode_text(byte additionalInfo) {
-        const auto length      = decode_unsigned(additionalInfo);
+    constexpr auto decode_text(byte additionalInfo) { return decode_text_payload(decode_unsigned(additionalInfo)); }
+
+    constexpr auto decode_text_payload(std::uint64_t length) {
         const auto span_length = require_bytes(length);
 
         if constexpr (IsContiguous<InputBuffer>) {
@@ -1347,6 +1347,74 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
     reader_type        reader_;
 
   private:
+    template <typename T> constexpr bool string_target_aliases_input(const T &target) const {
+        if constexpr (std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<InputBuffer>>) {
+            if (std::addressof(target) == std::addressof(data_)) {
+                return true;
+            }
+        }
+
+        if constexpr (std::ranges::contiguous_range<const T> && std::ranges::sized_range<const T> &&
+                      std::ranges::contiguous_range<const InputBuffer> && std::ranges::sized_range<const InputBuffer>) {
+            if (std::ranges::empty(target) || std::ranges::empty(data_) || std::is_constant_evaluated()) {
+                return false;
+            }
+
+            const auto *target_begin = std::ranges::data(target);
+            const auto *target_end   = target_begin + std::ranges::size(target);
+            const auto *input_begin  = std::ranges::data(data_);
+            const auto *input_end    = input_begin + std::ranges::size(data_);
+
+            const auto target_begin_address = reinterpret_cast<std::uintptr_t>(target_begin);
+            const auto target_end_address   = reinterpret_cast<std::uintptr_t>(target_end);
+            const auto input_begin_address  = reinterpret_cast<std::uintptr_t>(input_begin);
+            const auto input_end_address    = reinterpret_cast<std::uintptr_t>(input_end);
+            return input_begin_address < target_end_address && target_begin_address < input_end_address;
+        }
+
+        return false;
+    }
+
+    template <typename T, std::ranges::input_range R>
+    constexpr void append_definite_string(T &target, R &&payload, std::uint64_t payload_size) {
+        detail::appender<T> appender_;
+        if constexpr (HasReserve<T>) {
+            if constexpr (IsContiguous<R>) {
+                appender_(target, payload);
+            } else {
+                for (auto value : payload) {
+                    appender_(target, static_cast<typename T::value_type>(value));
+                }
+            }
+        } else {
+            static_assert(
+                requires(T &value) { value.pop_back(); }, "non-reservable string targets must support pop_back for failure rollback");
+
+            std::vector<typename T::value_type> staged;
+            if (std::cmp_greater(payload_size, staged.max_size())) {
+                throw std::length_error("CBOR string length exceeds staging container max_size");
+            }
+            staged.reserve(static_cast<std::size_t>(payload_size));
+            for (auto value : payload) {
+                staged.push_back(static_cast<typename T::value_type>(value));
+            }
+
+            std::size_t appended = 0;
+            try {
+                for (const auto value : staged) {
+                    appender_(target, value);
+                    ++appended;
+                }
+            } catch (...) {
+                while (appended != 0) {
+                    target.pop_back();
+                    --appended;
+                }
+                throw;
+            }
+        }
+    }
+
     // Keep std::variant on the original pack-based fast path; generic trait-backed variant dispatch is slower here.
     template <typename... T>
     constexpr status_code decode_variant(std::variant<T...> &value, major_type major, byte additionalInfo,

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -53,30 +53,6 @@ template <typename T> constexpr bool negative_argument_fits(std::uint64_t value)
     return value <= max_cbor_argument;
 }
 
-template <typename T>
-concept AppendReservable = HasReserve<T> && requires(const T &value) {
-    { value.size() } -> std::convertible_to<typename T::size_type>;
-};
-
-template <AppendReservable T> constexpr void reserve_for_append(T &value, std::uint64_t additional_size) {
-    using size_type = typename T::size_type;
-
-    const auto current_size = value.size();
-    const auto maximum_size = [&]() {
-        if constexpr (requires { value.max_size(); }) {
-            return value.max_size();
-        } else {
-            return std::numeric_limits<size_type>::max();
-        }
-    }();
-
-    if (std::cmp_greater(current_size, maximum_size) || std::cmp_greater(additional_size, maximum_size - current_size)) {
-        throw std::length_error("CBOR string length exceeds target container max_size");
-    }
-
-    value.reserve(static_cast<size_type>(current_size + static_cast<size_type>(additional_size)));
-}
-
 template <typename InputBuffer, typename Reader>
 constexpr status_code skip_sized_string_payload(Reader &reader, const InputBuffer &data, std::uint64_t length) {
     using size_type = typename Reader::size_type;
@@ -277,8 +253,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 return status_code::error;
             }
         }
-        if constexpr (!IsConstView<T> && !IsFixedArray<T> && detail::AppendReservable<T>) {
-            detail::reserve_for_append(t, bstring_size);
+        if constexpr (!IsConstView<T> && !IsFixedArray<T>) {
+            detail::appender<T>{}.reserve_for_append(t, bstring_size);
         }
 
         auto bstring = decode_bstring_payload(bstring_size);
@@ -302,7 +278,8 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         } else if constexpr (IsFixedArray<T>) {
             std::ranges::copy(bstring, t.begin());
         } else {
-            append_definite_string(t, bstring);
+            detail::appender<T> append;
+            detail::append_byte_range(append, t, bstring);
         }
 
         return status_code::success;
@@ -338,15 +315,16 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 return status_code::error;
             }
         }
-        if constexpr (!IsConstView<T> && detail::AppendReservable<T>) {
-            detail::reserve_for_append(t, text_size);
+        if constexpr (!IsConstView<T>) {
+            detail::appender<T>{}.reserve_for_append(t, text_size);
         }
 
         auto text = decode_text_payload(text_size);
         if constexpr (IsConstView<T>) {
             t = std::move(text);
         } else {
-            append_definite_string(t, text);
+            detail::appender<T> append;
+            detail::append_byte_range(append, t, text);
         }
 
         return status_code::success;
@@ -671,9 +649,10 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         if (string_target_aliases_input(value)) {
             return status_code::error;
         }
-        detail::reserve_for_append(value, text_size);
+        detail::appender<std::string> append;
+        append.reserve_for_append(value, text_size);
         auto text = decode_text_payload(text_size);
-        append_definite_string(value, text);
+        detail::append_byte_range(append, value, text);
         return status_code::success;
     }
 
@@ -1375,30 +1354,6 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         }
 
         return false;
-    }
-
-    template <typename T, std::ranges::input_range R> constexpr void append_definite_string(T &target, R &&payload) {
-        detail::appender<T> append;
-        if constexpr (detail::AppendReservable<T>) {
-            detail::append_byte_range(append, target, std::forward<R>(payload));
-        } else {
-            static_assert(
-                requires(T &value) { value.pop_back(); }, "non-reservable string targets must support pop_back for failure rollback");
-
-            std::size_t appended = 0;
-            try {
-                for (auto &&value : payload) {
-                    append(target, static_cast<typename T::value_type>(value));
-                    ++appended;
-                }
-            } catch (...) {
-                while (appended != 0) {
-                    target.pop_back();
-                    --appended;
-                }
-                throw;
-            }
-        }
     }
 
     // Keep std::variant on the original pack-based fast path; generic trait-backed variant dispatch is slower here.

--- a/include/cbor_tags/cbor_detail.h
+++ b/include/cbor_tags/cbor_detail.h
@@ -6,6 +6,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iterator>
 #include <limits>
@@ -25,6 +26,11 @@ template <typename T>
 concept AppendableContainer = requires {
     typename T::value_type;
     typename T::size_type;
+};
+
+template <typename T>
+concept AppendReservable = HasReserve<T> && requires(const T &value) {
+    { value.size() } -> std::convertible_to<typename T::size_type>;
 };
 
 template <typename T, bool IsArray = IsFixedArray<T>>
@@ -82,6 +88,27 @@ concept AssignableInsertOrAssignMap = IsMap<Container> && IsPairLike<Pair> && re
 
 template <typename T> struct appender<T, false> {
     using value_type = T::value_type;
+
+    constexpr void reserve_for_append(T &container, std::uint64_t additional_size) const {
+        if constexpr (AppendReservable<T>) {
+            using size_type = typename T::size_type;
+
+            const auto current_size = container.size();
+            const auto maximum_size = [&]() {
+                if constexpr (requires { container.max_size(); }) {
+                    return container.max_size();
+                } else {
+                    return std::numeric_limits<size_type>::max();
+                }
+            }();
+
+            if (std::cmp_greater(current_size, maximum_size) || std::cmp_greater(additional_size, maximum_size - current_size)) {
+                throw std::length_error("CBOR string length exceeds target container max_size");
+            }
+
+            container.reserve(static_cast<size_type>(current_size + static_cast<size_type>(additional_size)));
+        }
+    }
 
     constexpr void operator()(T &container, const value_type &value)
         requires(!IsMap<T>)

--- a/test/test_cbor_tags.cpp
+++ b/test/test_cbor_tags.cpp
@@ -454,7 +454,7 @@ TEST_CASE("Switching instead of variant") {
             break;
         }
         case 141: {
-            F2 f2;
+            F2 f2{.s = {}};
             result = dec(f2);
             REQUIRE(result);
             CHECK_EQ(f2.s, "43");

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -129,6 +129,33 @@ struct ReserveWithoutSizeByteBuffer {
     void               pop_back() { bytes.pop_back(); }
 };
 
+struct ExternalByteBuffer {
+    using value_type = std::byte;
+    using size_type  = std::size_t;
+
+    std::byte *storage{};
+    size_type  current_size{};
+    size_type  capacity{};
+
+    [[nodiscard]] auto begin() noexcept { return storage; }
+    [[nodiscard]] auto begin() const noexcept { return static_cast<const std::byte *>(storage); }
+    [[nodiscard]] auto end() noexcept { return storage + current_size; }
+    [[nodiscard]] auto end() const noexcept { return static_cast<const std::byte *>(storage) + current_size; }
+    [[nodiscard]] auto size() const noexcept { return current_size; }
+    void               push_back(value_type value) {
+        if (current_size == capacity) {
+            throw std::length_error("external byte buffer is full");
+        }
+        storage[current_size++] = value;
+    }
+    void insert(std::byte *, const std::byte *first, const std::byte *last) {
+        for (; first != last; ++first) {
+            push_back(*first);
+        }
+    }
+    void pop_back() { --current_size; }
+};
+
 struct controlled_memory_resource : std::pmr::memory_resource {
     std::pmr::memory_resource *upstream{std::pmr::new_delete_resource()};
     std::size_t                allocations_before_failure{std::numeric_limits<std::size_t>::max()};
@@ -161,7 +188,9 @@ static_assert(std::same_as<typename decltype(make_decoder(std::declval<AdlSizedB
 static_assert(CborInputBuffer<SignedSizeDequeByteRange>);
 static_assert(std::same_as<typename decltype(make_decoder(std::declval<SignedSizeDequeByteRange &>()))::size_type, int>);
 static_assert(IsBinaryString<ReserveWithoutSizeByteBuffer>);
-static_assert(!HasReserve<ReserveWithoutSizeByteBuffer>);
+static_assert(HasReserve<ReserveWithoutSizeByteBuffer>);
+static_assert(!detail::AppendReservable<ReserveWithoutSizeByteBuffer>);
+static_assert(IsBinaryString<ExternalByteBuffer>);
 
 TEST_CASE("float16 should cover infinity nan and subnormal conversions") {
     CHECK(std::isinf(static_cast<float>(float16_t{static_cast<std::uint16_t>(0x7C00)})));
@@ -584,6 +613,41 @@ TEST_CASE("decoder rejects definite string targets that alias input storage") {
         CHECK_EQ(result.error(), status_code::error);
         CHECK_EQ(storage, original);
     }
+
+    SUBCASE("input span starts inside byte vector") {
+        std::vector<std::byte> storage{std::byte{0x00}, std::byte{0x43}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}};
+        const auto             original = storage;
+        const auto             input    = std::span<const std::byte>{storage}.subspan(1);
+        auto                   dec      = make_decoder(input);
+        auto                   result   = dec(storage);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK_EQ(storage, original);
+    }
+
+    SUBCASE("mutable target starts inside input") {
+        std::vector<std::byte> input{std::byte{0x41}, std::byte{0xAA}, std::byte{0x00}};
+        const auto             original = input;
+        ExternalByteBuffer     target{input.data() + 1, 1, 2};
+        auto                   dec    = make_decoder(input);
+        auto                   result = dec(target);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK_EQ(input, original);
+    }
+
+    SUBCASE("adjacent input and target ranges do not overlap") {
+        std::vector<std::byte> storage{std::byte{0x41}, std::byte{0xAA}, std::byte{0x00}, std::byte{0x00}};
+        const auto             input = std::span<const std::byte>{storage}.first<2>();
+        ExternalByteBuffer     target{storage.data() + 2, 1, 2};
+        auto                   dec = make_decoder(input);
+
+        REQUIRE(dec(target));
+        REQUIRE_EQ(target.size(), 2);
+        CHECK_EQ(target.storage[1], std::byte{0xAA});
+    }
 }
 
 TEST_CASE("decoder reserves non-contiguous definite text before mutation") {
@@ -619,7 +683,7 @@ TEST_CASE("decoder rolls back non-reservable definite string append failures") {
     CHECK_EQ(decoded.front(), std::byte{0x01});
 }
 
-TEST_CASE("reserve without size falls back to staged definite string append") {
+TEST_CASE("reserve without size falls back to rollback-capable append") {
     const std::deque<std::byte>  input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
     ReserveWithoutSizeByteBuffer decoded{{std::byte{0x01}}};
 

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -10,10 +10,12 @@
 #include <deque>
 #include <doctest/doctest.h>
 #include <limits>
+#include <list>
 #include <map>
 #include <memory>
 #include <memory_resource>
 #include <ranges>
+#include <span>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -111,6 +113,39 @@ struct SignedSizeDequeByteRange {
     [[nodiscard]] auto end() const noexcept { return bytes.end(); }
     [[nodiscard]] auto size() const noexcept { return static_cast<size_type>(bytes.size()); }
 };
+
+struct ReserveWithoutSizeByteBuffer {
+    using value_type = std::byte;
+    using size_type  = std::size_t;
+
+    std::vector<std::byte> bytes;
+
+    [[nodiscard]] auto begin() noexcept { return bytes.begin(); }
+    [[nodiscard]] auto begin() const noexcept { return bytes.begin(); }
+    [[nodiscard]] auto end() noexcept { return bytes.end(); }
+    [[nodiscard]] auto end() const noexcept { return bytes.end(); }
+    void               reserve(size_type count) { bytes.reserve(count); }
+    void               push_back(value_type value) { bytes.push_back(value); }
+    void               pop_back() { bytes.pop_back(); }
+};
+
+struct controlled_memory_resource : std::pmr::memory_resource {
+    std::pmr::memory_resource *upstream{std::pmr::new_delete_resource()};
+    std::size_t                allocations_before_failure{std::numeric_limits<std::size_t>::max()};
+
+  private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+        if (allocations_before_failure == 0) {
+            throw std::bad_alloc{};
+        }
+        --allocations_before_failure;
+        return upstream->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void *ptr, std::size_t bytes, std::size_t alignment) override { upstream->deallocate(ptr, bytes, alignment); }
+
+    bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
+};
 } // namespace
 
 static_assert(!std::is_default_constructible_v<NonDefaultComparator>);
@@ -125,6 +160,8 @@ static_assert(CborInputBuffer<AdlSizedByteRange>);
 static_assert(std::same_as<typename decltype(make_decoder(std::declval<AdlSizedByteRange &>()))::size_type, std::uint16_t>);
 static_assert(CborInputBuffer<SignedSizeDequeByteRange>);
 static_assert(std::same_as<typename decltype(make_decoder(std::declval<SignedSizeDequeByteRange &>()))::size_type, int>);
+static_assert(IsBinaryString<ReserveWithoutSizeByteBuffer>);
+static_assert(!HasReserve<ReserveWithoutSizeByteBuffer>);
 
 TEST_CASE("float16 should cover infinity nan and subnormal conversions") {
     CHECK(std::isinf(static_cast<float>(float16_t{static_cast<std::uint16_t>(0x7C00)})));
@@ -509,6 +546,88 @@ TEST_CASE("decoder leaves mutable strings unchanged for truncated definite paylo
         CHECK_EQ(result.error(), status_code::incomplete);
         CHECK_EQ(decoded, "prefix");
     }
+}
+
+TEST_CASE("decoder rejects definite string targets that alias input storage") {
+    SUBCASE("same byte vector") {
+        std::vector<std::byte> input{std::byte{0x43}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}};
+        const auto             original = input;
+        auto                   dec      = make_decoder(input);
+        auto                   result   = dec(input);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK_EQ(input, original);
+    }
+
+    SUBCASE("same text string") {
+        std::string input{"\x63"
+                          "abc",
+                          4};
+        const auto  original = input;
+        auto        dec      = make_decoder(input);
+        auto        result   = dec(input);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK_EQ(input, original);
+    }
+
+    SUBCASE("input span overlaps byte vector") {
+        std::vector<std::byte> storage{std::byte{0x43}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}};
+        const auto             original = storage;
+        const auto             input    = std::span<const std::byte>{storage};
+        auto                   dec      = make_decoder(input);
+        auto                   result   = dec(storage);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK_EQ(storage, original);
+    }
+}
+
+TEST_CASE("decoder reserves non-contiguous definite text before mutation") {
+    std::deque<std::byte> input{std::byte{0x78}, std::byte{0x40}};
+    input.insert(input.end(), 64, std::byte{'x'});
+
+    controlled_memory_resource resource;
+    std::pmr::string           decoded{"prefix", &resource};
+    const auto                 original = std::string{decoded};
+    resource.allocations_before_failure = 0;
+
+    auto dec    = make_decoder(input);
+    auto result = dec(decoded);
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::out_of_memory);
+    CHECK_EQ(std::string_view{decoded}, original);
+}
+
+TEST_CASE("decoder rolls back non-reservable definite string append failures") {
+    const std::vector<std::byte> input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
+    controlled_memory_resource   resource;
+    std::pmr::list<std::byte>    decoded{&resource};
+    decoded.push_back(std::byte{0x01});
+    resource.allocations_before_failure = 1;
+
+    auto dec    = make_decoder(input);
+    auto result = dec(decoded);
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::out_of_memory);
+    REQUIRE_EQ(decoded.size(), 1);
+    CHECK_EQ(decoded.front(), std::byte{0x01});
+}
+
+TEST_CASE("reserve without size falls back to staged definite string append") {
+    const std::deque<std::byte>  input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
+    ReserveWithoutSizeByteBuffer decoded{{std::byte{0x01}}};
+
+    auto dec    = make_decoder(input);
+    auto result = dec(decoded);
+
+    REQUIRE(result);
+    CHECK_EQ(decoded.bytes, (std::vector<std::byte>{std::byte{0x01}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}}));
 }
 
 TEST_CASE("decoder should preserve text bytes without utf8 validation") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -12,6 +12,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <memory_resource>
 #include <ranges>
 #include <string>
 #include <string_view>
@@ -465,6 +466,49 @@ TEST_CASE("decoder should accept empty text strings") {
 
     CHECK_MESSAGE(result, "Decoding an empty text string should succeed.");
     CHECK(decoded.empty());
+}
+
+TEST_CASE("decoder appends definite strings to mutable targets") {
+    const std::vector<std::byte> source_bytes{std::byte{0xAA}, std::byte{0xBB}};
+    const std::string            source_text{"payload"};
+    std::vector<std::byte>       buffer;
+    auto                         enc = make_encoder(buffer);
+    REQUIRE(enc(source_bytes, source_text, source_text));
+
+    std::vector<std::byte> decoded_bytes{std::byte{0x01}};
+    std::string            decoded_text{"prefix:"};
+    std::pmr::string       decoded_pmr_text{"pmr:"};
+    auto                   dec    = make_decoder(buffer);
+    auto                   result = dec(decoded_bytes, decoded_text, decoded_pmr_text);
+
+    REQUIRE(result);
+    CHECK_EQ(decoded_bytes, (std::vector<std::byte>{std::byte{0x01}, std::byte{0xAA}, std::byte{0xBB}}));
+    CHECK_EQ(decoded_text, "prefix:payload");
+    CHECK_EQ(decoded_pmr_text, "pmr:payload");
+}
+
+TEST_CASE("decoder leaves mutable strings unchanged for truncated definite payloads") {
+    {
+        const std::vector<std::byte> buffer{std::byte{0x43}, std::byte{0xAA}};
+        std::vector<std::byte>       decoded{std::byte{0x01}};
+        auto                         dec    = make_decoder(buffer);
+        auto                         result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x01}}));
+    }
+
+    {
+        const std::vector<std::byte> buffer{std::byte{0x63}, std::byte{'a'}};
+        std::string                  decoded{"prefix"};
+        auto                         dec    = make_decoder(buffer);
+        auto                         result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_EQ(decoded, "prefix");
+    }
 }
 
 TEST_CASE("decoder should preserve text bytes without utf8 validation") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -10,7 +10,6 @@
 #include <deque>
 #include <doctest/doctest.h>
 #include <limits>
-#include <list>
 #include <map>
 #include <memory>
 #include <memory_resource>
@@ -126,7 +125,34 @@ struct ReserveWithoutSizeByteBuffer {
     [[nodiscard]] auto end() const noexcept { return bytes.end(); }
     void               reserve(size_type count) { bytes.reserve(count); }
     void               push_back(value_type value) { bytes.push_back(value); }
-    void               pop_back() { bytes.pop_back(); }
+};
+
+struct ThrowingReservableByteBuffer {
+    using value_type = std::byte;
+    using size_type  = std::size_t;
+
+    std::vector<std::byte> bytes;
+    size_type              appends_before_failure{std::numeric_limits<size_type>::max()};
+
+    [[nodiscard]] auto begin() noexcept { return bytes.begin(); }
+    [[nodiscard]] auto begin() const noexcept { return bytes.begin(); }
+    [[nodiscard]] auto end() noexcept { return bytes.end(); }
+    [[nodiscard]] auto end() const noexcept { return bytes.end(); }
+    [[nodiscard]] auto size() const noexcept { return bytes.size(); }
+    [[nodiscard]] auto max_size() const noexcept { return bytes.max_size(); }
+    void               reserve(size_type count) { bytes.reserve(count); }
+    void               push_back(value_type value) {
+        if (appends_before_failure == 0) {
+            throw std::bad_alloc{};
+        }
+        --appends_before_failure;
+        bytes.push_back(value);
+    }
+    void insert(std::vector<std::byte>::iterator, const std::byte *first, const std::byte *last) {
+        for (; first != last; ++first) {
+            push_back(*first);
+        }
+    }
 };
 
 struct ExternalByteBuffer {
@@ -190,6 +216,8 @@ static_assert(std::same_as<typename decltype(make_decoder(std::declval<SignedSiz
 static_assert(IsBinaryString<ReserveWithoutSizeByteBuffer>);
 static_assert(HasReserve<ReserveWithoutSizeByteBuffer>);
 static_assert(!detail::AppendReservable<ReserveWithoutSizeByteBuffer>);
+static_assert(IsBinaryString<ThrowingReservableByteBuffer>);
+static_assert(detail::AppendReservable<ThrowingReservableByteBuffer>);
 static_assert(IsBinaryString<ExternalByteBuffer>);
 
 TEST_CASE("float16 should cover infinity nan and subnormal conversions") {
@@ -667,23 +695,34 @@ TEST_CASE("decoder reserves non-contiguous definite text before mutation") {
     CHECK_EQ(std::string_view{decoded}, original);
 }
 
-TEST_CASE("decoder rolls back non-reservable definite string append failures") {
+TEST_CASE("decoder does not roll back non-reservable string appends when the destination fails") {
     const std::vector<std::byte> input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
-    controlled_memory_resource   resource;
-    std::pmr::list<std::byte>    decoded{&resource};
-    decoded.push_back(std::byte{0x01});
-    resource.allocations_before_failure = 1;
+    std::array<std::byte, 2>     storage{std::byte{0x01}, std::byte{0x00}};
+    ExternalByteBuffer           decoded{storage.data(), 1, storage.size()};
 
     auto dec    = make_decoder(input);
     auto result = dec(decoded);
 
     REQUIRE_FALSE(result);
     CHECK_EQ(result.error(), status_code::out_of_memory);
-    REQUIRE_EQ(decoded.size(), 1);
-    CHECK_EQ(decoded.front(), std::byte{0x01});
+    REQUIRE_EQ(decoded.size(), 2);
+    CHECK_EQ(storage[0], std::byte{0x01});
+    CHECK_EQ(storage[1], std::byte{0xAA});
 }
 
-TEST_CASE("reserve without size falls back to rollback-capable append") {
+TEST_CASE("decoder does not roll back reservable string appends when the destination fails") {
+    const std::vector<std::byte> input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
+    ThrowingReservableByteBuffer decoded{{std::byte{0x01}}, 1};
+
+    auto dec    = make_decoder(input);
+    auto result = dec(decoded);
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::out_of_memory);
+    CHECK_EQ(decoded.bytes, (std::vector<std::byte>{std::byte{0x01}, std::byte{0xAA}}));
+}
+
+TEST_CASE("reserve without size falls back to direct append") {
     const std::deque<std::byte>  input{std::byte{0x43}, std::byte{0xAA}, std::byte{0xBB}, std::byte{0xCC}};
     ReserveWithoutSizeByteBuffer decoded{{std::byte{0x01}}};
 

--- a/test/test_indefinite.cpp
+++ b/test/test_indefinite.cpp
@@ -82,14 +82,11 @@ TEST_CASE("decode indefinite bstr into vector") {
 
     auto dec = make_decoder(buffer);
 
-    std::vector<std::byte> decoded;
+    std::vector<std::byte> decoded{std::byte{0x00}};
     auto                   result = dec(decoded);
 
     CHECK_MESSAGE(result, "Decoding an indefinite byte string into a normal vector should succeed.");
-    CHECK_EQ(decoded.size(), 3);
-    CHECK_EQ(decoded[0], std::byte{0x01});
-    CHECK_EQ(decoded[1], std::byte{0x02});
-    CHECK_EQ(decoded[2], std::byte{0x03});
+    CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x00}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}}));
 }
 
 TEST_CASE("decode indefinite bstr with wrong chunk type") {
@@ -110,11 +107,11 @@ TEST_CASE("decode indefinite tstr into string") {
 
     auto dec = make_decoder(buffer);
 
-    std::string decoded;
+    std::string decoded{"prefix:"};
     auto        result = dec(decoded);
 
     CHECK_MESSAGE(result, "Decoding an indefinite text string into a normal string should succeed.");
-    CHECK_EQ(decoded, "abc");
+    CHECK_EQ(decoded, "prefix:abc");
 }
 
 TEST_CASE("decode explicit indefinite tstr from non-contiguous input") {
@@ -276,6 +273,7 @@ TEST_CASE("decode indefinite bstr without break returns incomplete") {
 
     CHECK_FALSE_MESSAGE(result, "Missing break marker should report incomplete.");
     CHECK_EQ(result.error(), status_code::incomplete);
+    CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x01}, std::byte{0xAA}}));
 }
 
 TEST_CASE("decode indefinite bstr with indefinite chunk returns no match") {
@@ -300,6 +298,31 @@ TEST_CASE("decode indefinite bstr with truncated chunk returns incomplete") {
 
     CHECK_FALSE_MESSAGE(result, "Truncated chunk payload should report incomplete.");
     CHECK_EQ(result.error(), status_code::incomplete);
+    CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0xFF}}));
+}
+
+TEST_CASE("decode indefinite strings retain completed chunks before malformed input") {
+    {
+        const std::vector<std::byte> buffer{std::byte{0x5F}, std::byte{0x41}, std::byte{0xAA}, std::byte{0x60}};
+        std::vector<std::byte>       decoded{std::byte{0x01}};
+        auto                         dec    = make_decoder(buffer);
+        auto                         result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::no_match_for_bstr_on_buffer);
+        CHECK_EQ(decoded, (std::vector<std::byte>{std::byte{0x01}, std::byte{0xAA}}));
+    }
+
+    {
+        const std::vector<std::byte> buffer{std::byte{0x7F}, std::byte{0x61}, std::byte{'a'}, std::byte{0x40}};
+        std::string                  decoded{"prefix:"};
+        auto                         dec    = make_decoder(buffer);
+        auto                         result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::no_match_for_tstr_on_buffer);
+        CHECK_EQ(decoded, "prefix:a");
+    }
 }
 
 TEST_CASE("roundtrip indefinite tagged class direct") {

--- a/test/test_status_handling.cpp
+++ b/test/test_status_handling.cpp
@@ -297,8 +297,8 @@ TEST_SUITE("Decoding the wrong thing") {
             auto                   enc = make_encoder(data);
             REQUIRE(enc(std::vector<std::byte>(64, std::byte{0xAB})));
 
-            // MSVC's Debug STL allocates container proxy state for the temporary
-            // decode target; keep the resource failure on the payload reserve.
+            // Leave room for MSVC Debug STL container proxy state so the bounded
+            // resource fails on the payload reserve.
             check_decode_out_of_memory<std::pmr::vector<std::byte>, 32>(data);
         }
     }


### PR DESCRIPTION
## Summary

- append definite byte and text strings to mutable owning destinations, matching arrays, maps, and indefinite strings
- preserve exact assignment behavior for fixed-size destinations and borrowed views
- validate complete definite payloads before mutation and reject detected input/output storage overlap before capacity changes
- centralize optional append reservation in `detail::appender` and reuse the existing bulk range append path
- document that malformed input leaves definite-string targets unchanged while destination-side insertions are not rolled back
- track the broader destination-bound append-sink design separately in #76

## Validation

- C++20: 37/37 CTest targets passed
- C++26: 37/37 CTest targets passed
- ASan/LSan: 36/36 CTest targets passed
- changed-file clang-format and `git diff --check` passed