### PR TITLE
Fix declared CMake minimum versions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,6 +10,43 @@ permissions:
   contents: read
 
 jobs:
+  minimum-cmake:
+    name: CMake 3.23 Raw Roundtrip
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Setup CMake 3.23.5
+      uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: '3.23.5'
+
+    - name: Install build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y g++ gcc ninja-build
+
+    - name: Configure
+      shell: bash
+      run: |
+        cmake -S . -B build/minimum-cmake -G Ninja \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DCBOR_TAGS_BUILD_CLI=ON \
+          -DCBOR_TAGS_BUILD_EXAMPLES=ON \
+          -DCBOR_TAGS_BUILD_TESTS=OFF
+
+    - name: Build
+      shell: bash
+      run: cmake --build build/minimum-cmake --parallel
+
+    - name: Test
+      shell: bash
+      run: |
+        ./build/minimum-cmake/examples/cbor_tags_basic_roundtrip
+        ./build/minimum-cmake/tools/cbor_tags_cli diagnostic --input hex 01
+
   format-and-tidy:
     name: C++ Format + Clang-Tidy
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,6 +47,68 @@ jobs:
         ./build/minimum-cmake/examples/cbor_tags_basic_roundtrip
         ./build/minimum-cmake/tools/cbor_tags_cli diagnostic --input hex 01
 
+  cmake-3-25-features:
+    name: CMake 3.25 Tests, Benchmark, Install
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+
+    - name: Setup CMake 3.25.3
+      uses: lukka/get-cmake@v4.3.2
+      with:
+        cmakeVersion: '3.25.3'
+
+    - name: Install build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y curl g++ gcc ninja-build tar unzip zip
+
+    - name: Bootstrap vcpkg
+      uses: ./.github/actions/bootstrap-vcpkg
+
+    - name: Configure tests, benchmarks, and install
+      shell: bash
+      run: |
+        cmake -S . -B build/cmake-3.25 -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_STANDARD=20 \
+          -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+          -DCMAKE_CXX_EXTENSIONS=OFF \
+          -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+          -DCMAKE_INSTALL_PREFIX="${RUNNER_TEMP}/cbor-tags-cmake-3.25" \
+          -DCBOR_TAGS_BUILD_TESTS=ON \
+          -DCBOR_TAGS_BUILD_BENCHMARKS=ON \
+          -DCBOR_TAGS_INSTALL=ON \
+          -DCBOR_TAGS_USE_SYSTEM_EXPECTED=ON
+
+    - name: Build tests and benchmark target
+      shell: bash
+      run: |
+        cmake --build build/cmake-3.25 \
+          --target tests test_decode_stack_floor test_unsigned_char cbor_tags_cli bench_encoder \
+          --parallel
+
+    - name: Run tests
+      shell: bash
+      run: ctest --test-dir build/cmake-3.25 --exclude-regex '^bench_' --output-on-failure
+
+    - name: Install package
+      shell: bash
+      run: cmake --install build/cmake-3.25
+
+    - name: Build installed package consumer
+      shell: bash
+      run: |
+        cmake -S test_package -B build/cmake-3.25-consumer -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_STANDARD=20 \
+          -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+          -DCMAKE_PREFIX_PATH="${RUNNER_TEMP}/cbor-tags-cmake-3.25;${GITHUB_WORKSPACE}/build/cmake-3.25/vcpkg_installed/x64-linux"
+        cmake --build build/cmake-3.25-consumer --parallel
+        ./build/cmake-3.25-consumer/test_package
+
   format-and-tidy:
     name: C++ Format + Clang-Tidy
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,25 +10,25 @@ permissions:
   contents: read
 
 jobs:
-  minimum-cmake:
-    name: CMake 3.23 Raw Roundtrip
+  cmake-compatibility:
+    name: CMake 3.23 Raw + 3.25 Features
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v6.0.2
+
+    - name: Install build tools
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y curl g++ gcc ninja-build tar unzip zip
 
     - name: Setup CMake 3.23.5
       uses: lukka/get-cmake@v4.3.2
       with:
         cmakeVersion: '3.23.5'
 
-    - name: Install build tools
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y g++ gcc ninja-build
-
-    - name: Configure
+    - name: Configure raw CMake 3.23 build
       shell: bash
       run: |
         cmake -S . -B build/minimum-cmake -G Ninja \
@@ -37,33 +37,20 @@ jobs:
           -DCBOR_TAGS_BUILD_EXAMPLES=ON \
           -DCBOR_TAGS_BUILD_TESTS=OFF
 
-    - name: Build
+    - name: Build raw CMake 3.23 targets
       shell: bash
       run: cmake --build build/minimum-cmake --parallel
 
-    - name: Test
+    - name: Test raw CMake 3.23 roundtrips
       shell: bash
       run: |
         ./build/minimum-cmake/examples/cbor_tags_basic_roundtrip
         ./build/minimum-cmake/tools/cbor_tags_cli diagnostic --input hex 01
 
-  cmake-3-25-features:
-    name: CMake 3.25 Tests, Benchmark, Install
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v6.0.2
-
     - name: Setup CMake 3.25.3
       uses: lukka/get-cmake@v4.3.2
       with:
         cmakeVersion: '3.25.3'
-
-    - name: Install build tools
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y curl g++ gcc ninja-build tar unzip zip
 
     - name: Bootstrap vcpkg
       uses: ./.github/actions/bootstrap-vcpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.23)
 project(cbor_tags VERSION 0.20.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ pattern.
 - Optional C++26 STL-only mode with `CBOR_TAGS_STL_ONLY=ON`; this uses `std::expected`, `std::format`, and `std::meta` and exports no fmt, nameof, or tl::expected dependency.
 - Optional C++20 named-map support through Boost.PFR field names, requiring Boost 1.84 or newer, `BOOST_PFR_CORE_NAME_ENABLED`, and a Boost CMake package config when enabled through CMake.
 - Optional CDDL enum-name support through C++26 static reflection or magic_enum 0.9.7 or newer.
-- CMake 3.23+ for raw `cmake -S/-B` builds, 3.25+ for the doctest suite or an installed CMake package with `CBOR_TAGS_INSTALL=ON`, and 3.31+ for the checked-in preset workflows.
+- CMake 3.23+ for raw `cmake -S/-B` builds, 3.25+ for tests, benchmarks, or an installed CMake package with `CBOR_TAGS_INSTALL=ON`, and 3.31+ for the checked-in preset workflows.
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -854,7 +854,7 @@ pattern.
 - Optional C++26 STL-only mode with `CBOR_TAGS_STL_ONLY=ON`; this uses `std::expected`, `std::format`, and `std::meta` and exports no fmt, nameof, or tl::expected dependency.
 - Optional C++20 named-map support through Boost.PFR field names, requiring Boost 1.84 or newer, `BOOST_PFR_CORE_NAME_ENABLED`, and a Boost CMake package config when enabled through CMake.
 - Optional CDDL enum-name support through C++26 static reflection or magic_enum 0.9.7 or newer.
-- CMake 3.20+ for raw `cmake -S/-B` builds, 3.25+ when building an installed CMake package with `CBOR_TAGS_INSTALL=ON`, and 3.31+ for the checked-in preset workflows.
+- CMake 3.23+ for raw `cmake -S/-B` builds, 3.25+ for the doctest suite or an installed CMake package with `CBOR_TAGS_INSTALL=ON`, and 3.31+ for the checked-in preset workflows.
 
 ## 📦 Installation
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.25)
 project(benchmarks_new CXX)
 
 add_library(benchmark_util INTERFACE)

--- a/benchmarks/decoder/CMakeLists.txt
+++ b/benchmarks/decoder/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
           fmt::fmt
           doctest
           nanobench
-          nameof
+          nameof::nameof
           benchmark_util
           test_util)
 cbor_tags_configure_benchmark_target(${PROJECT_NAME})

--- a/benchmarks/encoder/CMakeLists.txt
+++ b/benchmarks/encoder/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(
           fmt::fmt
           doctest
           nanobench
-          nameof
+          nameof::nameof
           benchmark_util
           test_util)
 cbor_tags_configure_benchmark_target(${PROJECT_NAME})

--- a/benchmarks/ranges/CMakeLists.txt
+++ b/benchmarks/ranges/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(
           fmt::fmt
           doctest
           nanobench
-          nameof
+          nameof::nameof
           benchmark_util
           test_util)
 cbor_tags_configure_benchmark_target(${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.25)
 project(tests VERSION 1.0.0)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/get_cpm.cmake)
 set(CPM_SOURCE_CACHE ${CMAKE_BINARY_DIR}/cpm_cache)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.23)
 project(tools VERSION 0.1.0)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/get_cpm.cmake)


### PR DESCRIPTION
## Intent

Declare the actual CMake versions required by the raw project, tools, doctest suite, and install path, and continuously exercise the minimum raw-build version.

## Changes

- raise the root and tools minimum from CMake 3.20 to 3.23, matching `FILE_SET HEADERS`
- declare CMake 3.25 for the doctest subproject, matching its pinned dependency
- document the separate 3.23 raw-build, 3.25 tests/install, and 3.31 preset requirements
- add a CMake 3.23.5 CI job that builds the CLI and semantic roundtrip example, then runs both

## Validation

- CMake 3.23.5 configure and build with `CBOR_TAGS_BUILD_CLI=ON`, `CBOR_TAGS_BUILD_EXAMPLES=ON`, and tests disabled
- `cbor_tags_basic_roundtrip` passed under CMake 3.23.5
- `cbor_tags_cli diagnostic --input hex 01` passed under CMake 3.23.5
- regular debug suite passed 31/31
- workflow YAML parsed with `yq`