### PR TITLE
fix: address accepted review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,18 @@ out-of-bounds access and attacker-controlled allocation attempts.
 
 Mutable contiguous destinations whose exposed storage overlaps the decoder input
 are rejected with `status_code::error`; use separate input and output storage.
-Custom destinations must not write into decoder input storage that is not exposed
-by their range. Fixed-size destinations and borrowed views retain their exact-size
-or assignment semantics. Advanced callers that can guarantee separate storage
-can disable the runtime check through `unchecked_aliasing_decoder_options`; see
-[encoder and decoder options](doc/options.md#unchecked-inputoutput-aliasing).
+The runtime check recognizes only direct/common contiguous aliases: input range
+adaptors and views that hide shared storage are unsupported and must also use
+separate storage. Fixed-size destinations and borrowed views retain their
+exact-size or assignment semantics. Advanced callers that can guarantee
+separate storage can disable the runtime check through
+`unchecked_aliasing_decoder_options`; see [encoder and decoder
+options](doc/options.md#unchecked-inputoutput-aliasing).
+
+While encoding, input values must not alias an appendable output buffer. A
+fixed output span may share its backing allocation with a source span only when
+their byte regions do not overlap; see [encoder source/output
+aliasing](doc/options.md#encoder-sourceoutput-aliasing).
 
 Equivalent to manually encoding the struct in the following example:
 ```cpp

--- a/doc/options.md
+++ b/doc/options.md
@@ -109,8 +109,50 @@ using unchecked_aliasing_decoder_options =
 The option removes the runtime checks at compile time. Violating the caller
 promise can invalidate decoder input and cause undefined behavior. The checked
 mode detects identical input/output objects and overlapping contiguous ranges;
-custom destinations must not write through hidden storage that overlaps the
-input.
+it is not a general alias analysis.
+
+The input must not alias a mutable owning string or byte-string destination
+through an adaptor, proxy, or non-contiguous view, even with the checked mode.
+For example, this is unsupported because the `transform_view` hides the
+vector's storage from the runtime overlap check:
+
+```cpp
+std::vector<std::byte> storage{std::byte{0x42}, std::byte{0x01}, std::byte{0x02}};
+auto input = storage | std::views::transform([](std::byte& byte) -> std::byte& { return byte; });
+
+auto dec = make_decoder(input);
+dec(storage); // Unsupported: input and mutable destination share storage.
+```
+
+Keep decoder input and mutable string destinations in separate storage. This
+contract also applies to `std::ranges::subrange`, segmented ranges, and custom
+views that refer to destination storage.
+
+## Encoder Source/Output Aliasing
+
+Values passed to an encoder must not alias an appendable output buffer. In
+particular, `enc(output)` and encoding a view into `output` are unsupported:
+the encoder writes headers to the output before it copies the value.
+
+Fixed output spans can share a backing allocation with the source only when the
+source region does not overlap bytes the encoder writes. For example, reserve a
+separate source region after the fixed output region:
+
+```cpp
+std::array<std::byte, 5> storage{
+    std::byte{}, std::byte{}, std::byte{}, std::byte{0x01}, std::byte{0x02}};
+std::span<std::byte, 3>       output{storage.data(), 3};
+std::span<const std::byte, 2> source{storage.data() + 3, 2};
+
+auto enc = make_encoder(output);
+enc(source);
+
+// output now contains: 42 01 02
+```
+
+Passing the complete output span as the source, or otherwise overlapping the
+source with bytes the encoder writes, remains unsupported. Use separate storage
+when that layout is not practical.
 
 ## Wrapping Groups
 

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -492,8 +492,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return status_code::no_match_for_tag_on_buffer;
         }
 
-        auto decoded_value = dynamic_tag<T>{decode_unsigned(additionalInfo)};
-        if (decoded_value.cbor_tag != value.cbor_tag) {
+        if (decode_unsigned(additionalInfo) != static_cast<std::uint64_t>(value.cbor_tag)) {
             return status_code::no_match_for_tag;
         }
 

--- a/include/cbor_tags/detail/custom_codec_1_serialization.h
+++ b/include/cbor_tags/detail/custom_codec_1_serialization.h
@@ -96,6 +96,10 @@ class span_reader {
     std::size_t                position_{};
 };
 
+[[nodiscard]] constexpr std::uint64_t bounded_reservation_length(std::uint64_t length, std::size_t remaining) noexcept {
+    return std::cmp_less(remaining, length) ? static_cast<std::uint64_t>(remaining) : length;
+}
+
 class size_writer {
   public:
     constexpr void write_byte(std::byte) noexcept { ++size_; }
@@ -327,7 +331,7 @@ template <typename Value, typename Container> constexpr Value make_decode_value_
     }
 }
 
-template <typename T> constexpr status_code reserve_decoded_container(T &value, std::uint64_t length) {
+template <typename T> constexpr status_code reserve_decoded_container(T &value, std::uint64_t length, std::uint64_t reservation_length) {
     using type = std::remove_cvref_t<T>;
     if constexpr (requires { typename type::size_type; }) {
         if (length > static_cast<std::uint64_t>(std::numeric_limits<typename type::size_type>::max())) {
@@ -340,7 +344,10 @@ template <typename T> constexpr status_code reserve_decoded_container(T &value, 
         }
     }
     if constexpr (HasReserve<type>) {
-        value.reserve(static_cast<typename type::size_type>(length));
+        if (reservation_length == 0U) {
+            return status_code::success;
+        }
+        value.reserve(static_cast<typename type::size_type>(reservation_length));
     }
     return status_code::success;
 }
@@ -552,7 +559,7 @@ template <typename T> constexpr status_code decode_byte_string(span_reader &read
         }
     } else {
         auto decoded = make_decode_value_for_existing(value);
-        status       = reserve_decoded_container(decoded, length);
+        status       = reserve_decoded_container(decoded, length, length);
         if (status != status_code::success) {
             return status;
         }
@@ -744,7 +751,7 @@ template <typename T> constexpr status_code decode_map(span_reader &reader, T &v
     if constexpr (requires { value.clear(); }) {
         value.clear();
     }
-    status = reserve_decoded_container(value, length);
+    status = reserve_decoded_container(value, length, bounded_reservation_length(length, reader.remaining()));
     if (status != status_code::success) {
         return status;
     }
@@ -839,6 +846,15 @@ template <typename T> constexpr status_code decode_contiguous_bulk_range(span_re
 }
 
 template <typename T> constexpr status_code decode_resizable_bulk_range(span_reader &reader, T &value, std::uint64_t length) {
+    using element_type = std::ranges::range_value_t<T>;
+    if (byte_size_overflows<element_type>(length)) {
+        return status_code::error;
+    }
+    const auto byte_count = static_cast<std::size_t>(length) * sizeof(element_type);
+    if (byte_count > reader.remaining()) {
+        return status_code::incomplete;
+    }
+
     auto status = resize_decoded_range(value, length);
     if (status != status_code::success) {
         return status;
@@ -878,7 +894,7 @@ template <typename T> constexpr status_code decode_range(span_reader &reader, T 
         } else if constexpr (ResizableRange<T> && is_bulk_little_endian_scalar_v<std::ranges::range_value_t<T>>) {
             return decode_resizable_bulk_range(reader, value, length);
         }
-        status = reserve_decoded_container(value, length);
+        status = reserve_decoded_container(value, length, bounded_reservation_length(length, reader.remaining()));
         if (status != status_code::success) {
             return status;
         }

--- a/include/cbor_tags/float16_ieee754.h
+++ b/include/cbor_tags/float16_ieee754.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <bit>
 #include <cmath>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <functional>
 #include <limits>
 
@@ -16,6 +17,14 @@ struct float16_t {
     float16_t(std::uint16_t value) : value(value) {}
     float16_t(float f) { *this = f; }
     float16_t(double d) { *this = d; }
+
+    // Keep encoded binary16 values usable as keys: signed zero and NaN payloads
+    // remain distinct. Convert explicitly to float for numeric comparisons.
+    friend constexpr bool operator==(float16_t lhs, float16_t rhs) noexcept { return lhs.value == rhs.value; }
+
+    friend constexpr std::strong_ordering operator<=>(float16_t lhs, float16_t rhs) noexcept {
+        return total_order_key(lhs.value) <=> total_order_key(rhs.value);
+    }
 
     operator float() const {
         unsigned exp  = (value >> 10) & 0x1f;
@@ -36,46 +45,81 @@ struct float16_t {
     operator double() const { return static_cast<double>(static_cast<float>(*this)); }
 
     float16_t &operator=(float f) {
-        std::uint32_t x;
-        std::memcpy(&x, &f, sizeof(float));
-
-        std::uint32_t sign         = (x >> 16) & 0x8000;
-        std::uint32_t raw_exponent = (x >> 23) & 0xffU;
-        int           exponent     = static_cast<int>(raw_exponent) - 127;
-        std::uint32_t mantissa     = x & 0x7fffff;
-
-        if (raw_exponent == 0xffU) {
-            value = sign | (mantissa == 0U ? 0x7c00U : 0x7e00U);
-        } else if (exponent > 15) {
-            // Overflow, set to infinity
-            value = sign | 0x7c00;
-        } else if (exponent < -14) {
-            // Underflow
-            if (exponent >= -24) {
-                // Denormalized
-                mantissa |= 0x800000;
-                value = sign | (mantissa >> (-(exponent + 14) + 1));
-            } else {
-                // Zero
-                value = sign;
-            }
-        } else {
-            // Normalized
-            value = sign | ((exponent + 15) << 10) | (mantissa >> 13);
-        }
-
+        value = binary16_from_ieee_bits<8U, 23U, 127>(std::bit_cast<std::uint32_t>(f));
         return *this;
     }
 
     float16_t &operator=(double d) {
-        *this = static_cast<float>(d);
+        value = binary16_from_ieee_bits<11U, 52U, 1023>(std::bit_cast<std::uint64_t>(d));
         return *this;
+    }
+
+  private:
+    [[nodiscard]] static constexpr std::uint64_t round_right_to_even(std::uint64_t value, unsigned int shift) noexcept {
+        if (shift == 0U) {
+            return value;
+        }
+
+        const auto truncated      = value >> shift;
+        const auto remainder_mask = (std::uint64_t{1} << shift) - 1U;
+        const auto remainder      = value & remainder_mask;
+        const auto halfway        = std::uint64_t{1} << (shift - 1U);
+
+        return truncated + static_cast<std::uint64_t>(remainder > halfway || (remainder == halfway && (truncated & 1U) != 0U));
+    }
+
+    [[nodiscard]] static constexpr std::uint16_t total_order_key(std::uint16_t bits) noexcept {
+        return (bits & 0x8000U) != 0U ? static_cast<std::uint16_t>(~bits) : static_cast<std::uint16_t>(bits | 0x8000U);
+    }
+
+    template <unsigned int ExponentBits, unsigned int FractionBits, int ExponentBias>
+    [[nodiscard]] static constexpr std::uint16_t binary16_from_ieee_bits(std::uint64_t bits) noexcept {
+        const auto sign          = static_cast<std::uint16_t>((bits >> (FractionBits + ExponentBits - 15U)) & 0x8000U);
+        const auto exponent_mask = (std::uint64_t{1} << ExponentBits) - 1U;
+        const auto fraction_mask = (std::uint64_t{1} << FractionBits) - 1U;
+        const auto raw_exponent  = static_cast<unsigned int>((bits >> FractionBits) & exponent_mask);
+        const auto fraction      = bits & fraction_mask;
+
+        if (raw_exponent == exponent_mask) {
+            return static_cast<std::uint16_t>(sign | (fraction == 0U ? 0x7C00U : 0x7E00U));
+        }
+        if (raw_exponent == 0U) {
+            return sign;
+        }
+
+        const auto exponent = static_cast<int>(raw_exponent) - ExponentBias;
+        if (exponent > 15) {
+            return static_cast<std::uint16_t>(sign | 0x7C00U);
+        }
+
+        if (exponent >= -14) {
+            auto half_exponent = exponent + 15;
+            auto half_fraction = round_right_to_even(fraction, FractionBits - 10U);
+            if (half_fraction == 0x400U) {
+                half_fraction = 0U;
+                ++half_exponent;
+            }
+            if (half_exponent >= 31) {
+                return static_cast<std::uint16_t>(sign | 0x7C00U);
+            }
+            return static_cast<std::uint16_t>(sign | (static_cast<std::uint16_t>(half_exponent) << 10U) |
+                                              static_cast<std::uint16_t>(half_fraction));
+        }
+
+        if (exponent < -25) {
+            return sign;
+        }
+
+        const auto significand   = fraction | (std::uint64_t{1} << FractionBits);
+        const auto shift         = static_cast<unsigned int>(static_cast<int>(FractionBits) - exponent - 24);
+        const auto half_fraction = round_right_to_even(significand, shift);
+        return static_cast<std::uint16_t>(sign | static_cast<std::uint16_t>(half_fraction));
     }
 };
 } // namespace cbor::tags
 
 namespace std {
 template <> struct hash<cbor::tags::float16_t> {
-    size_t operator()(const cbor::tags::float16_t &f) const { return std::hash<float>{}(f.value); }
+    size_t operator()(const cbor::tags::float16_t &f) const { return std::hash<std::uint16_t>{}(f.value); }
 };
 } // namespace std

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -16,7 +16,75 @@ Environment:
   CXX          C++ compiler (default: g++)
   GCOVR        gcovr executable (default: gcovr)
   JOBS         build parallelism (default: CMake default)
+
+For safety, an existing report directory is reset only when it contains the
+.cbor-tags-generated marker written by this script.
 EOF
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 2
+}
+
+repo_subdirectory() {
+    local base="$1"
+    local requested="$2"
+    local label="$3"
+    local candidate relative current component
+    local -a components
+
+    while [[ "$requested" == ./* ]]; do
+        requested="${requested#./}"
+    done
+
+    if [[ "$requested" == /* ]]; then
+        candidate="$requested"
+    else
+        candidate="$root/$requested"
+    fi
+
+    [[ "$candidate" == "$base/"* ]] || die "$label must be a subdirectory of $base"
+    [[ ! -L "$base" ]] || die "$label base directory must not be a symbolic link: $base"
+
+    relative="${candidate#"$base"/}"
+    case "/$relative/" in
+        *'//'*|*'/./'*|*'/../'*)
+            die "$label must not contain empty, '.' or '..' path components"
+            ;;
+    esac
+
+    current="$base"
+    local IFS='/'
+    read -r -a components <<< "$relative"
+    for component in "${components[@]}"; do
+        current="$current/$component"
+        [[ ! -L "$current" ]] || die "$label must not traverse a symbolic link: $current"
+    done
+
+    printf '%s\n' "$candidate"
+}
+
+require_resettable_generated_dir() {
+    local path="$1"
+    local label="$2"
+    local marker="$path/.cbor-tags-generated"
+
+    [[ ! -L "$path" ]] || die "$label must not be a symbolic link: $path"
+    if [[ -e "$path" ]]; then
+        [[ -d "$path" ]] || die "$label must be a directory: $path"
+        [[ -f "$marker" && ! -L "$marker" ]] ||
+            die "refusing to delete unmarked $label: $path (remove it manually once if it is disposable)"
+    fi
+}
+
+reset_generated_dir() {
+    local path="$1"
+
+    require_resettable_generated_dir "$path" "report directory"
+    rm -rf -- "$path"
+    mkdir -p -- "$path"
+    : > "$path/.cbor-tags-generated"
 }
 
 case "${1:-}" in
@@ -33,13 +101,15 @@ case "${1:-}" in
 esac
 
 root="$(git rev-parse --show-toplevel)"
+root="$(cd -- "$root" && pwd -P)"
 cd "$root"
 
 cc="${CC:-gcc}"
 cxx="${CXX:-g++}"
 gcovr="${GCOVR:-gcovr}"
-build_dir="${BUILD_DIR:-build/coverage}"
-report_dir="${REPORT_DIR:-coverage-report}"
+build_dir="$(repo_subdirectory "$root/build" "${BUILD_DIR:-build/coverage}" "BUILD_DIR")"
+report_dir="$(repo_subdirectory "$root" "${REPORT_DIR:-coverage-report}" "REPORT_DIR")"
+require_resettable_generated_dir "$report_dir" "REPORT_DIR"
 
 for tool in cmake ctest python3 "$cc" "$cxx" "$gcovr"; do
     if ! command -v "$tool" >/dev/null 2>&1; then
@@ -81,8 +151,7 @@ fi
 cmake "${build_args[@]}"
 ctest --test-dir "$build_dir" --output-on-failure
 
-rm -rf "$report_dir"
-mkdir -p "$report_dir"
+reset_generated_dir "$report_dir"
 
 "$gcovr" \
     --root "$root" \

--- a/scripts/run-installed-consumer.sh
+++ b/scripts/run-installed-consumer.sh
@@ -1,8 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+die() {
+  echo "error: $*" >&2
+  exit 2
+}
+
+canonical_generated_dir() {
+  local requested="$1"
+  local label="$2"
+  local parent name
+
+  case "/$requested/" in
+    *'/./'*|*'/../'*)
+      die "$label must not contain '.' or '..' path components"
+      ;;
+  esac
+
+  name="$(basename -- "$requested")"
+  [[ "$name" != "." && "$name" != ".." && "$name" != "/" ]] ||
+    die "$label must name a directory"
+
+  parent="$(dirname -- "$requested")"
+  mkdir -p -- "$parent"
+  parent="$(cd -- "$parent" && pwd -P)"
+  printf '%s/%s\n' "$parent" "$name"
+}
+
+require_resettable_generated_dir() {
+  local path="$1"
+  local label="$2"
+  local marker="$path/.cbor-tags-generated"
+
+  [[ ! -L "$path" ]] || die "$label must not be a symbolic link: $path"
+  if [[ -e "$path" ]]; then
+    [[ -d "$path" ]] || die "$label must be a directory: $path"
+    [[ -f "$marker" && ! -L "$marker" ]] ||
+      die "refusing to delete unmarked $label: $path (remove it manually once if it is disposable)"
+  fi
+}
+
+reset_generated_dir() {
+  local path="$1"
+
+  require_resettable_generated_dir "$path" "consumer directory"
+  rm -rf -- "$path"
+  mkdir -p -- "$path"
+  : > "$path/.cbor-tags-generated"
+}
+
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source_dir="${CBOR_TAGS_SOURCE_DIR:-$(cd -- "${script_dir}/.." && pwd)}"
+source_dir="$(cd -- "$source_dir" && pwd -P)"
 name="${CBOR_TAGS_CONSUMER_NAME:-local}"
 build_dir="${CBOR_TAGS_BUILD_DIR:-${source_dir}/build/install-consumer-${name}}"
 install_prefix="${CBOR_TAGS_INSTALL_PREFIX:-${build_dir}/prefix}"
@@ -13,6 +62,8 @@ vcpkg_features="${CBOR_TAGS_VCPKG_FEATURES:-}"
 vcpkg_no_default_features="${CBOR_TAGS_VCPKG_NO_DEFAULT_FEATURES:-OFF}"
 consumer_mode="${CBOR_TAGS_CONSUMER_MODE:-default}"
 generator="${CBOR_TAGS_CMAKE_GENERATOR:-${CMAKE_GENERATOR:-Ninja}}"
+consumer_dir="$(canonical_generated_dir "$consumer_dir" "CBOR_TAGS_CONSUMER_DIR")"
+require_resettable_generated_dir "$consumer_dir" "CBOR_TAGS_CONSUMER_DIR"
 
 configure_args=()
 if [[ -n "${configure_flags}" ]]; then
@@ -49,8 +100,7 @@ cmake -S "${source_dir}" -B "${build_dir}" -G "${generator}" \
 cmake --build "${build_dir}" --parallel
 cmake --install "${build_dir}"
 
-rm -rf "${consumer_dir}"
-mkdir -p "${consumer_dir}"
+reset_generated_dir "${consumer_dir}"
 
 cat > "${consumer_dir}/CMakeLists.txt" <<EOF
 cmake_minimum_required(VERSION 3.25)

--- a/test/test_cbor.cpp
+++ b/test/test_cbor.cpp
@@ -182,7 +182,7 @@ TEST_CASE("CBOR Encoder") {
 
         CHECK(enc(as_array{3}, float16_t(3.14f), float(3.14f), double(3.14)));
 
-        REQUIRE_EQ(to_hex(data), "83f94247fa4048f5c3fb40091eb851eb851f");
+        REQUIRE_EQ(to_hex(data), "83f94248fa4048f5c3fb40091eb851eb851f");
 
         std::array<std::variant<float16_t, float, double>, 3> values;
         static_assert(IsSimple<float16_t>);
@@ -318,7 +318,7 @@ TEST_CASE("CBOR Encoder") {
         CHECK(enc(number_and_stuff));
         CBOR_TAGS_TEST_LOG("Number and stuff: {}\n", to_hex(data));
         if (decltype(enc)::options::wrap_groups) {
-            REQUIRE_EQ(to_hex(data), "8601026568656c6c6f03fa40800000d901ff82f94247fb40091eb851eb851f");
+            REQUIRE_EQ(to_hex(data), "8601026568656c6c6f03fa40800000d901ff82f94248fb40091eb851eb851f");
         }
         std::vector<variant> number_and_stuff_result;
         CHECK(dec(number_and_stuff_result));

--- a/test/test_cbor_operators.cpp
+++ b/test/test_cbor_operators.cpp
@@ -7,6 +7,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <variant>
 #include <vector>
 
@@ -71,4 +72,35 @@ TEST_CASE("variant comparator handles tag alternatives") {
 
 TEST_CASE("variant visitor returns false for different direct types") {
     CHECK_FALSE(cbor_variant_visitor<std::less<>>{}(std::uint64_t{1}, std::string{"1"}));
+}
+
+TEST_CASE("float16 has bitwise equality and a total ordering") {
+    const float16_t positive_zero{std::uint16_t{0x0000}};
+    const float16_t negative_zero{std::uint16_t{0x8000}};
+    const float16_t one{std::uint16_t{0x3C00}};
+    const float16_t quiet_nan{std::uint16_t{0x7E00}};
+    const float16_t other_nan{std::uint16_t{0x7E01}};
+
+    CHECK_NE(positive_zero, negative_zero);
+    CHECK_EQ(quiet_nan, quiet_nan);
+    CHECK_NE(quiet_nan, other_nan);
+    CHECK(negative_zero < positive_zero);
+    CHECK(positive_zero < one);
+    CHECK(one < quiet_nan);
+
+    std::unordered_set<float16_t> values;
+    values.insert(positive_zero);
+    values.insert(negative_zero);
+    values.insert(one);
+    values.insert(one);
+    values.insert(quiet_nan);
+    values.insert(other_nan);
+    CHECK_EQ(values.size(), 5U);
+
+    using variant_t = std::variant<float16_t, int>;
+    std::map<variant_t, int, variant_comparator<>> ordered;
+    ordered.emplace(positive_zero, 1);
+    ordered.emplace(negative_zero, 2);
+    ordered.emplace(one, 3);
+    CHECK_EQ(ordered.size(), 3U);
 }

--- a/test/test_compact_tagged.cpp
+++ b/test/test_compact_tagged.cpp
@@ -21,6 +21,7 @@
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -200,6 +201,30 @@ struct throwing_memory_resource : std::pmr::memory_resource {
     void *do_allocate(std::size_t, std::size_t) override { throw std::bad_alloc(); }
     void  do_deallocate(void *, std::size_t, std::size_t) override {}
     bool  do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
+};
+
+struct allocation_tracking_memory_resource : std::pmr::memory_resource {
+    std::size_t largest_request{};
+    std::size_t maximum_request{std::numeric_limits<std::size_t>::max()};
+
+    void reject_large_allocations(std::size_t maximum) noexcept {
+        largest_request = 0;
+        maximum_request = maximum;
+    }
+
+  private:
+    void *do_allocate(std::size_t bytes, std::size_t alignment) override {
+        largest_request = std::max(largest_request, bytes);
+        if (bytes > maximum_request) {
+            throw std::bad_alloc{};
+        }
+        return std::pmr::get_default_resource()->allocate(bytes, alignment);
+    }
+
+    void do_deallocate(void *pointer, std::size_t bytes, std::size_t alignment) override {
+        std::pmr::get_default_resource()->deallocate(pointer, bytes, alignment);
+    }
+    bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override { return this == &other; }
 };
 
 struct default_memory_resource_guard {
@@ -1158,6 +1183,46 @@ TEST_CASE("compact tagged malformed containers leave destinations unchanged") {
         REQUIRE_FALSE(result);
         CHECK(result.error() == status_code::incomplete);
         CHECK(decoded == std::map<std::uint8_t, std::string>{{9, "keep"}});
+    }
+}
+
+TEST_CASE("compact tagged truncated containers do not allocate from declared lengths") {
+    constexpr auto truncated_length = "c1488080808080808002";
+
+    SUBCASE("generic range") {
+        allocation_tracking_memory_resource resource;
+        std::pmr::vector<std::string>       decoded{&resource};
+        const auto                          maximum_safe_request = resource.largest_request;
+        resource.reject_large_allocations(maximum_safe_request);
+
+        auto result = decode_compact_hex(truncated_length, as_custom_codec_1(static_tag<1>{}, decoded));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_LE(resource.largest_request, maximum_safe_request);
+    }
+
+    SUBCASE("resizable non-contiguous scalar range") {
+        allocation_tracking_memory_resource resource;
+        std::pmr::deque<std::uint32_t>      decoded{&resource};
+        const auto                          maximum_safe_request = resource.largest_request;
+        resource.reject_large_allocations(maximum_safe_request);
+
+        auto result = decode_compact_hex(truncated_length, as_custom_codec_1(static_tag<1>{}, decoded));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_LE(resource.largest_request, maximum_safe_request);
+    }
+
+    SUBCASE("reservable map") {
+        allocation_tracking_memory_resource                 resource;
+        std::pmr::unordered_map<std::uint8_t, std::uint8_t> decoded{&resource};
+        const auto                                          maximum_safe_request = resource.largest_request;
+        resource.reject_large_allocations(maximum_safe_request);
+
+        auto result = decode_compact_hex(truncated_length, as_custom_codec_1(static_tag<1>{}, decoded));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_LE(resource.largest_request, maximum_safe_request);
     }
 }
 

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -248,6 +248,15 @@ TEST_CASE("float16 should cover infinity nan and subnormal conversions") {
 
     float16_t underflow{std::numeric_limits<float>::denorm_min()};
     CHECK_EQ(underflow.value, 0);
+
+    CHECK_EQ(float16_t{std::ldexp(1.0F, -24)}.value, std::uint16_t{0x0001});
+    CHECK_EQ(float16_t{std::ldexp(1.0, -24)}.value, std::uint16_t{0x0001});
+    CHECK_EQ(float16_t{std::ldexp(1023.0F, -24)}.value, std::uint16_t{0x03FF});
+    CHECK_EQ(float16_t{std::ldexp(1.0F, -14)}.value, std::uint16_t{0x0400});
+    CHECK_EQ(float16_t{1.00048828125F}.value, std::uint16_t{0x3C00});
+    CHECK_EQ(float16_t{1.0006F}.value, std::uint16_t{0x3C01});
+    CHECK_EQ(float16_t{65504.0F}.value, std::uint16_t{0x7BFF});
+    CHECK_EQ(float16_t{65520.0F}.value, std::uint16_t{0x7C00});
 }
 
 TEST_CASE("decoder should slice unsigned integer overflow") {

--- a/test/test_status_handling.cpp
+++ b/test/test_status_handling.cpp
@@ -592,6 +592,29 @@ TEST_SUITE("Decoding the wrong thing") {
         REQUIRE(!result);
         CHECK_EQ(result.error(), status_code::no_match_for_tag);
     }
+
+    TEST_CASE("Decode narrow dynamic tags") {
+        {
+            const auto data = std::vector<std::byte>{std::byte{0xD8}, std::byte{0x18}};
+            auto       dec  = make_decoder(data);
+            auto       tag  = dynamic_tag<std::uint8_t>{24};
+            REQUIRE(dec(tag));
+        }
+        {
+            const auto data   = std::vector<std::byte>{std::byte{0xD9}, std::byte{0x01}, std::byte{0x2C}};
+            auto       dec    = make_decoder(data);
+            auto       tag    = dynamic_tag<std::uint8_t>{44};
+            auto       result = dec(tag);
+            REQUIRE_FALSE(result);
+            CHECK_EQ(result.error(), status_code::no_match_for_tag);
+        }
+        {
+            const auto data = std::vector<std::byte>{std::byte{0xD9}, std::byte{0x01}, std::byte{0x2C}};
+            auto       dec  = make_decoder(data);
+            auto       tag  = dynamic_tag<std::uint16_t>{300};
+            REQUIRE(dec(tag));
+        }
+    }
 }
 
 TEST_SUITE("Open objects - wrap as etc") {


### PR DESCRIPTION
## Summary

- Document the checked-decoder aliasing boundary and the supported fixed-output encoder layout.
- Fix binary16 round-to-nearest-even conversion, comparison/hash semantics, and narrow dynamic-tag matching.
- Bound compact-codec reservations by available payload data and protect generated-directory cleanup with ownership markers.

## Validation

- `cmake --build --preset=debug --parallel`
- `ctest --test-dir build --output-on-failure`
- `scripts/lint-cxx.sh`
- `bash -n scripts/coverage.sh scripts/run-installed-consumer.sh`
- Manual cleanup-guard checks for external, unmarked, and symlinked paths.
- Compiled the documented aliasing examples; the fixed-span encoder example ran successfully.

## Scope

- Keeps UTF-8 chunking as the documented unsupported contract in #80.
- Leaves the typed-array direct-constructor concern unchanged, per review disposition.