### PR TITLE
test(cddl): fix STL-only negative harness

### DIFF
--- a/test/named_map_extension_fields_compile_fail.cc
+++ b/test/named_map_extension_fields_compile_fail.cc
@@ -66,7 +66,7 @@ int main() {
     auto                   dec = cbor::tags::make_decoder(input);
     (void)dec(cbor::tags::as_named_map{value});
 #elif defined(CBOR_TAGS_EXTENSION_FIELDS_CDDL)
-    fmt::memory_buffer output;
+    std::string output;
     cbor::tags::cddl_schema_to<cbor::tags::as_named_map<TestRoot>>(output, {.root_name = "bad"});
 #else
 #error "expected an extension-field compile-fail mode"


### PR DESCRIPTION
## Summary

- use `std::string` as the CDDL output buffer in the named-extension compile-failure harness
- keep the harness independent of the fmt-backed or STL-only formatting backend
- restore the intended duplicate-extension diagnostic checks for all three aggregate shapes

## Root cause

The negative test declared `fmt::memory_buffer` directly. In an STL-only C++26
build, compilation stopped at the missing `fmt` namespace before reaching the
expected `as_named_extension` uniqueness diagnostic.

## Validation

- C++26 STL-only/std::meta suite: 57/57 passed
- C++20 Boost.PFR suite: 57/57 passed
- clang-format check
- `git diff --check`
