### PR TITLE
Keep CBOR integer wrappers in the wire domain

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -57,6 +57,29 @@ if (!result) {
 Decode to `integer`, `positive`, or `negative` when the full CBOR integer
 domain matters.
 
+### Wire-domain integer values
+
+`negative` and `integer` preserve values that do not fit any native signed
+integer. Their `value` member is a magnitude: `negative{1}` represents `-1`,
+and `negative{std::numeric_limits<std::uint64_t>::max()}` represents
+`-18446744073709551615`. `negative{0}` is the sentinel for the remaining CBOR
+value, `-18446744073709551616` (`-2^64`):
+
+```cpp
+negative minus_one{1};
+negative cbor_min{0};
+integer  either_sign = cbor_min;
+
+assert(cbor_min < minus_one);
+```
+
+These types support construction, equality, ordering, encoding, and decoding.
+They intentionally do not provide arithmetic because the `negative{0}`
+sentinel has no native unsigned magnitude and arithmetic could silently wrap.
+Convert a non-sentinel value to an application numeric type only after checking
+that the destination can represent it. `positive` remains an alias for
+`std::uint64_t`.
+
 ## Wrapping Groups
 
 `default_wrapping` controls whether reflected aggregates and tuple-like grouped

--- a/include/cbor_tags/cbor_concepts_checking.h
+++ b/include/cbor_tags/cbor_concepts_checking.h
@@ -21,7 +21,7 @@ namespace cbor::tags {
 // Major Type  | Meaning           | Content
 // ------------|-------------------|-------------------------
 // 0           | unsigned integer  | N (integer in [0, uint64_max])
-// 1           | negative integer  | -1-N (integer in [-uint64_max, -1])
+// 1           | negative integer  | -1-N (integer in [-2^64, -1])
 // 2           | byte string       | N bytes
 // 3           | text string       | N bytes (UTF-8 text)
 // 4           | array             | N data items (elements)

--- a/include/cbor_tags/cbor_integer.h
+++ b/include/cbor_tags/cbor_integer.h
@@ -2,7 +2,6 @@
 
 #include <compare>
 #include <cstdint>
-#include <limits>
 
 namespace cbor::tags {
 
@@ -10,210 +9,50 @@ using positive = std::uint64_t;
 struct integer;
 
 struct negative {
-    positive value;
+    positive value; // Magnitude; zero represents the CBOR-only value -2^64.
 
     constexpr negative() : value(0) {}
     constexpr negative(positive N) : value(N) {}
 
-    constexpr auto operator<=>(const negative &rhs) const {
+    constexpr std::strong_ordering operator<=>(const negative &rhs) const noexcept {
+        if (value == rhs.value) {
+            return std::strong_ordering::equal;
+        }
+        if (value == 0) {
+            return std::strong_ordering::less;
+        }
+        if (rhs.value == 0) {
+            return std::strong_ordering::greater;
+        }
         return rhs.value <=> value; // Reverse comparison because negative numbers
     }
 
-    constexpr auto operator==(const negative &rhs) const { return value == rhs.value; }
-
-    // Unary operators
-    constexpr std::uint64_t operator-() const { return value; }
-    constexpr negative      operator+() const { return *this; }
+    constexpr bool operator==(const negative &rhs) const noexcept { return value == rhs.value; }
 };
 
 struct integer {
-    positive value;
+    positive value; // For a negative value, zero represents -2^64.
     bool     is_negative;
 
     constexpr integer(positive N) : value(N), is_negative(false) {}
     constexpr integer(positive N, bool is_negative) : value(N), is_negative(is_negative) {}
     constexpr integer(negative N) : value(N.value), is_negative(true) {}
 
-    constexpr auto operator<=>(const integer &rhs) const {
+    constexpr std::strong_ordering operator<=>(const integer &rhs) const noexcept {
         if (is_negative && rhs.is_negative) {
-            return rhs.value <=> value; // Reverse comparison because negative numbers
+            return negative{value} <=> negative{rhs.value};
         } else if (is_negative) {
-            return -1 <=> 0;
+            return std::strong_ordering::less;
         } else if (rhs.is_negative) {
-            return 1 <=> 0;
+            return std::strong_ordering::greater;
         } else {
             return value <=> rhs.value;
         }
     }
 
-    constexpr auto operator==(const integer &rhs) const { return value == rhs.value && is_negative == rhs.is_negative; }
-
-    // Unary operators
-    constexpr integer operator-() const { return {value, !is_negative}; }
-
-    constexpr integer operator+() const { return *this; }
-
-    // Addition
-    constexpr integer operator+(const integer &rhs) const {
-        if (is_negative == rhs.is_negative) {
-            // Same sign: add values and keep sign
-            return {value + rhs.value, is_negative};
-        } else {
-            // Different signs: subtract smaller from larger and take sign of larger
-            if (value > rhs.value) {
-                return {value - rhs.value, is_negative};
-            } else if (value < rhs.value) {
-                return {rhs.value - value, rhs.is_negative};
-            } else {
-                return {0};
-            }
-        }
-    }
-
-    // Subtraction
-    constexpr integer operator-(const integer &rhs) const { return *this + (-rhs); }
-
-    // Multiplication
-    constexpr integer operator*(const integer &rhs) const {
-        auto result = value * rhs.value;
-        return {result, (is_negative != rhs.is_negative) && (result != 0)};
-    }
-
-    // Division
-    constexpr integer operator/(const integer &rhs) const {
-        auto result = value / rhs.value;
-        return {result, (is_negative != rhs.is_negative) && (result != 0)};
-    }
-
-    // Modulo
-    constexpr integer operator%(const integer &rhs) const {
-        auto result = value % rhs.value;
-        return {result, is_negative && (result != 0)};
-    }
-
-    // Compound assignment operators
-    constexpr integer &operator+=(const integer &rhs) {
-        *this = *this + rhs;
-        return *this;
-    }
-
-    constexpr integer &operator-=(const integer &rhs) {
-        *this = *this - rhs;
-        return *this;
-    }
-
-    constexpr integer &operator*=(const integer &rhs) {
-        *this = *this * rhs;
-        return *this;
-    }
-
-    constexpr integer &operator/=(const integer &rhs) {
-        *this = *this / rhs;
-        return *this;
-    }
-
-    constexpr integer &operator%=(const integer &rhs) {
-        *this = *this % rhs;
-        return *this;
-    }
-
-    // Increment/Decrement operators
-    constexpr integer &operator++() {
-        *this += integer(1);
-        return *this;
-    }
-
-    constexpr integer operator++(int) {
-        integer temp = *this;
-        ++(*this);
-        return temp;
-    }
-
-    constexpr integer &operator--() {
-        *this -= integer(1);
-        return *this;
-    }
-
-    constexpr integer operator--(int) {
-        integer temp = *this;
-        --(*this);
-        return temp;
-    }
+    constexpr bool operator==(const integer &rhs) const noexcept { return value == rhs.value && is_negative == rhs.is_negative; }
 };
 
-constexpr auto operator+(positive a, integer b) {
-    const auto result = a + (b.is_negative ? -b.value : b.value);
-    if (b.is_negative && b.value > a) {
-        return integer(std::numeric_limits<positive>::max() - result);
-    } else {
-        return integer(result);
-    }
-}
-
-constexpr auto operator+(integer a, positive b) { return b + a; }
-
-constexpr auto operator+(positive a, negative b) {
-    auto result      = a - b.value;
-    bool is_negative = b.value > a;
-    result           = is_negative ? (std::numeric_limits<positive>::max() - result + 1) : result;
-    return integer(result, is_negative);
-}
-
-constexpr auto operator+(integer a, negative b) {
-    const auto result = a.value + (a.is_negative ? b.value : -b.value);
-    if (b.value > a.value && !a.is_negative) {
-        return integer(std::numeric_limits<positive>::max() - result + 1, true);
-    } else {
-        return integer(result, a.is_negative);
-    }
-}
-constexpr auto operator+(negative a, integer b) { return b + a; }
-
-constexpr auto operator-(integer a, negative b) {
-    const auto result = a.value + (a.is_negative ? -b.value : b.value);
-    if (a.is_negative && b.value > a.value) {
-        return integer(std::numeric_limits<positive>::max() - result - 1, false);
-    } else {
-        return integer(result, a.value < b.value);
-    }
-}
-constexpr auto operator-(negative a, integer b) {
-    b.is_negative = !b.is_negative;
-
-    const auto result = a.value + (b.is_negative ? b.value : -b.value);
-    if (!b.is_negative && b.value > a.value) {
-        return integer(std::numeric_limits<positive>::max() - result - 1, false);
-    } else {
-        return integer(result, true);
-    }
-}
-
-constexpr auto operator+(negative a, positive b) { return b + a; }
-constexpr auto operator+(negative a, negative b) { return negative(a.value + b.value); }
-constexpr auto operator-(positive a, negative b) { return a + integer(b.value); }
-constexpr auto operator-(negative a, positive b) { return negative(a.value + b); }
-constexpr auto operator-(negative a, negative b) {
-    auto result = a.value - b.value;
-    if (b.value > a.value) {
-        return integer(result - 1, true);
-    } else {
-        return integer(result);
-    }
-}
-
-constexpr auto operator-(positive a, integer b) {
-    const auto result = a - (b.is_negative ? -b.value : b.value);
-    if (b.is_negative && b.value > a) {
-        return integer(std::numeric_limits<positive>::max() - result);
-    } else {
-        return integer(result);
-    }
-}
-
-constexpr auto operator-(integer a, positive b) { return b - a; }
-
 constexpr auto operator""_neg(unsigned long long N) { return negative(N); }
-
-// Implement basic
 
 } // namespace cbor::tags

--- a/include/cbor_tags/extensions/cbor_visualization.h
+++ b/include/cbor_tags/extensions/cbor_visualization.h
@@ -102,6 +102,13 @@ auto cddl_schema_to(OutputBuffer &output_buffer, CDDLOptions = {}, Context = {})
 
 namespace detail {
 
+[[nodiscard]] inline std::string negative_diagnostic_text(negative value) {
+    if (value.value == 0U) {
+        return "-18446744073709551616";
+    }
+    return text::format("-{}", value.value);
+}
+
 struct CDDLContext;
 
 template <typename T, cddl_shared_pointer_mode PointerMode = cddl_shared_pointer_mode::nullable>
@@ -1901,10 +1908,7 @@ template <typename OutputBuffer> struct smart_annotator {
     [[nodiscard]] static std::size_t bytes_comment_size(std::size_t length) { return checked_add(3U, checked_mul(length, 2U)); }
 
     [[nodiscard]] static std::string negative_comment(std::uint64_t argument) {
-        if (argument == std::numeric_limits<std::uint64_t>::max()) {
-            return "negative(-18446744073709551616)";
-        }
-        return text::format("negative(-{})", argument + 1U);
+        return text::format("negative({})", detail::negative_diagnostic_text(negative{argument + 1U}));
     }
 
     [[nodiscard]] static std::string tag_comment(std::uint64_t tag) {
@@ -2275,7 +2279,7 @@ template <typename OutputBuffer, typename Decoder> struct diagnostic_visitor {
         if constexpr (IsUnsigned<std::remove_cvref_t<decltype(arg)>>) {
             text::format_to(std::back_inserter(output_buffer), "{}", arg);
         } else if constexpr (IsNegative<std::remove_cvref_t<decltype(arg)>>) {
-            text::format_to(std::back_inserter(output_buffer), "-{}", arg.value);
+            text::format_to(std::back_inserter(output_buffer), "{}", detail::negative_diagnostic_text(arg));
         } else if constexpr (IsTagHeader<std::remove_cvref_t<decltype(arg)>>) {
             check_depth();
             detail::catch_all_variant value;

--- a/test/test_cbor_integer.cpp
+++ b/test/test_cbor_integer.cpp
@@ -1,11 +1,74 @@
+#include <array>
 #include <cbor_tags/cbor_concepts.h>
 #include <cbor_tags/cbor_decoder.h>
 #include <cbor_tags/cbor_encoder.h>
 #include <cbor_tags/cbor_integer.h>
+#include <compare>
+#include <cstdint>
 #include <doctest/doctest.h>
 #include <limits>
+#include <vector>
 
 using namespace cbor::tags;
+
+namespace {
+
+template <typename T>
+concept HasUnaryPlus = requires(T value) { +value; };
+template <typename T>
+concept HasUnaryMinus = requires(T value) { -value; };
+template <typename L, typename R>
+concept HasAddition = requires(L lhs, R rhs) { lhs + rhs; };
+template <typename L, typename R>
+concept HasSubtraction = requires(L lhs, R rhs) { lhs - rhs; };
+template <typename L, typename R>
+concept HasMultiplication = requires(L lhs, R rhs) { lhs * rhs; };
+template <typename L, typename R>
+concept HasDivision = requires(L lhs, R rhs) { lhs / rhs; };
+template <typename L, typename R>
+concept HasModulo = requires(L lhs, R rhs) { lhs % rhs; };
+template <typename T>
+concept HasAdditionAssignment = requires(T lhs, T rhs) { lhs += rhs; };
+template <typename T>
+concept HasSubtractionAssignment = requires(T lhs, T rhs) { lhs -= rhs; };
+template <typename T>
+concept HasMultiplicationAssignment = requires(T lhs, T rhs) { lhs *= rhs; };
+template <typename T>
+concept HasDivisionAssignment = requires(T lhs, T rhs) { lhs /= rhs; };
+template <typename T>
+concept HasModuloAssignment = requires(T lhs, T rhs) { lhs %= rhs; };
+template <typename T>
+concept HasPreIncrement = requires(T value) { ++value; };
+template <typename T>
+concept HasPostIncrement = requires(T value) { value++; };
+template <typename T>
+concept HasPreDecrement = requires(T value) { --value; };
+template <typename T>
+concept HasPostDecrement = requires(T value) { value--; };
+
+template <typename T>
+constexpr bool has_self_arithmetic =
+    HasUnaryPlus<T> || HasUnaryMinus<T> || HasAddition<T, T> || HasSubtraction<T, T> || HasMultiplication<T, T> || HasDivision<T, T> ||
+    HasModulo<T, T> || HasAdditionAssignment<T> || HasSubtractionAssignment<T> || HasMultiplicationAssignment<T> ||
+    HasDivisionAssignment<T> || HasModuloAssignment<T> || HasPreIncrement<T> || HasPostIncrement<T> || HasPreDecrement<T> ||
+    HasPostDecrement<T>;
+
+template <typename L, typename R>
+constexpr bool has_binary_arithmetic =
+    HasAddition<L, R> || HasSubtraction<L, R> || HasMultiplication<L, R> || HasDivision<L, R> || HasModulo<L, R>;
+
+static_assert(!has_self_arithmetic<negative>);
+static_assert(!has_self_arithmetic<integer>);
+static_assert(!has_binary_arithmetic<negative, positive>);
+static_assert(!has_binary_arithmetic<positive, negative>);
+static_assert(!has_binary_arithmetic<negative, integer>);
+static_assert(!has_binary_arithmetic<integer, negative>);
+static_assert(!has_binary_arithmetic<integer, positive>);
+static_assert(!has_binary_arithmetic<positive, integer>);
+static_assert(std::three_way_comparable<negative>);
+static_assert(std::three_way_comparable<integer>);
+
+} // namespace
 
 TEST_CASE("Test IsNegative concept") {
     static_assert(IsNegative<negative>);
@@ -24,165 +87,58 @@ TEST_CASE("Basic conversion") {
     CHECK(i.is_negative);
 }
 
-TEST_CASE("Addition") {
-    negative n(10);
-    integer  i(20);
+TEST_CASE("negative literal preserves its wire magnitude") {
+    constexpr auto value = 42_neg;
+    static_assert(value == negative{42});
+}
 
-    auto result = n + i;
-    CHECK_EQ(result.value, 20 - 10);
-    CHECK(!result.is_negative);
+TEST_CASE("wire integer wrappers have numeric ordering across the full CBOR domain") {
+    constexpr auto max = std::numeric_limits<std::uint64_t>::max();
 
-    result = i + n;
-    CHECK_EQ(result.value, 20 - 10);
-    CHECK(!result.is_negative);
+    CHECK(negative{0} < negative{max});
+    CHECK(negative{max} < negative{2});
+    CHECK(negative{2} < negative{1});
 
-    result = n + n;
-    CHECK_EQ(result.value, 10 + 10);
-    CHECK(result.is_negative);
+    CHECK(integer{negative{0}} < integer{negative{max}});
+    CHECK(integer{negative{max}} < integer{negative{2}});
+    CHECK(integer{negative{2}} < integer{negative{1}});
+    CHECK(integer{negative{1}} < integer{positive{0}});
+    CHECK(integer{positive{0}} < integer{max});
+}
 
-    result = n + std::uint64_t(9);
-    CHECK_EQ(result.value, 1);
-    CHECK(result.is_negative);
+TEST_CASE("negative wrapper roundtrips the full CBOR negative domain") {
+    constexpr auto max    = std::numeric_limits<std::uint64_t>::max();
+    const auto     values = std::array{negative{1}, negative{2}, negative{max}, negative{0}};
 
-    result = std::uint64_t(9) + n;
-    CHECK_EQ(result.value, 1);
-    CHECK(result.is_negative);
+    for (const auto original : values) {
+        CAPTURE(original.value);
+        std::vector<std::byte> data;
+        auto                   enc = make_encoder(data);
+        REQUIRE(enc(original));
 
-    result = n + std::uint64_t(10);
-    CHECK_EQ(result.value, 0);
-    CHECK(!result.is_negative);
-
-    {
-        auto test = std::uint64_t(10) + std::numeric_limits<std::uint64_t>::max();
-        REQUIRE_EQ(test + 1, 10); // Sanity check, + 1 should because of overflow
+        negative decoded{1};
+        auto     dec = make_decoder(data);
+        REQUIRE(dec(decoded));
+        CHECK_EQ(decoded, original);
     }
-
-    // Overflow negative
-    result = n + negative(std::numeric_limits<std::uint64_t>::max());
-    CHECK_EQ(result.value + 1, n.value); // Same as sanity check
-
-    // Underflow negative
-    result = n + std::uint64_t(11);
-    CHECK_EQ(result.value, 1);
-    CHECK(!result.is_negative);
 }
 
-TEST_CASE("Subtraction") {
-    negative n(10);
-    integer  i(20);
+TEST_CASE("signed wire wrapper roundtrips positive and negative CBOR boundaries") {
+    constexpr auto max = std::numeric_limits<std::uint64_t>::max();
+    const auto values  = std::array{integer{positive{0}}, integer{max}, integer{negative{1}}, integer{negative{max}}, integer{negative{0}}};
 
-    auto result = n - i;
-    CHECK_EQ(result.value, 30);
-    CHECK(result.is_negative);
+    for (const auto original : values) {
+        CAPTURE(original.value);
+        CAPTURE(original.is_negative);
+        std::vector<std::byte> data;
+        auto                   enc = make_encoder(data);
+        REQUIRE(enc(original));
 
-    result = i - n;
-    CHECK_EQ(result.value, 30);
-    CHECK(!result.is_negative);
-
-    result = n - n;
-    CHECK_EQ(result.value, 0);
-    CHECK(!result.is_negative);
-
-    result = n - std::uint64_t(9);
-    CHECK_EQ(result.value, 19);
-    CHECK(result.is_negative);
-
-    result = std::uint64_t(9) - n;
-    CHECK_EQ(result.value, 19);
-    CHECK(!result.is_negative);
-
-    result = n - std::uint64_t(10);
-    CHECK_EQ(result.value, 20);
-    CHECK(result.is_negative);
-
-    // Overflow negative
-    result = negative(std::numeric_limits<std::uint64_t>::max()) - std::uint64_t(n.value);
-    CHECK_EQ(result.value + 1, n.value); // + 1 because of overflow
-    CHECK(result.is_negative);
-
-    // Underflow negative
-    result = n + std::uint64_t(11);
-    CHECK_EQ(result.value, 1);
-    CHECK(!result.is_negative);
-}
-
-TEST_CASE("test max positive + min negative") {
-    positive a = std::numeric_limits<std::uint64_t>::max();
-    auto     b = negative(std::numeric_limits<std::uint64_t>::max());
-
-    auto result = a + b;
-    CHECK_EQ(result.value, 0);
-
-    // Sanity check exactly zero
-    result = 3ULL + 3_neg;
-    CHECK_EQ(result.value, 0);
-
-    result = -3ULL - 3_neg;
-    CHECK_EQ(result.value, 0);
-
-    result = 3_neg + 3ULL;
-    CHECK_EQ(result.value, 0);
-}
-
-TEST_CASE("Just integer maths") {
-    integer a(10);
-    integer b(negative(20));
-
-    auto result = a + b;
-    CHECK_EQ(result.value, 10);
-    CHECK(result.is_negative);
-
-    CHECK_EQ(result, b + a);
-
-    result = a - b;
-    CHECK_EQ(result.value, 30);
-    CHECK(!result.is_negative);
-
-    CHECK_EQ(-result, b - a);
-
-    // Overflow
-    result = std::numeric_limits<std::uint64_t>::max() + 1;
-    CHECK_EQ(result.value, 0);
-
-    // Underflow
-    result = -std::numeric_limits<std::uint64_t>::max() - 1;
-    CHECK_EQ(result.value, 0);
-
-    // Multiplication
-    result = a * b;
-    CHECK_EQ(result.value, 200);
-    CHECK(result.is_negative);
-    CHECK_EQ(result, b * a);
-
-    result = b * 0;
-    CHECK_EQ(result.value, 0);
-    CHECK(!result.is_negative);
-
-    result = a * b * a * b;
-    CHECK_EQ(result.value, 40000);
-    CHECK(!result.is_negative);
-
-    // Division
-    result = a / b;
-    CHECK_EQ(result.value, 0);
-    CHECK(!result.is_negative);
-
-    result = b / a;
-    CHECK_EQ(result.value, 2);
-    CHECK(result.is_negative);
-
-    result = a * b / b;
-    CHECK_EQ(result.value, 10);
-    CHECK(!result.is_negative);
-
-    // Modulus
-    result = a % b;
-    CHECK_EQ(result.value, 10);
-    CHECK(!result.is_negative);
-
-    result = b % a;
-    CHECK_EQ(result.value, 0);
-    CHECK(!result.is_negative);
+        integer decoded{positive{0}};
+        auto    dec = make_decoder(data);
+        REQUIRE(dec(decoded));
+        CHECK_EQ(decoded, original);
+    }
 }
 
 TEST_CASE("Encode, Decode 0s") {

--- a/test/test_cbor_integer.cpp
+++ b/test/test_cbor_integer.cpp
@@ -1,3 +1,5 @@
+#include "test_util.h"
+
 #include <array>
 #include <cbor_tags/cbor_concepts.h>
 #include <cbor_tags/cbor_decoder.h>
@@ -7,6 +9,7 @@
 #include <cstdint>
 #include <doctest/doctest.h>
 #include <limits>
+#include <string_view>
 #include <vector>
 
 using namespace cbor::tags;
@@ -139,6 +142,44 @@ TEST_CASE("signed wire wrapper roundtrips positive and negative CBOR boundaries"
         REQUIRE(dec(decoded));
         CHECK_EQ(decoded, original);
     }
+}
+
+TEST_CASE("wire integer wrappers encode exact CBOR width boundaries") {
+    using namespace std::string_view_literals;
+    constexpr auto max = std::numeric_limits<std::uint64_t>::max();
+
+    const auto check_wire = [](const auto value, std::string_view expected_hex) {
+        std::vector<std::byte> data;
+        auto                   enc = make_encoder(data);
+        REQUIRE(enc(value));
+        CHECK_EQ(to_hex(data), expected_hex);
+    };
+
+    check_wire(positive{0}, "00"sv);
+    check_wire(positive{23}, "17"sv);
+    check_wire(positive{24}, "1818"sv);
+    check_wire(positive{255}, "18ff"sv);
+    check_wire(positive{256}, "190100"sv);
+    check_wire(positive{65535}, "19ffff"sv);
+    check_wire(positive{65536}, "1a00010000"sv);
+    check_wire(positive{0xffffffffULL}, "1affffffff"sv);
+    check_wire(positive{0x100000000ULL}, "1b0000000100000000"sv);
+    check_wire(positive{max}, "1bffffffffffffffff"sv);
+
+    check_wire(negative{1}, "20"sv);
+    check_wire(negative{24}, "37"sv);
+    check_wire(negative{25}, "3818"sv);
+    check_wire(negative{256}, "38ff"sv);
+    check_wire(negative{257}, "390100"sv);
+    check_wire(negative{65536}, "39ffff"sv);
+    check_wire(negative{65537}, "3a00010000"sv);
+    check_wire(negative{0x100000000ULL}, "3affffffff"sv);
+    check_wire(negative{0x100000001ULL}, "3b0000000100000000"sv);
+    check_wire(negative{max}, "3bfffffffffffffffe"sv);
+    check_wire(negative{0}, "3bffffffffffffffff"sv);
+
+    check_wire(integer{positive{max}}, "1bffffffffffffffff"sv);
+    check_wire(integer{negative{0}}, "3bffffffffffffffff"sv);
 }
 
 TEST_CASE("Encode, Decode 0s") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -23,10 +23,6 @@ using namespace cbor::tags;
 using namespace std::string_view_literals;
 
 namespace {
-consteval bool negative_wrapper_argument_is_representable(std::uint64_t argument) {
-    return argument != std::numeric_limits<std::uint64_t>::max();
-}
-
 struct minimal_decoder_options {
     using is_options  = void;
     using return_type = expected<void, status_code>;
@@ -116,8 +112,6 @@ struct SignedSizeDequeByteRange {
 };
 } // namespace
 
-static_assert(negative_wrapper_argument_is_representable(std::numeric_limits<std::uint64_t>::max() - 1));
-static_assert(!negative_wrapper_argument_is_representable(std::numeric_limits<std::uint64_t>::max()));
 static_assert(!std::is_default_constructible_v<NonDefaultComparator>);
 static_assert(std::is_move_assignable_v<NonDefaultComparator>);
 static_assert(!std::is_default_constructible_v<NonAssignableComparator>);
@@ -130,20 +124,6 @@ static_assert(CborInputBuffer<AdlSizedByteRange>);
 static_assert(std::same_as<typename decltype(make_decoder(std::declval<AdlSizedByteRange &>()))::size_type, std::uint16_t>);
 static_assert(CborInputBuffer<SignedSizeDequeByteRange>);
 static_assert(std::same_as<typename decltype(make_decoder(std::declval<SignedSizeDequeByteRange &>()))::size_type, int>);
-
-TEST_CASE("integer arithmetic should cover cancellation and larger negative branches") {
-    const auto cancelled = integer{2, true} + integer{2};
-    CHECK_FALSE(cancelled.is_negative);
-    CHECK_EQ(cancelled.value, 0);
-
-    const auto positive_plus_larger_negative = positive{1} + negative{3};
-    CHECK(positive_plus_larger_negative.is_negative);
-    CHECK_EQ(positive_plus_larger_negative.value, 2);
-
-    const auto integer_plus_larger_negative = integer{1} + negative{3};
-    CHECK(integer_plus_larger_negative.is_negative);
-    CHECK_EQ(integer_plus_larger_negative.value, 2);
-}
 
 TEST_CASE("float16 should cover infinity nan and subnormal conversions") {
     CHECK(std::isinf(static_cast<float>(float16_t{static_cast<std::uint16_t>(0x7C00)})));
@@ -290,7 +270,7 @@ TEST_CASE("decoder should preserve cbor integer sign") {
     CHECK_EQ(decoded.value, 1);
 }
 
-TEST_CASE("decoder should document max negative wrapper edge behavior") {
+TEST_CASE("decoder should represent the CBOR minimum integer with the negative zero sentinel") {
     std::vector<std::byte> buffer{std::byte{0x3B}, std::byte{0xFF}, std::byte{0xFF}, std::byte{0xFF}, std::byte{0xFF},
                                   std::byte{0xFF}, std::byte{0xFF}, std::byte{0xFF}, std::byte{0xFF}};
 

--- a/test/test_encode_to_buffer.cpp
+++ b/test/test_encode_to_buffer.cpp
@@ -131,7 +131,7 @@ TEST_CASE_TEMPLATE("CBOR Encoder array/vector buffer", T, std::vector<std::byte>
     }
 }
 
-TEST_CASE("CBOR Encoder documents zero negative wrapper edge behavior") {
+TEST_CASE("CBOR Encoder writes the negative zero sentinel as the CBOR minimum integer") {
     std::vector<std::byte> data;
     auto                   enc = make_encoder(data);
 

--- a/test/test_visualization_coverage.cpp
+++ b/test/test_visualization_coverage.cpp
@@ -343,6 +343,10 @@ TEST_CASE("smart buffer annotation renders uint64 max negative exactly") {
     buffer_annotate(buffer, annotation, {.annotation_column = 40});
 
     CHECK(annotation.find("negative(-18446744073709551616)") != std::string::npos);
+
+    std::string diagnostic;
+    buffer_diagnostic(buffer, diagnostic, {.row_options = {.format_by_rows = false}});
+    CHECK_EQ(diagnostic, "[-18446744073709551616]");
 }
 
 TEST_CASE("smart buffer annotation stress tests adversarial single byte inputs") {


### PR DESCRIPTION
## Summary

- remove arithmetic, compound-assignment, and increment/decrement operators from `negative` and `integer`
- preserve construction, equality, ordering, `_neg`, encoding, and decoding
- define `negative{0}` as the wire sentinel for CBOR `-2^64` and fix its ordering
- replace wraparound arithmetic tests with compile-time API checks and full-domain roundtrip/boundary tests
- document safe application conversion expectations

## Why

The wrappers preserve the entire CBOR integer domain, including `-2^64`, whose magnitude cannot be represented by `std::uint64_t`. Treating their storage as ordinary arithmetic silently wrapped and produced incorrect values. They are now transport values; application arithmetic belongs in an explicitly chosen numeric type after representability checks.

## Validation

- GCC 15.2 C++20: 30/30 CTest targets
- GCC 15.2 C++23 with `std::expected`: 31/31 CTest targets
- Clang 21.1 C++20: 31/31 CTest targets
- focused integer suite: 20 cases, 101 assertions
- `clang-format --dry-run --Werror` on changed C++ files