### PR TITLE
ci: skip docs-only workflow runs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,8 +3,14 @@ name: macOS Tests (AppleClang C++20/26)
 on:
   push:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,8 +3,14 @@ name: Quality (Lint, Coverage)
 on:
   push:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 permissions:
   contents: read

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,8 +3,14 @@ name: Ubuntu Tests (GCC 12-16, LLVM 17-22)
 on:
   push:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,8 +3,14 @@ name: Windows Tests (MSVC/Clang-CL C++20/26)
 on:
   push:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   pull_request:
     branches: [ master, integration ]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- skip macOS, Windows, Ubuntu, and quality workflows when every changed file is Markdown or `LICENSE`
- apply the same filter to pushes and pull requests targeting `master` or `integration`
- keep all CMake, GitHub workflow/action, shell script, source, and documentation-tooling changes CI-triggering

GitHub evaluates `paths-ignore` against every changed path. A mixed change such as `README.md` plus `CMakeLists.txt` therefore still runs CI.

The filter intentionally uses `**.md` instead of `doc/**`, because `doc/test_readme/` contains a `CMakeLists.txt` and C++ tooling that must continue to trigger CI.

## Validation

- `actionlint v1.7.7` passed for all four workflows, ignoring only its outdated unknown-runner warning for GitHub's `macos-26` label
- `git diff --check` passed
- confirmed the active repository ruleset does not require status checks, avoiding pending required checks on path-filtered PRs

Reference: [GitHub Actions path filtering](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore)