### PR TITLE
chore(release): bump version to 0.21.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.23)
-project(cbor_tags VERSION 0.20.0)
+project(cbor_tags VERSION 0.21.0)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/README.md
+++ b/README.md
@@ -932,7 +932,7 @@ include(FetchContent)
 FetchContent_Declare(
   cbor_tags
   GIT_REPOSITORY https://github.com/jkammerland/cbor_tags.git
-  GIT_TAG v0.20.0 # or a newer release/commit for newer extension features
+  GIT_TAG v0.21.0 # or a newer release/commit for newer extension features
 )
 
 FetchContent_MakeAvailable(cbor_tags)

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ from conan.tools.files import copy
 
 class CborTagsConan(ConanFile):
     name = "cbor-tags"
-    version = "0.20.0"
+    version = "0.21.0"
     license = "MIT"
     description = "Binary tagging library with automatic encoding/decoding for CBOR"
     homepage = "https://github.com/jkammerland/cbor_tags"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "cbor-tags",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "RFC 8949 implementation with automatic reflection",
   "homepage": "https://github.com/jkammerland/cbor_tags",
   "license": "MIT",


### PR DESCRIPTION
## Summary

The zero-width dynamic compact-collection fix that originally motivated this PR
is already in `master` via #82. After rebasing, this PR carries the v0.21.0
release bump:

- CMake project version
- Conan recipe version
- vcpkg manifest version
- FetchContent example tag in the README

## Validation

- `cmake --preset debug-tests`
- `cmake --build --preset debug-tests --parallel`
- `ctest --test-dir build/debug-tests --output-on-failure` (50/50)
- `scripts/format-cxx.sh --check`