### PR TITLE
fix(cwt): support array audience claims

### DIFF
--- a/doc/cwt.md
+++ b/doc/cwt.md
@@ -16,10 +16,10 @@ The base `cbor::tags` target does not link a crypto library.
 
 `claims_set` accepts both definite-length and break-terminated indefinite-length
 CBOR maps. Every decoded integer or text claim label must be unique, including
-unknown and non-canonically encoded labels. A duplicate is rejected instead of applying
-first-value-wins or last-value-wins semantics because conflicting claim values
-are not interoperable and are unsafe inputs for authorization decisions. This
-matches RFC 8949's treatment of duplicate map keys as invalid CBOR.
+unknown and non-canonically encoded labels. A duplicate is rejected instead of
+applying first-value-wins or last-value-wins semantics because conflicting claim
+values are not interoperable and are unsafe inputs for authorization decisions.
+This matches RFC 8949's treatment of duplicate map keys as invalid CBOR.
 
 Unknown integer and text claims are consumed but not retained. Integer
 `NumericDate` values must fit in `std::int64_t`; values outside that range are

--- a/doc/cwt.md
+++ b/doc/cwt.md
@@ -15,21 +15,28 @@ The base `cbor::tags` target does not link a crypto library.
 ## Claims Validation
 
 `claims_set` accepts both definite-length and break-terminated indefinite-length
-CBOR maps. Every decoded integer claim label must be unique, including unknown
-and non-canonically encoded labels. A duplicate is rejected instead of applying
+CBOR maps. Every decoded integer or text claim label must be unique, including
+unknown and non-canonically encoded labels. A duplicate is rejected instead of applying
 first-value-wins or last-value-wins semantics because conflicting claim values
 are not interoperable and are unsafe inputs for authorization decisions. This
 matches RFC 8949's treatment of duplicate map keys as invalid CBOR.
 
-Unknown integer claims are consumed but not retained. Integer `NumericDate`
-values must fit in `std::int64_t`; values outside that range are rejected rather
-than narrowed. Floating `NumericDate` values must be finite: NaN and infinities
-are rejected during encoding and decoding so expiration checks cannot fail open.
-Failed claim-map validation leaves the destination `claims_set` unchanged.
+Unknown integer and text claims are consumed but not retained. Integer
+`NumericDate` values must fit in `std::int64_t`; values outside that range are
+rejected rather than narrowed. Floating `NumericDate` values must be finite:
+NaN and infinities are rejected during encoding and decoding so expiration
+checks cannot fail open. Failed claim-map validation leaves the destination
+`claims_set` unchanged.
 
 See [RFC 8392](https://www.rfc-editor.org/rfc/rfc8392.html) for CWT claims and
 [RFC 8949 Section 5.3.1](https://www.rfc-editor.org/rfc/rfc8949.html#section-5.3.1)
 for duplicate-map-key validity.
+
+`claims_set::audience` is `std::optional<cwt::audience_claim>`, where
+`cwt::audience_claim` is `std::variant<std::string, std::vector<std::string>>`.
+This matches CWT's compact single-audience string form and its general
+array-valued audience form. Unknown claim keys, including private text-string
+keys, are consumed during decode but are not retained.
 
 ## Header Validation
 

--- a/include/cbor_tags/cwt/cwt.h
+++ b/include/cbor_tags/cwt/cwt.h
@@ -20,8 +20,9 @@
 
 namespace cbor::tags::cwt {
 
-using byte_string  = std::vector<std::byte>;
-using numeric_date = std::variant<std::int64_t, double>;
+using byte_string    = std::vector<std::byte>;
+using numeric_date   = std::variant<std::int64_t, double>;
+using audience_claim = std::variant<std::string, std::vector<std::string>>;
 
 inline constexpr std::uint64_t cwt_tag_value        = 61;
 inline constexpr std::uint64_t cose_sign1_tag_value = 18;
@@ -386,13 +387,13 @@ struct header_map {
 };
 
 struct claims_set {
-    std::optional<std::string>  issuer;
-    std::optional<std::string>  subject;
-    std::optional<std::string>  audience;
-    std::optional<numeric_date> expiration;
-    std::optional<numeric_date> not_before;
-    std::optional<numeric_date> issued_at;
-    std::optional<byte_string>  cwt_id;
+    std::optional<std::string>    issuer;
+    std::optional<std::string>    subject;
+    std::optional<audience_claim> audience;
+    std::optional<numeric_date>   expiration;
+    std::optional<numeric_date>   not_before;
+    std::optional<numeric_date>   issued_at;
+    std::optional<byte_string>    cwt_id;
 
     template <typename Encoder> constexpr auto encode(Encoder &enc) const {
         if ((expiration && !detail::is_finite_numeric_date(*expiration)) || (not_before && !detail::is_finite_numeric_date(*not_before)) ||
@@ -499,7 +500,7 @@ struct claims_set {
                 }
                 decoded.subject = std::move(value);
             } else if (key->value == 3U) {
-                std::string value;
+                audience_claim value;
                 const auto  value_status = dec.decode(value);
                 if (value_status != status_code::success) {
                     return value_status;

--- a/include/cbor_tags/cwt/cwt.h
+++ b/include/cbor_tags/cwt/cwt.h
@@ -501,7 +501,7 @@ struct claims_set {
                 decoded.subject = std::move(value);
             } else if (key->value == 3U) {
                 audience_claim value;
-                const auto  value_status = dec.decode(value);
+                const auto     value_status = dec.decode(value);
                 if (value_status != status_code::success) {
                     return value_status;
                 }

--- a/test/test_cwt.cpp
+++ b/test/test_cwt.cpp
@@ -157,6 +157,70 @@ TEST_CASE("CWT claims roundtrip array-valued audience") {
     CHECK_EQ(dec.tell(), encoded.end());
 }
 
+TEST_CASE("CWT claims accept empty and indefinite audience arrays") {
+    SUBCASE("empty array roundtrip") {
+        claims_set claims;
+        claims.audience = std::vector<std::string>{};
+
+        std::vector<std::byte> encoded;
+        auto                   enc = make_encoder(encoded);
+        REQUIRE(enc(claims));
+        CHECK_EQ(to_hex(encoded), "a10380");
+
+        claims_set decoded;
+        REQUIRE(make_decoder(encoded)(decoded));
+        REQUIRE(decoded.audience);
+        REQUIRE(std::holds_alternative<std::vector<std::string>>(*decoded.audience));
+        CHECK(std::get<std::vector<std::string>>(*decoded.audience).empty());
+    }
+
+    SUBCASE("indefinite map and array") {
+        auto       input = to_bytes("bf039f61616162ffff");
+        claims_set decoded;
+        auto       dec = make_decoder(input);
+
+        REQUIRE(dec(decoded));
+        REQUIRE(decoded.audience);
+        REQUIRE(std::holds_alternative<std::vector<std::string>>(*decoded.audience));
+        CHECK_EQ(std::get<std::vector<std::string>>(*decoded.audience), (std::vector<std::string>{"a", "b"}));
+        CHECK_EQ(dec.tell(), input.end());
+    }
+}
+
+TEST_CASE("CWT claims reject malformed audience arrays atomically") {
+    constexpr std::array malformed{
+        "a103826576616c696401",
+        "a1039f6161",
+    };
+
+    for (const auto hex : malformed) {
+        CAPTURE(hex);
+        auto       input = to_bytes(hex);
+        claims_set decoded;
+        decoded.issuer   = "unchanged";
+        decoded.audience = std::string{"unchanged"};
+        auto result      = make_decoder(input)(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(decoded.issuer, "unchanged");
+        REQUIRE(decoded.audience);
+        CHECK_EQ(*decoded.audience, audience_claim{std::string{"unchanged"}});
+    }
+}
+
+TEST_CASE("encoded item view options retain array-valued audience claims") {
+    auto       input = to_bytes("a1039f61616162ff");
+    claims_set decoded;
+    auto       dec    = make_decoder_with_options<encoded_item_view_decoder_options>(input);
+    auto       result = dec(decoded);
+
+    REQUIRE(result);
+    REQUIRE(decoded.audience);
+    CHECK_EQ(*decoded.audience, (audience_claim{std::vector<std::string>{"a", "b"}}));
+    CHECK_EQ(to_hex(result->bytes()), to_hex(input));
+    CHECK_EQ(dec.tell(), input.end());
+}
+
 TEST_CASE("encoded item view options decode non-empty CWT claims maps") {
     claims_set claims;
     claims.issuer     = "idp";

--- a/test/test_cwt.cpp
+++ b/test/test_cwt.cpp
@@ -138,6 +138,25 @@ TEST_CASE("CWT claims encode with registered integer claim keys") {
     CHECK_EQ(decoded.cwt_id, claims.cwt_id);
 }
 
+TEST_CASE("CWT claims roundtrip array-valued audience") {
+    claims_set claims;
+    claims.audience = std::vector<std::string>{"coap://light.example.com", "coap://sensor.example.com"};
+
+    std::vector<std::byte> encoded;
+    auto                   enc = make_encoder(encoded);
+    REQUIRE(enc(claims));
+    CHECK_EQ(to_hex(encoded),
+             "a103827818636f61703a2f2f6c696768742e6578616d706c652e636f6d7819636f61703a2f2f73656e736f722e6578616d706c652e636f6d");
+
+    claims_set decoded;
+    auto       dec = make_decoder(encoded);
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded.audience);
+    REQUIRE(std::holds_alternative<std::vector<std::string>>(*decoded.audience));
+    CHECK_EQ(std::get<std::vector<std::string>>(*decoded.audience), std::get<std::vector<std::string>>(*claims.audience));
+    CHECK_EQ(dec.tell(), encoded.end());
+}
+
 TEST_CASE("encoded item view options decode non-empty CWT claims maps") {
     claims_set claims;
     claims.issuer     = "idp";


### PR DESCRIPTION
## Summary

- Represent `claims_set::audience` as `std::optional<cwt::audience_claim>`, where `audience_claim` is `std::variant<std::string, std::vector<std::string>>`.
- Decode claim key 3 through that variant so both the compact single StringOrURI and array-valued audience forms work.
- Add a regression test that encodes and decodes a multi-audience CWT claim and documents the public type.

## Validation

- `cmake --preset debug-tests`
- `cmake --build --preset debug-tests --parallel`
- `./build/debug-tests/test/tests --test-case="*CWT*"`
- `ctest --test-dir build/debug-tests --output-on-failure` (50/50)
- `scripts/format-cxx.sh --check`
- `git diff --check`

Fixes PR #69 review comment: https://github.com/jkammerland/cbor_tags/pull/69#discussion_r3607870479

## Stack

#54 → #70 → #71. Merge #54 first, then #70; retarget or rebase #71 only after #70 is in `master`.