### PR TITLE
fix: harden decoder and compact codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,10 @@ complete value and does not make the decoder resumable. Definite strings still
 validate their declared payload before forming a view, which prevents
 out-of-bounds access and attacker-controlled allocation attempts.
 
-Mutable contiguous destinations whose exposed storage overlaps the decoder input
-are rejected with `status_code::error`; use separate input and output storage.
-The runtime check recognizes only direct/common contiguous aliases: input range
+Mutable owning text- and byte-string destinations whose exposed contiguous
+storage overlaps the decoder input are rejected with `status_code::error`; use
+separate input and output storage. Other mutable output types must not alias
+the decoder input: the runtime check is not general alias analysis. Input range
 adaptors and views that hide shared storage are unsupported and must also use
 separate storage. Fixed-size destinations and borrowed views retain their
 exact-size or assignment semantics. Advanced callers that can guarantee
@@ -755,10 +756,10 @@ narrow to show data without truncation throw `std::runtime_error`. Set
 Invalid UTF-8 text payloads render as `non-utf8(N)`, where `N` is byte length.
 
 The same visualization helpers are available from the optional CLI tool. Build
-it with `-DCBOR_TAGS_BUILD_TOOLS=ON`:
+it with `-DCBOR_TAGS_BUILD_CLI=ON`:
 
 ```bash
-cmake -B build -G Ninja -DCBOR_TAGS_BUILD_TOOLS=ON
+cmake -B build -G Ninja -DCBOR_TAGS_BUILD_CLI=ON
 cmake --build build --target cbor_tags_cli
 ```
 

--- a/doc/custom_codec_1.md
+++ b/doc/custom_codec_1.md
@@ -195,10 +195,10 @@ auto segments = cc1::encode_borrowed_segments(static_tag<1001>{}, samples);
 
 ## Known Limitations
 
-- Malformed payloads can currently declare very large variable-size
-  container lengths before the decoder proves the payload is incomplete. Decode
-  `custom_codec_1` data only from inputs that are already bounded by your
-  transport, file-size limit, or application framing.
+- Variable-size ranges with zero-width elements, such as
+  `std::vector<std::nullptr_t>`, are unsupported. Use a fixed-extent
+  `std::span` or `std::array` when the schema must carry such elements; a fixed
+  extent bounds decoding even though each element has no payload bytes.
 - `as_custom_codec_1(...)` stores a reference and encoding observes the value
   through a `const` view. Input ranges that can only be iterated through a
   non-`const` `begin()` still need to be materialized or wrapped before

--- a/doc/custom_codec_1.md
+++ b/doc/custom_codec_1.md
@@ -113,6 +113,12 @@ as lazy tag matches do.
   char-like value types, including `std::pmr::string`.
 - `std::array` stores its elements directly; its length is part of the C++
   schema, not the payload.
+- Dynamically sized ranges and maps require each element or key/value pair to
+  consume payload bytes. Zero-width values (for example `std::nullptr_t`, or
+  an aggregate made only of tag metadata) are therefore supported only in a
+  fixed-cardinality destination such as `std::array` or a fixed-extent
+  `std::span<T, N>`. A dynamic-extent `std::span<T>` is rejected for this
+  case, even when its runtime size is known.
 - `std::optional<T>` uses a one-byte presence marker followed by `T` when set.
 - `std::variant<...>` stores the selected alternative index followed by that
   alternative.

--- a/doc/decoder_resource_limits.md
+++ b/doc/decoder_resource_limits.md
@@ -95,7 +95,10 @@ schema validation or limit how much input the application accepts.
 - `std::variant` alternatives do not currently receive their parent's PMR
   allocator context.
 
-Definite container lengths are read once and checked before `reserve`.
+Before reserving a dynamic definite container, the decoder confirms that the
+remaining input contains at least one byte per declared element. This
+structural lower bound prevents a truncated header from forcing a large
+allocation; it is not a replacement for an application-level size limit.
 Indefinite containers are decoded in one pass and can retain a successfully
 decoded prefix when a later item exceeds the bound. See
 [CDDL Size-Bounded Containers](cddl_handling.md#size-bounded-containers) for

--- a/doc/decoder_resource_limits.md
+++ b/doc/decoder_resource_limits.md
@@ -96,9 +96,10 @@ schema validation or limit how much input the application accepts.
   allocator context.
 
 Before reserving a dynamic definite container, the decoder confirms that the
-remaining input contains at least one byte per declared element. This
-structural lower bound prevents a truncated header from forcing a large
-allocation; it is not a replacement for an application-level size limit.
+remaining input contains at least one byte per declared array element or two
+bytes per declared map entry. This structural lower bound prevents a truncated
+header from forcing a large allocation; it is not a replacement for an
+application-level size limit.
 Indefinite containers are decoded in one pass and can retain a successfully
 decoded prefix when a later item exceeds the bound. See
 [CDDL Size-Bounded Containers](cddl_handling.md#size-bounded-containers) for

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -87,6 +87,24 @@ constexpr status_code skip_sized_string_payload(Reader &reader, const InputBuffe
     return status_code::success;
 }
 
+template <typename InputBuffer, typename Reader>
+constexpr status_code require_minimum_container_payload(Reader &reader, const InputBuffer &data, std::uint64_t length) {
+    using size_type = typename Reader::size_type;
+
+    if (length == 0U) {
+        return status_code::success;
+    }
+
+    if constexpr (std::numeric_limits<size_type>::max() < std::numeric_limits<std::uint64_t>::max()) {
+        if (length > static_cast<std::uint64_t>(std::numeric_limits<size_type>::max())) {
+            return status_code::incomplete;
+        }
+    }
+
+    const auto minimum_bytes = static_cast<size_type>(length);
+    return reader.empty(data, minimum_bytes - 1U) ? status_code::incomplete : status_code::success;
+}
+
 } // namespace detail
 
 template <typename InputBuffer, IsOptions Options, template <typename> typename... Decoders>
@@ -380,7 +398,12 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
         auto text = take_text_payload(payload_size);
         if constexpr (IsConstView<T>) {
-            t = std::move(text);
+            using text_char = typename std::remove_cvref_t<T>::value_type;
+            if constexpr (std::same_as<text_char, char>) {
+                t = std::move(text);
+            } else {
+                t = T{reinterpret_cast<const text_char *>(text.data()), text.size()};
+            }
         } else {
             detail::appender<T> append;
             detail::append_byte_range(append, t, text);
@@ -419,6 +442,10 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         }
         if constexpr (HasReserve<T>) {
+            const auto payload_status = detail::require_minimum_container_payload(reader_, data_, length);
+            if (payload_status != status_code::success) {
+                return payload_status;
+            }
             if (std::cmp_greater(length, std::numeric_limits<typename T::size_type>::max())) {
                 throw std::length_error("CBOR array length exceeds target container size_type");
             }

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -444,9 +444,18 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         if constexpr (HasReserve<T>) {
             if constexpr (std::ranges::sized_range<const InputBuffer>) {
                 // A known input size permits this lower-bound check without traversing
-                // the input. Do not walk an unsized range merely to reserve from an
-                // untrusted container header.
-                const auto payload_status = detail::require_minimum_container_payload(reader_, data_, length);
+                // the input. A map entry has a key and a value, whereas an array
+                // element has only one child. Do not walk an unsized range merely to
+                // reserve from an untrusted container header.
+                auto minimum_payload_length = length;
+                if constexpr (IsMap<T>) {
+                    if (length > std::numeric_limits<std::uint64_t>::max() / 2U) {
+                        return status_code::incomplete;
+                    }
+                    minimum_payload_length = length * 2U;
+                }
+
+                const auto payload_status = detail::require_minimum_container_payload(reader_, data_, minimum_payload_length);
                 if (payload_status != status_code::success) {
                     return payload_status;
                 }

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -442,14 +442,21 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             }
         }
         if constexpr (HasReserve<T>) {
-            const auto payload_status = detail::require_minimum_container_payload(reader_, data_, length);
-            if (payload_status != status_code::success) {
-                return payload_status;
-            }
-            if (std::cmp_greater(length, std::numeric_limits<typename T::size_type>::max())) {
+            if constexpr (std::ranges::sized_range<const InputBuffer>) {
+                // A known input size permits this lower-bound check without traversing
+                // the input. Do not walk an unsized range merely to reserve from an
+                // untrusted container header.
+                const auto payload_status = detail::require_minimum_container_payload(reader_, data_, length);
+                if (payload_status != status_code::success) {
+                    return payload_status;
+                }
+                if (std::cmp_greater(length, std::numeric_limits<typename T::size_type>::max())) {
+                    throw std::length_error("CBOR array length exceeds target container size_type");
+                }
+                value.reserve(static_cast<typename T::size_type>(length));
+            } else if (std::cmp_greater(length, std::numeric_limits<typename T::size_type>::max())) {
                 throw std::length_error("CBOR array length exceeds target container size_type");
             }
-            value.reserve(static_cast<typename T::size_type>(length));
         }
         detail::appender<T> appender_;
         for (auto i = length; i > 0; --i) {

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -116,7 +116,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
                       requires { appender_.append_borrowed(data_, detail::as_byte_span(value)); }) {
             appender_.append_borrowed(data_, detail::as_byte_span(value));
         } else {
-            appender_(data_, value);
+            detail::append_byte_range(appender_, data_, value);
         }
     }
 

--- a/include/cbor_tags/detail/custom_codec_1_serialization.h
+++ b/include/cbor_tags/detail/custom_codec_1_serialization.h
@@ -7,7 +7,6 @@
 #include "cbor_tags/cbor_reflection.h"
 #include "cbor_tags/cbor_segments.h"
 #include "cbor_tags/cbor_simple.h"
-#include "cbor_tags/detail/cbor_encode_error.h"
 #include "cbor_tags/float16_ieee754.h"
 
 #include <array>
@@ -34,6 +33,12 @@ namespace cbor::tags::detail::custom_codec_1 {
 template <typename T> struct is_std_array : std::false_type {};
 template <typename T, std::size_t N> struct is_std_array<std::array<T, N>> : std::true_type {};
 template <typename T> inline constexpr bool is_std_array_v = is_std_array<std::remove_cvref_t<T>>::value;
+
+// `IsFixedArray` answers whether the core decoder can write directly into a
+// range. Compact payloads need a different property here: whether the
+// cardinality is part of the C++ schema. A dynamic-extent span has a bounded
+// destination at runtime, but its cardinality is not encoded in its type.
+template <typename T> inline constexpr bool is_fixed_cardinality_range_v = is_std_array_v<T> || is_static_extent_span_v<T>;
 
 template <typename T> struct is_mutable_byte_span : std::false_type {};
 template <std::size_t Extent> struct is_mutable_byte_span<std::span<std::byte, Extent>> : std::true_type {};
@@ -364,6 +369,52 @@ template <typename T> constexpr bool tuple_first_field_is_tag() {
         return is_static_tag_t<first_type>::value || is_dynamic_tag_t<first_type>;
     }
 }
+
+// A dynamically sized compact range can use its count as the only payload
+// bytes when every element decodes without consuming input. Such a range would
+// turn a small count into an unbounded decode loop, so keep that wire shape for
+// fixed-cardinality destinations only.
+template <typename T> struct has_zero_width_compact_encoding;
+
+template <typename Tuple, std::size_t... Indices>
+consteval bool tuple_payload_has_zero_width_compact_encoding_impl(std::index_sequence<Indices...>) {
+    using tuple_type = std::remove_cvref_t<Tuple>;
+    return (((tuple_first_field_is_tag<tuple_type>() && Indices == 0U) ||
+             has_zero_width_compact_encoding<std::remove_cvref_t<std::tuple_element_t<Indices, tuple_type>>>::value) &&
+            ...);
+}
+
+template <typename Tuple> consteval bool tuple_payload_has_zero_width_compact_encoding() {
+    using tuple_type = std::remove_cvref_t<Tuple>;
+    return tuple_payload_has_zero_width_compact_encoding_impl<tuple_type>(std::make_index_sequence<std::tuple_size_v<tuple_type>>{});
+}
+
+template <typename T> struct has_zero_width_compact_encoding {
+  private:
+    using type = std::remove_cvref_t<T>;
+
+    static consteval bool value_impl() {
+        if constexpr (std::is_same_v<type, std::nullptr_t>) {
+            return true;
+        } else if constexpr (is_std_array_v<type>) {
+            return std::tuple_size_v<type> == 0U || has_zero_width_compact_encoding<typename type::value_type>::value;
+        } else if constexpr (IsUntaggedTuple<type> || IsTaggedTuple<type>) {
+            return tuple_payload_has_zero_width_compact_encoding<type>();
+        } else if constexpr (std::is_aggregate_v<type> && !IsMap<type> && !IsRangeOfCborValues<type> && !IsVariant<type> &&
+                             !is_text_string_v<type> && !IsBinaryString<type>) {
+            using tuple_type = std::remove_cvref_t<decltype(to_tuple(std::declval<type &>()))>;
+            return tuple_payload_has_zero_width_compact_encoding<tuple_type>();
+        } else {
+            return false;
+        }
+    }
+
+  public:
+    static constexpr bool value = value_impl();
+};
+
+template <typename T>
+inline constexpr bool has_zero_width_compact_encoding_v = has_zero_width_compact_encoding<std::remove_cvref_t<T>>::value;
 
 template <typename Tuple, typename Fn> constexpr decltype(auto) visit_tuple_payload(Tuple &&tuple, Fn &&fn) {
     if constexpr (tuple_first_field_is_tag<Tuple>()) {
@@ -736,6 +787,8 @@ template <IsVariant Variant> constexpr status_code decode_variant(span_reader &r
 }
 
 template <typename Writer, typename T> constexpr void encode_map(Writer &writer, const T &value) {
+    static_assert(!(has_zero_width_compact_encoding_v<typename T::key_type> && has_zero_width_compact_encoding_v<typename T::mapped_type>),
+                  "custom_codec_1 dynamically sized maps cannot contain zero-width entries; use a fixed-size std::array or tuple instead");
     write_varuint(writer, static_cast<std::uint64_t>(std::ranges::size(value)));
     for (const auto &entry : value) {
         encode_value(writer, pair_first(entry));
@@ -744,6 +797,8 @@ template <typename Writer, typename T> constexpr void encode_map(Writer &writer,
 }
 
 template <typename T> constexpr status_code decode_map(span_reader &reader, T &value) {
+    static_assert(!(has_zero_width_compact_encoding_v<typename T::key_type> && has_zero_width_compact_encoding_v<typename T::mapped_type>),
+                  "custom_codec_1 dynamically sized maps cannot contain zero-width entries; use a fixed-size std::array or tuple instead");
     std::uint64_t length{};
     auto          status = read_varuint(reader, length);
     if (status != status_code::success) {
@@ -774,15 +829,13 @@ template <typename T> constexpr status_code decode_map(span_reader &reader, T &v
 }
 
 template <typename Writer, typename T> constexpr void encode_range(Writer &writer, const T &value) {
-    using type       = std::remove_cvref_t<T>;
-    using value_type = std::ranges::range_value_t<T>;
-
+    using type = std::remove_cvref_t<T>;
+    if constexpr (!is_fixed_cardinality_range_v<type>) {
+        static_assert(
+            !has_zero_width_compact_encoding_v<std::ranges::range_value_t<T>>,
+            "custom_codec_1 dynamically sized ranges cannot contain zero-width values; use std::array or a fixed-extent std::span instead");
+    }
     if constexpr (std::ranges::sized_range<const T>) {
-        if constexpr (std::same_as<std::remove_cvref_t<value_type>, std::nullptr_t> && !IsFixedArray<type>) {
-            if (std::ranges::size(value) != 0U) {
-                throw ::cbor::tags::detail::encode_status_exception{status_code::size_limit_exceeded};
-            }
-        }
         write_varuint(writer, static_cast<std::uint64_t>(std::ranges::size(value)));
         if constexpr (is_bulk_little_endian_contiguous_range_v<const T>) {
             encode_bulk_little_endian_range(writer, value);
@@ -792,14 +845,10 @@ template <typename Writer, typename T> constexpr void encode_range(Writer &write
             }
         }
     } else {
+        using value_type = std::ranges::range_value_t<T>;
         std::vector<value_type> materialized;
         for (auto &&element : value) {
             materialized.emplace_back(std::forward<decltype(element)>(element));
-        }
-        if constexpr (std::same_as<std::remove_cvref_t<value_type>, std::nullptr_t>) {
-            if (!materialized.empty()) {
-                throw ::cbor::tags::detail::encode_status_exception{status_code::size_limit_exceeded};
-            }
         }
         write_varuint(writer, static_cast<std::uint64_t>(materialized.size()));
         for (const auto &element : materialized) {
@@ -882,6 +931,12 @@ template <typename T> constexpr status_code decode_resizable_bulk_range(span_rea
 }
 
 template <typename T> constexpr status_code decode_range(span_reader &reader, T &value) {
+    using type = std::remove_cvref_t<T>;
+    if constexpr (!is_fixed_cardinality_range_v<type>) {
+        static_assert(
+            !has_zero_width_compact_encoding_v<std::ranges::range_value_t<T>>,
+            "custom_codec_1 dynamically sized ranges cannot contain zero-width values; use std::array or a fixed-extent std::span instead");
+    }
     std::uint64_t length{};
     auto          status = read_varuint(reader, length);
     if (status != status_code::success) {

--- a/include/cbor_tags/detail/custom_codec_1_serialization.h
+++ b/include/cbor_tags/detail/custom_codec_1_serialization.h
@@ -7,6 +7,7 @@
 #include "cbor_tags/cbor_reflection.h"
 #include "cbor_tags/cbor_segments.h"
 #include "cbor_tags/cbor_simple.h"
+#include "cbor_tags/detail/cbor_encode_error.h"
 #include "cbor_tags/float16_ieee754.h"
 
 #include <array>
@@ -773,7 +774,15 @@ template <typename T> constexpr status_code decode_map(span_reader &reader, T &v
 }
 
 template <typename Writer, typename T> constexpr void encode_range(Writer &writer, const T &value) {
+    using type       = std::remove_cvref_t<T>;
+    using value_type = std::ranges::range_value_t<T>;
+
     if constexpr (std::ranges::sized_range<const T>) {
+        if constexpr (std::same_as<std::remove_cvref_t<value_type>, std::nullptr_t> && !IsFixedArray<type>) {
+            if (std::ranges::size(value) != 0U) {
+                throw ::cbor::tags::detail::encode_status_exception{status_code::size_limit_exceeded};
+            }
+        }
         write_varuint(writer, static_cast<std::uint64_t>(std::ranges::size(value)));
         if constexpr (is_bulk_little_endian_contiguous_range_v<const T>) {
             encode_bulk_little_endian_range(writer, value);
@@ -783,10 +792,14 @@ template <typename Writer, typename T> constexpr void encode_range(Writer &write
             }
         }
     } else {
-        using value_type = std::ranges::range_value_t<T>;
         std::vector<value_type> materialized;
         for (auto &&element : value) {
             materialized.emplace_back(std::forward<decltype(element)>(element));
+        }
+        if constexpr (std::same_as<std::remove_cvref_t<value_type>, std::nullptr_t>) {
+            if (!materialized.empty()) {
+                throw ::cbor::tags::detail::encode_status_exception{status_code::size_limit_exceeded};
+            }
         }
         write_varuint(writer, static_cast<std::uint64_t>(materialized.size()));
         for (const auto &element : materialized) {
@@ -900,10 +913,14 @@ template <typename T> constexpr status_code decode_range(span_reader &reader, T 
         }
         detail::appender<T> appender;
         for (std::uint64_t i = 0; i < length; ++i) {
-            auto element = make_decode_value_for_container<typename T::value_type>(value);
-            status       = decode_value(reader, element);
+            auto       element          = make_decode_value_for_container<typename T::value_type>(value);
+            const auto remaining_before = reader.remaining();
+            status                      = decode_value(reader, element);
             if (status != status_code::success) {
                 return status;
+            }
+            if (reader.remaining() == remaining_before) {
+                return status_code::size_limit_exceeded;
             }
             if constexpr (requires { value.push_back(std::move(element)); }) {
                 value.push_back(std::move(element));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,21 @@ function(add_dynamic_bounded_size_compile_fail_test TEST_NAME SOURCE_FILE PASS_R
       "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 endfunction()
 
+function(add_custom_codec_1_compile_fail_test TEST_NAME SOURCE_FILE PASS_REGEX)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+  target_link_libraries(${TEST_NAME} PRIVATE cbor::tags)
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND
+      ${CMAKE_COMMAND}
+      "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+      "-DTEST_TARGET=${TEST_NAME}"
+      "-DCONFIG=$<CONFIG>"
+      "-DPASS_REGEX=${PASS_REGEX}"
+      -P
+      "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+endfunction()
+
 add_incompatible_codec_result_compile_fail_test(
   incompatible_member_encode_result_compile_fails
   CBOR_TAGS_INCOMPATIBLE_MEMBER_ENCODE
@@ -117,6 +132,27 @@ add_dynamic_bounded_size_compile_fail_test(
   dynamic_bounded_size_nested_compile_fails
   dynamic_bounded_size_nested_compile_fail.cc
   "bounded size wrappers cannot directly contain another bounded size wrapper")
+
+add_custom_codec_1_compile_fail_test(
+  custom_codec_1_zero_width_dynamic_range_compile_fails
+  custom_codec_1_zero_width_dynamic_range_compile_fail.cc
+  "custom_codec_1 dynamically sized ranges cannot contain zero-width values")
+add_custom_codec_1_compile_fail_test(
+  custom_codec_1_zero_width_dynamic_array_compile_fails
+  custom_codec_1_zero_width_dynamic_array_compile_fail.cc
+  "custom_codec_1 dynamically sized ranges cannot contain zero-width values")
+add_custom_codec_1_compile_fail_test(
+  custom_codec_1_zero_width_dynamic_range_decode_compile_fails
+  custom_codec_1_zero_width_dynamic_range_decode_compile_fail.cc
+  "custom_codec_1 dynamically sized ranges cannot contain zero-width values")
+add_custom_codec_1_compile_fail_test(
+  custom_codec_1_zero_width_dynamic_span_compile_fails
+  custom_codec_1_zero_width_dynamic_span_compile_fail.cc
+  "custom_codec_1 dynamically sized ranges cannot contain zero-width values")
+add_custom_codec_1_compile_fail_test(
+  custom_codec_1_zero_width_dynamic_map_compile_fails
+  custom_codec_1_zero_width_dynamic_map_compile_fail.cc
+  "custom_codec_1 dynamically sized maps cannot contain zero-width entries")
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   add_dynamic_bounded_size_compile_fail_test(

--- a/test/custom_codec_1_zero_width_dynamic_array_compile_fail.cc
+++ b/test/custom_codec_1_zero_width_dynamic_array_compile_fail.cc
@@ -1,0 +1,16 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::custom_codec_1;
+
+    std::vector<std::byte>          output;
+    std::vector<std::array<int, 0>> values(1U);
+    auto                            enc = make_encoder<custom_codec_1>(output);
+    return enc(as_custom_codec_1(static_tag<1>{}, values)).has_value() ? 0 : 1;
+}

--- a/test/custom_codec_1_zero_width_dynamic_map_compile_fail.cc
+++ b/test/custom_codec_1_zero_width_dynamic_map_compile_fail.cc
@@ -1,0 +1,21 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+
+#include <compare>
+#include <cstddef>
+#include <map>
+#include <vector>
+
+struct zero_width_key {
+    constexpr auto operator<=>(const zero_width_key &) const = default;
+};
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::custom_codec_1;
+
+    std::vector<std::byte>                   output;
+    std::map<zero_width_key, std::nullptr_t> values;
+    auto                                     enc = make_encoder<custom_codec_1>(output);
+    return enc(as_custom_codec_1(static_tag<1>{}, values)).has_value() ? 0 : 1;
+}

--- a/test/custom_codec_1_zero_width_dynamic_range_compile_fail.cc
+++ b/test/custom_codec_1_zero_width_dynamic_range_compile_fail.cc
@@ -1,0 +1,15 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+
+#include <cstddef>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::custom_codec_1;
+
+    std::vector<std::byte>      output;
+    std::vector<std::nullptr_t> values(1U);
+    auto                        enc = make_encoder<custom_codec_1>(output);
+    return enc(as_custom_codec_1(static_tag<1>{}, values)).has_value() ? 0 : 1;
+}

--- a/test/custom_codec_1_zero_width_dynamic_range_decode_compile_fail.cc
+++ b/test/custom_codec_1_zero_width_dynamic_range_decode_compile_fail.cc
@@ -1,0 +1,16 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+
+#include <array>
+#include <cstddef>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::custom_codec_1;
+
+    const std::vector<std::byte>    input;
+    std::vector<std::array<int, 0>> values;
+    auto                            dec = make_decoder<custom_codec_1>(input);
+    return dec(as_custom_codec_1(static_tag<1>{}, values)).has_value() ? 0 : 1;
+}

--- a/test/custom_codec_1_zero_width_dynamic_span_compile_fail.cc
+++ b/test/custom_codec_1_zero_width_dynamic_span_compile_fail.cc
@@ -1,0 +1,18 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/custom_codec_1.h"
+
+#include <array>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::custom_codec_1;
+
+    std::array<std::nullptr_t, 1> storage{nullptr};
+    std::span<std::nullptr_t>     values{storage};
+    std::vector<std::byte>        output;
+    auto                          enc = make_encoder<custom_codec_1>(output);
+    return enc(as_custom_codec_1(static_tag<1>{}, values)).has_value() ? 0 : 1;
+}

--- a/test/test_compact_tagged.cpp
+++ b/test/test_compact_tagged.cpp
@@ -1161,6 +1161,40 @@ TEST_CASE("compact tagged rejects malformed compact lengths and variant indexes"
     }
 }
 
+TEST_CASE("compact tagged requires a fixed extent for zero-width range elements") {
+    SUBCASE("dynamic ranges are rejected by the encoder") {
+        const std::vector<std::nullptr_t> values(2);
+        std::vector<std::byte>            encoded;
+
+        auto result = make_encoder<custom_codec_1>(encoded)(as_custom_codec_1(static_tag<1>{}, values));
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(encoded.empty());
+    }
+
+    SUBCASE("dynamic ranges are rejected before a declared count can spin") {
+        std::vector<std::nullptr_t> decoded;
+        auto                        result = decode_compact_hex("c1488080808080808002", as_custom_codec_1(static_tag<1>{}, decoded));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
+        CHECK(decoded.empty());
+    }
+
+    SUBCASE("fixed-extent spans remain supported") {
+        std::array<std::nullptr_t, 2> backing{};
+        std::span<std::nullptr_t, 2>  values{backing};
+        std::vector<std::byte>        encoded;
+
+        REQUIRE(make_encoder<custom_codec_1>(encoded)(as_custom_codec_1(static_tag<1>{}, values)));
+        CHECK_EQ(to_hex(encoded), "c14102");
+
+        std::array<std::nullptr_t, 2> decoded_backing{};
+        std::span<std::nullptr_t, 2>  decoded{decoded_backing};
+        REQUIRE(decode_compact_hex("c14102", as_custom_codec_1(static_tag<1>{}, decoded)));
+    }
+}
+
 TEST_CASE("compact tagged malformed containers leave destinations unchanged") {
 
     {

--- a/test/test_compact_tagged.cpp
+++ b/test/test_compact_tagged.cpp
@@ -19,6 +19,7 @@
 #include <new>
 #include <optional>
 #include <ranges>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -1161,38 +1162,36 @@ TEST_CASE("compact tagged rejects malformed compact lengths and variant indexes"
     }
 }
 
-TEST_CASE("compact tagged requires a fixed extent for zero-width range elements") {
-    SUBCASE("dynamic ranges are rejected by the encoder") {
-        const std::vector<std::nullptr_t> values(2);
-        std::vector<std::byte>            encoded;
+TEST_CASE("compact tagged permits zero-width values in fixed-cardinality ranges") {
+    const std::array<std::nullptr_t, 3> values{nullptr, nullptr, nullptr};
 
-        auto result = make_encoder<custom_codec_1>(encoded)(as_custom_codec_1(static_tag<1>{}, values));
-        REQUIRE_FALSE(result);
-        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
-        CHECK(encoded.empty());
-    }
+    std::vector<std::byte> compact;
+    auto                   enc = make_encoder<custom_codec_1>(compact);
+    REQUIRE(enc(as_custom_codec_1(static_tag<20>{}, values)));
+    CHECK_EQ(to_hex(compact), "d440");
 
-    SUBCASE("dynamic ranges are rejected before a declared count can spin") {
-        std::vector<std::nullptr_t> decoded;
-        auto                        result = decode_compact_hex("c1488080808080808002", as_custom_codec_1(static_tag<1>{}, decoded));
+    std::array<std::nullptr_t, 3> decoded{nullptr, nullptr, nullptr};
+    auto                          dec = make_decoder<custom_codec_1>(compact);
+    REQUIRE(dec(as_custom_codec_1(static_tag<20>{}, decoded)));
+    CHECK(decoded == values);
 
-        REQUIRE_FALSE(result);
-        CHECK_EQ(result.error(), status_code::size_limit_exceeded);
-        CHECK(decoded.empty());
-    }
+    std::array<std::nullptr_t, 2> span_values{nullptr, nullptr};
+    std::span<std::nullptr_t, 2>  fixed_span{span_values};
+    compact.clear();
+    REQUIRE(enc(as_custom_codec_1(static_tag<21>{}, fixed_span)));
+    CHECK_EQ(to_hex(compact), "d54102");
 
-    SUBCASE("fixed-extent spans remain supported") {
-        std::array<std::nullptr_t, 2> backing{};
-        std::span<std::nullptr_t, 2>  values{backing};
-        std::vector<std::byte>        encoded;
+    std::array<std::nullptr_t, 2> span_decoded{nullptr, nullptr};
+    std::span<std::nullptr_t, 2>  decoded_span{span_decoded};
+    auto                          span_dec = make_decoder<custom_codec_1>(compact);
+    REQUIRE(span_dec(as_custom_codec_1(static_tag<21>{}, decoded_span)));
+    CHECK(std::ranges::equal(decoded_span, fixed_span));
 
-        REQUIRE(make_encoder<custom_codec_1>(encoded)(as_custom_codec_1(static_tag<1>{}, values)));
-        CHECK_EQ(to_hex(encoded), "c14102");
-
-        std::array<std::nullptr_t, 2> decoded_backing{};
-        std::span<std::nullptr_t, 2>  decoded{decoded_backing};
-        REQUIRE(decode_compact_hex("c14102", as_custom_codec_1(static_tag<1>{}, decoded)));
-    }
+    const std::array<std::nullptr_t, 2>      const_span_values{nullptr, nullptr};
+    const std::span<const std::nullptr_t, 2> const_fixed_span{const_span_values};
+    compact.clear();
+    REQUIRE(enc(as_custom_codec_1(static_tag<22>{}, const_fixed_span)));
+    CHECK_EQ(to_hex(compact), "d64102");
 }
 
 TEST_CASE("compact tagged malformed containers leave destinations unchanged") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -164,6 +165,20 @@ struct ReservationProbeRange {
     void               push_back(value_type value) { values.push_back(value); }
 };
 
+struct ReservationProbeMap : std::unordered_map<int, int> {
+    using base_type = std::unordered_map<int, int>;
+    using size_type = typename base_type::size_type;
+    using base_type::base_type;
+
+    size_type reserve_calls{};
+    size_type last_reserve{};
+
+    void reserve(size_type count) {
+        ++reserve_calls;
+        last_reserve = count;
+    }
+};
+
 struct ThrowingReservableByteBuffer {
     using value_type = std::byte;
     using size_type  = std::size_t;
@@ -254,6 +269,7 @@ static_assert(std::same_as<typename decltype(make_decoder(std::declval<SignedSiz
 static_assert(IsBinaryString<ReserveWithoutSizeByteBuffer>);
 static_assert(HasReserve<ReserveWithoutSizeByteBuffer>);
 static_assert(!detail::AppendReservable<ReserveWithoutSizeByteBuffer>);
+static_assert(IsMap<ReservationProbeMap>);
 static_assert(IsBinaryString<ThrowingReservableByteBuffer>);
 static_assert(detail::AppendReservable<ThrowingReservableByteBuffer>);
 static_assert(IsBinaryString<ExternalByteBuffer>);
@@ -1192,6 +1208,41 @@ TEST_CASE("decoder rejects truncated definite containers before reservation") {
     CHECK_EQ(result.error(), status_code::incomplete);
     CHECK_EQ(decoded.reserve_calls, 0U);
     CHECK(decoded.values.empty());
+}
+
+TEST_CASE("decoder reserves sized maps only when each pair has a payload lower bound") {
+    SUBCASE("complete map retains the reserve fast path") {
+        const std::vector<std::byte> input{
+            std::byte{0xA2}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04},
+        };
+        ReservationProbeMap decoded;
+
+        auto result = make_decoder(input)(decoded);
+
+        REQUIRE(result);
+        CHECK_EQ(decoded.reserve_calls, 1U);
+        CHECK_EQ(decoded.last_reserve, 2U);
+        CHECK_EQ(decoded.size(), 2U);
+        CHECK_EQ(decoded.at(1), 2);
+        CHECK_EQ(decoded.at(3), 4);
+    }
+
+    SUBCASE("truncated map cannot force a reserve") {
+        const std::vector<std::byte> input{
+            std::byte{0xA2},
+            std::byte{0x01},
+            std::byte{0x02},
+            std::byte{0x03},
+        };
+        ReservationProbeMap decoded;
+
+        auto result = make_decoder(input)(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_EQ(decoded.reserve_calls, 0U);
+        CHECK(decoded.empty());
+    }
 }
 
 TEST_CASE("decoder skips reservation for unsized input ranges") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -146,6 +146,23 @@ struct ReserveWithoutSizeByteBuffer {
     void               push_back(value_type value) { bytes.push_back(value); }
 };
 
+struct ReservationProbeRange {
+    using value_type = std::uint8_t;
+    using size_type  = std::size_t;
+
+    ReservationProbeRange() {}
+
+    std::vector<value_type> values;
+    size_type               reserve_calls{};
+
+    [[nodiscard]] auto begin() noexcept { return values.begin(); }
+    [[nodiscard]] auto begin() const noexcept { return values.begin(); }
+    [[nodiscard]] auto end() noexcept { return values.end(); }
+    [[nodiscard]] auto end() const noexcept { return values.end(); }
+    void               reserve(size_type) { ++reserve_calls; }
+    void               push_back(value_type value) { values.push_back(value); }
+};
+
 struct ThrowingReservableByteBuffer {
     using value_type = std::byte;
     using size_type  = std::size_t;
@@ -1161,6 +1178,19 @@ TEST_CASE("decoder should decode definite containers without requiring indefinit
     CHECK_EQ(non_default_vector[0], 7);
     CHECK_EQ(non_default_vector[1], 8);
     CHECK_EQ(non_default_vector.get_allocator().tag, 3);
+}
+
+TEST_CASE("decoder rejects truncated definite containers before reservation") {
+    // array(1,073,741,824) with no element payload
+    const std::vector<std::byte> buffer{std::byte{0x9A}, std::byte{0x40}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+
+    ReservationProbeRange decoded;
+    auto                  result = make_decoder(buffer)(decoded);
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::incomplete);
+    CHECK_EQ(decoded.reserve_calls, 0U);
+    CHECK(decoded.values.empty());
 }
 
 TEST_CASE("decoder should decode indefinite containers without staging through assignable temporaries") {

--- a/test/test_decoder_regressions.cpp
+++ b/test/test_decoder_regressions.cpp
@@ -10,6 +10,7 @@
 #include <deque>
 #include <doctest/doctest.h>
 #include <limits>
+#include <list>
 #include <map>
 #include <memory>
 #include <memory_resource>
@@ -1186,6 +1187,34 @@ TEST_CASE("decoder rejects truncated definite containers before reservation") {
 
     ReservationProbeRange decoded;
     auto                  result = make_decoder(buffer)(decoded);
+
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::incomplete);
+    CHECK_EQ(decoded.reserve_calls, 0U);
+    CHECK(decoded.values.empty());
+}
+
+TEST_CASE("decoder skips reservation for unsized input ranges") {
+    const std::list<std::byte> storage{std::byte{0x82}, std::byte{0x01}, std::byte{0x02}};
+    auto                       input = std::ranges::subrange(storage.cbegin(), storage.cend());
+    static_assert(!std::ranges::sized_range<decltype(input)>);
+
+    ReservationProbeRange decoded;
+    auto                  result = make_decoder(input)(decoded);
+
+    REQUIRE(result);
+    CHECK_EQ(decoded.reserve_calls, 0U);
+    CHECK_EQ(decoded.values, (std::vector<std::uint8_t>{1U, 2U}));
+}
+
+TEST_CASE("decoder rejects truncated unsized definite containers without reservation") {
+    // array(1,073,741,824) with no element payload
+    const std::list<std::byte> storage{std::byte{0x9A}, std::byte{0x40}, std::byte{0x00}, std::byte{0x00}, std::byte{0x00}};
+    auto                       input = std::ranges::subrange(storage.cbegin(), storage.cend());
+    static_assert(!std::ranges::sized_range<decltype(input)>);
+
+    ReservationProbeRange decoded;
+    auto                  result = make_decoder(input)(decoded);
 
     REQUIRE_FALSE(result);
     CHECK_EQ(result.error(), status_code::incomplete);

--- a/test/test_status_handling.cpp
+++ b/test/test_status_handling.cpp
@@ -263,8 +263,16 @@ TEST_SUITE("Decoding the wrong thing") {
         check_decode_out_of_memory<std::pmr::vector<int>>(data);
     }
 
-    TEST_CASE("Decode bounded pmr array length_error returns out_of_memory") {
-        check_decode_out_of_memory<std::pmr::vector<int>>(uint64_max_array_header());
+    TEST_CASE("Decode truncated max-length array returns incomplete without allocating") {
+        throwing_memory_resource resource;
+        std::pmr::vector<int>    decoded{&resource};
+        const auto               data = uint64_max_array_header();
+
+        auto dec    = make_decoder(data);
+        auto result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
     }
 
     TEST_CASE("Decode pmr array append failure returns out_of_memory") {

--- a/test/test_unsigned_char.cc
+++ b/test/test_unsigned_char.cc
@@ -36,7 +36,9 @@ int main() {
     static_assert(!IsTextChar<unsigned char>);
     static_assert(IsTextString<std::string>);
     static_assert(IsTextString<std::string_view>);
+    static_assert(IsTextString<std::basic_string<signed char>>);
     static_assert(IsTextString<std::basic_string_view<char>>);
+    static_assert(IsTextString<std::basic_string_view<signed char>>);
     static_assert(!IsTextString<std::vector<char>>);
     static_assert(!IsTextString<std::basic_string<unsigned char>>);
     static_assert(!IsTextString<std::basic_string_view<unsigned char>>);
@@ -59,6 +61,24 @@ int main() {
     std::string decoded;
     require(dec(decoded).has_value());
     require(decoded == "hi");
+
+    auto                                 signed_data = std::vector<std::byte>{};
+    auto                                 signed_enc  = make_encoder(signed_data);
+    const std::basic_string<signed char> signed_text{static_cast<signed char>('o'), static_cast<signed char>('k')};
+    require(signed_enc(signed_text).has_value());
+    require(to_hex(signed_data) == "626f6b");
+
+    auto signed_decoded = std::basic_string<signed char>{};
+    auto signed_dec     = make_decoder(signed_data);
+    require(signed_dec(signed_decoded).has_value());
+    require(signed_decoded == signed_text);
+
+    std::basic_string_view<signed char> signed_view;
+    auto                                signed_view_dec = make_decoder(signed_data);
+    require(signed_view_dec(signed_view).has_value());
+    require(signed_view.size() == signed_text.size());
+    require(signed_view[0] == static_cast<signed char>('o'));
+    require(signed_view[1] == static_cast<signed char>('k'));
 
     auto                                        variant_data = std::vector<std::byte>{};
     auto                                        variant_enc  = make_encoder(variant_data);


### PR DESCRIPTION
## Summary

- Reserve definite decoded containers only when the input is a `std::ranges::sized_range`; that permits an O(1) minimum-payload check.
- For an unsized input range, do not pre-scan or reserve from the declared CBOR count; append only as elements decode.
- Reject variable-size `custom_codec_1` ranges of zero-width `std::nullptr_t` elements; fixed-extent spans and arrays remain supported.
- Complete `signed char` text string/view support and correct the documented aliasing and CLI build contracts.

## Root cause and impact

A definite container header could request a large `reserve()` before decoding an item. A size check can reject a truncated sized buffer without a scan, but it cannot validate that each item matches the destination type. Unsized inputs now keep their generic range support without a preflight traversal or header-driven reservation.

## Validation

- `cmake --build build --target tests --parallel`
- `ctest --test-dir build --output-on-failure` (44/44)
- Focused decoder reservation regressions (3/3)
- `scripts/format-cxx.sh --check`
- `scripts/lint-cxx.sh`