### PR TITLE
Remove the redundant variant hasher

### DIFF
--- a/doc/variant_handling.md
+++ b/doc/variant_handling.md
@@ -77,6 +77,35 @@ For raw `union` storage with a domain-specific discriminator, prefer an ADL
 `encode`/`decode` overload unless the type can honestly expose the same
 `index`/`get`/`visit`/`assign` operations as a variant.
 
+## Hashing And Migration
+
+`variant_hasher` has been removed. Replace it with the standard variant hasher
+when every alternative is itself hashable:
+
+```cpp
+using key = std::variant<int, std::string>;
+std::unordered_map<key, int> values;
+```
+
+`std::hash<std::variant<T...>>` is enabled only when `std::hash<T>` is enabled
+for every alternative. A variant containing `std::vector`, `std::map`, or
+another non-hashable type therefore still needs an application-specific hasher:
+
+```cpp
+using key = std::variant<int, std::vector<int>>;
+
+struct key_hash {
+    std::size_t operator()(const key &value) const noexcept;
+};
+
+std::unordered_map<key, int, key_hash> values;
+```
+
+This is a source-breaking migration for code that named `variant_hasher`. The
+old helper is not retained as a compatibility alias because its range and map
+branches delegated to unavailable `std::hash` specializations and did not
+provide the recursive hashing its interface implied.
+
 ## Compile-Time Dispatch
 
 Below is "pseudo code" that can be investigated with [godbolt](https://godbolt.org/). The code shows how you can optimize away unused code paths with `if constexpr`; in this case the code paths are constrained by the variant type.

--- a/doc/variant_handling.md
+++ b/doc/variant_handling.md
@@ -87,24 +87,66 @@ using key = std::variant<int, std::string>;
 std::unordered_map<key, int> values;
 ```
 
-`std::hash<std::variant<T...>>` is enabled only when `std::hash<T>` is enabled
-for every alternative. A variant containing `std::vector`, `std::map`, or
-another non-hashable type therefore still needs an application-specific hasher:
+[`std::hash<std::variant<T...>>`](https://en.cppreference.com/cpp/utility/variant/hash)
+is enabled only when `std::hash<T>` is enabled for every alternative, as also
+specified by the C++ standard's [`[variant.hash]`](https://eel.is/c++draft/variant.hash)
+wording. A variant containing `std::vector`, `std::map`, or another non-hashable
+type therefore still needs an application-specific hasher. For example, an
+application using integers and byte strings as keys can define their exact
+hashing policy alongside the key type:
 
 ```cpp
-using key = std::variant<int, std::vector<int>>;
+#include <cstddef>
+#include <functional>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+using bytes = std::vector<std::byte>;
+using key = std::variant<int, bytes>;
 
 struct key_hash {
-    std::size_t operator()(const key &value) const noexcept;
+    std::size_t operator()(const key &value) const noexcept {
+        std::size_t seed = std::hash<std::size_t>{}(value.index());
+
+        if (!value.valueless_by_exception()) {
+            mix(seed, std::visit([](const auto &item) noexcept {
+                return key_hash::hash_value(item);
+            }, value));
+        }
+
+        return seed;
+    }
+
+  private:
+    static void mix(std::size_t &seed, std::size_t value) noexcept {
+        seed ^= value + 0x9e3779b9U + (seed << 6U) + (seed >> 2U);
+    }
+
+    static std::size_t hash_value(int value) noexcept {
+        return std::hash<int>{}(value);
+    }
+
+    static std::size_t hash_value(const bytes &value) noexcept {
+        std::size_t seed = std::hash<std::size_t>{}(value.size());
+        for (std::byte byte : value) {
+            mix(seed, std::to_integer<unsigned char>(byte));
+        }
+        return seed;
+    }
 };
 
 std::unordered_map<key, int, key_hash> values;
 ```
 
+The overloads intentionally cover only the application's alternatives. Adding
+another alternative to `key` requires adding its hashing policy as well.
+
 This is a source-breaking migration for code that named `variant_hasher`. The
-old helper is not retained as a compatibility alias because its range and map
-branches delegated to unavailable `std::hash` specializations and did not
-provide the recursive hashing its interface implied.
+old helper partially handled byte strings and shallow ranges, but its generic
+interface implied support for arbitrary CBOR-compatible alternatives. Nested
+ranges and maps did not provide that support, and their equality and ordering
+semantics do not admit one universally correct hashing policy.
 
 ## Compile-Time Dispatch
 

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -4,7 +4,6 @@
 #include "cbor_tags/cbor_concepts.h"
 #include "cbor_tags/cbor_detail.h"
 #include "cbor_tags/cbor_integer.h"
-#include "cbor_tags/cbor_operators.h"
 #include "cbor_tags/cbor_range_encoder.h"
 #include "cbor_tags/cbor_reflection.h"
 #include "cbor_tags/cbor_simple.h"

--- a/include/cbor_tags/cbor_operators.h
+++ b/include/cbor_tags/cbor_operators.h
@@ -6,15 +6,10 @@
 #include "cbor_tags/float16_ieee754.h"
 
 #include <compare>
-#include <concepts>
 #include <cstddef>
-#include <exception>
 #include <functional>
-#include <iterator>
 #include <ranges>
-#include <string_view>
 #include <type_traits>
-#include <utility>
 #include <variant>
 
 namespace cbor::tags {
@@ -89,64 +84,6 @@ template <typename Compare = std::less<>> struct variant_comparator {
 
         return detail::variant_visit(cbor_variant_visitor<Compare>{}, lhs, rhs);
     }
-};
-
-struct variant_hasher {
-    template <IsVariant Variant> size_t operator()(const Variant &v) const noexcept {
-        // Start with the index hash
-        size_t seed = std::hash<size_t>{}(v.index());
-        seed ^= hash_variant_value(v);
-        seed *= fnv_prime;
-        return seed;
-    }
-
-  private:
-    static constexpr size_t fnv_prime = 16777619;
-
-    template <typename T> static size_t hash_cbor_value(const T &arg) noexcept {
-        using value_type = std::decay_t<T>;
-
-        if constexpr (IsUnsigned<value_type> || IsSigned<value_type>) {
-            return std::hash<value_type>{}(arg);
-        } else if constexpr (IsBinaryString<value_type> || IsTextString<value_type>) {
-            // Hash the contents of the string/binary data
-            return std::hash<std::string_view>{}(std::string_view(reinterpret_cast<const char *>(std::data(arg)), std::size(arg)));
-        } else if constexpr (IsArray<value_type> || IsMap<value_type>) {
-            // Hash each element in the container
-            size_t value_hash = 0;
-            for (const auto &elem : arg) {
-                // Combine hashes using FNV-1a-like algorithm
-                value_hash ^= std::hash<std::decay_t<decltype(elem)>>{}(elem);
-                value_hash *= fnv_prime;
-            }
-            return value_hash;
-        } else if constexpr (IsTag<value_type>) {
-            return std::hash<value_type>{}(arg);
-        } else if constexpr (IsSimple<value_type>) {
-            if constexpr (std::is_same_v<value_type, std::nullptr_t>) {
-                return 0;
-            } else {
-                return std::hash<value_type>{}(arg);
-            }
-        } else {
-            static_assert(always_false<value_type>::value, "Non-exhaustive visitor!");
-        }
-    }
-
-    template <std::size_t I, IsVariant Variant> static size_t hash_variant_value_impl(const Variant &v) noexcept {
-        using variant_type = std::remove_cvref_t<Variant>;
-
-        if constexpr (I == std::variant_size_v<variant_type>) {
-            std::terminate();
-        } else {
-            if (v.index() == I) {
-                return hash_cbor_value(std::get<I>(v));
-            }
-            return hash_variant_value_impl<I + 1>(v);
-        }
-    }
-
-    template <IsVariant Variant> static size_t hash_variant_value(const Variant &v) noexcept { return hash_variant_value_impl<0>(v); }
 };
 
 } // namespace cbor::tags

--- a/test/test_cbor.cpp
+++ b/test/test_cbor.cpp
@@ -416,9 +416,11 @@ TEST_CASE("Test std::greater in std::map<variant,...>") {
     CHECK_EQ(hex1.size(), hex2.size());
 }
 
-TEST_CASE("Unordered maps") {
-    std::unordered_map<variant, variant, variant_hasher> string_map = {{"c", true},  {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}},
-                                                                       {"ab", 5.0f}, {1, 3.0},      {-1, 3.0}};
+TEST_CASE("unordered maps use standard variant hashing and roundtrip") {
+    using map_t = std::unordered_map<variant, variant>;
+    static_assert(std::is_same_v<typename map_t::hasher, std::hash<variant>>);
+
+    map_t string_map = {{"c", true}, {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}}, {"ab", 5.0f}, {1, 3.0}, {-1, 3.0}};
 
     std::vector<std::byte> data;
     auto                   enc = make_encoder(data);
@@ -428,7 +430,7 @@ TEST_CASE("Unordered maps") {
 
     CBOR_TAGS_TEST_LOG("Unordered map: {}\n", to_hex(data));
 
-    std::unordered_map<variant, variant, variant_hasher> map_result;
+    map_t map_result;
     CHECK(dec(map_result));
 
     CHECK_EQ(map_result.size(), string_map.size());
@@ -436,10 +438,10 @@ TEST_CASE("Unordered maps") {
 }
 
 TEST_CASE("Sanity check equal size map unordered_map") {
-    std::unordered_map<variant, variant, variant_hasher> string_map1 = {{"c", true},  {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}},
-                                                                        {"ab", 5.0f}, {1, 3.0},      {-1, 3.0}};
-    std::map<variant, variant, variant_comparator<>>     string_map2 = {{"c", true},  {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}},
-                                                                        {"ab", 5.0f}, {1, 3.0},      {-1, 3.0}};
+    std::unordered_map<variant, variant>             string_map1 = {{"c", true},  {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}},
+                                                                    {"ab", 5.0f}, {1, 3.0},      {-1, 3.0}};
+    std::map<variant, variant, variant_comparator<>> string_map2 = {{"c", true},  {"ac", false}, {"b", 3.0}, {"a", std::nullptr_t{}},
+                                                                    {"ab", 5.0f}, {1, 3.0},      {-1, 3.0}};
     CHECK_EQ(string_map1.size(), string_map2.size());
 }
 

--- a/test/test_cbor_operators.cpp
+++ b/test/test_cbor_operators.cpp
@@ -55,20 +55,3 @@ TEST_CASE("variant comparator handles tag alternatives") {
 TEST_CASE("variant visitor returns false for different direct types") {
     CHECK_FALSE(cbor_variant_visitor<std::less<>>{}(std::uint64_t{1}, std::string{"1"}));
 }
-
-TEST_CASE("variant hasher combines index and hashable values") {
-    using bytes_t   = std::vector<std::byte>;
-    using array_t   = std::vector<int>;
-    using variant_t = std::variant<std::uint64_t, std::string, bytes_t, array_t, bool, std::nullptr_t, float16_t>;
-
-    variant_hasher hash;
-
-    CHECK_NE(hash(variant_t{1U}), hash(variant_t{2U}));
-    CHECK_EQ(hash(variant_t{std::string{"same"}}), hash(variant_t{std::string{"same"}}));
-    CHECK_NE(hash(variant_t{bytes_t{std::byte{0x01}}}), hash(variant_t{bytes_t{std::byte{0x02}}}));
-    CHECK_NE(hash(variant_t{array_t{1, 2}}), hash(variant_t{array_t{1, 3}}));
-    CHECK_NE(hash(variant_t{false}), hash(variant_t{true}));
-    CHECK_EQ(hash(variant_t{nullptr}), hash(variant_t{nullptr}));
-    CHECK_NE(hash(variant_t{float16_t{static_cast<std::uint16_t>(0x3C00)}}),
-             hash(variant_t{float16_t{static_cast<std::uint16_t>(0x4000)}}));
-}

--- a/test/test_cbor_operators.cpp
+++ b/test/test_cbor_operators.cpp
@@ -1,14 +1,31 @@
 #include "cbor_tags/cbor_operators.h"
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <doctest/doctest.h>
+#include <functional>
 #include <map>
 #include <string>
 #include <variant>
 #include <vector>
 
 using namespace cbor::tags;
+
+namespace {
+
+template <typename T>
+concept Hashable = requires(const T &value) {
+    { std::hash<T>{}(value) } -> std::convertible_to<std::size_t>;
+};
+
+using hashable_variant     = std::variant<int, std::string>;
+using non_hashable_variant = std::variant<int, std::vector<int>>;
+
+static_assert(Hashable<hashable_variant>);
+static_assert(!Hashable<non_hashable_variant>);
+
+} // namespace
 
 TEST_CASE("variant comparator orders by variant index") {
     using variant_t = std::variant<std::uint64_t, std::string, std::nullptr_t>;


### PR DESCRIPTION
## Summary

- remove the public `variant_hasher` helper
- use the standard `std::hash<std::variant<...>>` through default `std::unordered_map` types
- retain `variant_comparator` for ordered maps
- remove the unrelated `cbor_operators.h` dependency from `cbor_encoder.h`
- keep the existing unordered-map CBOR roundtrip as end-to-end standard-hash coverage

## Why

`std::hash<std::variant<...>>` is available whenever every alternative is hashable. The library helper duplicated that standard behavior, exposed a CBOR-unrelated API, and attempted to hash container alternatives that do not generally have standard hash specializations.

## Validation

- focused unordered-map tests: 13 cases, 22 assertions
- focused variant comparator tests: 4 cases, 17 assertions
- GCC 15.2 C++20: 30/30 CTest targets
- GCC 15.2 C++23 with `std::expected`: 31/31 CTest targets
- Clang 21.1 C++20: 31/31 CTest targets
- `clang-format --dry-run --Werror` on changed C++ files