### PR TITLE
fix(extensions): consume unsized payloads once

### DIFF
--- a/include/cbor_tags/detail/cbor_extension_decode.h
+++ b/include/cbor_tags/detail/cbor_extension_decode.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <ranges>
 #include <utility>
 
 namespace cbor::tags::detail {
@@ -57,10 +58,40 @@ template <typename Decoder> [[nodiscard]] constexpr status_code require_extensio
             return status_code::error;
         }
     }
-    if (byte_count > 0U && dec.reader_.empty(dec.data_, static_cast<typename Decoder::size_type>(byte_count - 1U))) {
-        return status_code::incomplete;
+    if constexpr (IsContiguous<typename Decoder::input_buffer_type> ||
+                  std::ranges::sized_range<const typename Decoder::input_buffer_type>) {
+        if (byte_count > 0U && dec.reader_.empty(dec.data_, static_cast<typename Decoder::size_type>(byte_count - 1U))) {
+            return status_code::incomplete;
+        }
     }
     return status_code::success;
+}
+
+// The core decoder has the one-pass behavior for unsized non-contiguous byte
+// strings. Extensions consume an already parsed bstr payload through these
+// helpers so they do not reintroduce a look-ahead scan.
+template <typename Decoder, typename Fn>
+[[nodiscard]] constexpr status_code consume_extension_bstring_payload(Decoder &dec, std::uint64_t byte_count, Fn &&consume) {
+    const auto status = require_extension_payload_bytes(dec, byte_count);
+    if (status != status_code::success) {
+        return status;
+    }
+
+    try {
+        return std::forward<Fn>(consume)(dec.decode_bstring_payload(byte_count));
+    } catch (const parse_incomplete_exception &) { return status_code::incomplete; }
+}
+
+template <typename Decoder, typename Output>
+[[nodiscard]] constexpr status_code decode_extension_bstring_payload_into(Decoder &dec, std::uint64_t byte_count, Output &output) {
+    const auto status = require_extension_payload_bytes(dec, byte_count);
+    if (status != status_code::success) {
+        return status;
+    }
+
+    try {
+        return dec.decode_definite_bstr(output, byte_count);
+    } catch (const parse_incomplete_exception &) { return status_code::incomplete; }
 }
 
 [[nodiscard]] constexpr status_code match_expected_tag(std::uint64_t expected_tag, std::uint64_t actual_tag) {

--- a/include/cbor_tags/extensions/custom_codec_1.h
+++ b/include/cbor_tags/extensions/custom_codec_1.h
@@ -209,21 +209,22 @@ template <typename Self> struct custom_codec_1 : cbor::tags::cbor_codec_mixin_ba
         if (status != status_code::success) {
             return status;
         }
-        status = cbor_detail::require_extension_payload_bytes(dec, payload_size);
-        if (status != status_code::success) {
-            return status;
-        }
-
         using payload_type = decltype(std::declval<Self &>().decode_bstring_payload(std::declval<std::uint64_t>()));
         if constexpr (!std::ranges::contiguous_range<payload_type> && codec_detail::has_borrowed_decode_refs_v<T>) {
             return status_code::contiguous_view_on_non_contiguous_data;
         }
 
-        auto payload = dec.decode_bstring_payload(payload_size);
-        if constexpr (std::ranges::contiguous_range<decltype(payload)>) {
-            return codec_detail::decode_payload(std::span<const std::byte>(std::ranges::data(payload), std::ranges::size(payload)), value);
+        if constexpr (std::ranges::contiguous_range<payload_type>) {
+            return cbor_detail::consume_extension_bstring_payload(dec, payload_size, [&](auto &&payload) {
+                return codec_detail::decode_payload(std::span<const std::byte>(std::ranges::data(payload), std::ranges::size(payload)),
+                                                    value);
+            });
         } else {
-            std::vector<std::byte> payload_bytes(payload.begin(), payload.end());
+            std::vector<std::byte> payload_bytes;
+            status = cbor_detail::decode_extension_bstring_payload_into(dec, payload_size, payload_bytes);
+            if (status != status_code::success) {
+                return status;
+            }
             return codec_detail::decode_payload(std::span<const std::byte>(payload_bytes.data(), payload_bytes.size()), value);
         }
     }

--- a/include/cbor_tags/extensions/rfc8746_typed_arrays.h
+++ b/include/cbor_tags/extensions/rfc8746_typed_arrays.h
@@ -1120,19 +1120,30 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         }
 
         const auto payload_size = static_cast<std::size_t>(payload_size_u64);
-        status                  = cbor::tags::detail::require_extension_payload_bytes(dec, payload_size_u64);
-        if (status != status_code::success) {
-            return status;
+        if constexpr (IsContiguous<typename Self::input_buffer_type>) {
+            return cbor::tags::detail::consume_extension_bstring_payload(dec, payload_size_u64, [&](auto &&raw_payload) {
+                if ((payload_size % sizeof(value_type)) != 0U) {
+                    return status_code::unexpected_group_size;
+                }
+                array.values() =
+                    detail::materialize_values<value_type, ByteOrder>(std::forward<decltype(raw_payload)>(raw_payload), payload_size);
+                return status_code::success;
+            });
+        } else {
+            std::vector<std::byte> raw_payload;
+            status = cbor::tags::detail::decode_extension_bstring_payload_into(dec, payload_size_u64, raw_payload);
+            if (status != status_code::success) {
+                return status;
+            }
+            if ((payload_size % sizeof(value_type)) != 0U) {
+                return status_code::unexpected_group_size;
+            }
+            array.values() = detail::materialize_values<value_type, ByteOrder>(std::move(raw_payload), payload_size);
+            return status_code::success;
         }
-        auto raw_payload = dec.decode_bstring_payload(payload_size_u64);
-        if ((payload_size % sizeof(value_type)) != 0U) {
-            return status_code::unexpected_group_size;
-        }
-        array.values() = detail::materialize_values<value_type, ByteOrder>(std::move(raw_payload), payload_size);
-        return status_code::success;
     }
 
-    template <typename Value, typed_array_byte_order ByteOrder, typename Consume>
+    template <typename Value, typed_array_byte_order ByteOrder, bool MaterializeNonContiguousPayload, typename Consume>
     [[nodiscard]] status_code decode_bounded_typed_array_bytes(major_type payload_major, std::byte payload_info, std::size_t min,
                                                                std::size_t max, Consume &&consume) {
         if (payload_major != major_type::ByteString || payload_info == std::byte{31}) {
@@ -1155,14 +1166,21 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
             return status_code::unexpected_group_size;
         }
 
-        status = cbor::tags::detail::require_extension_payload_bytes(dec, payload_size_u64);
-        if (status != status_code::success) {
-            return status;
-        }
-        auto       raw_payload  = dec.decode_bstring_payload(payload_size_u64);
         const auto payload_size = static_cast<std::size_t>(payload_size_u64);
-        std::forward<Consume>(consume)(std::move(raw_payload), payload_size);
-        return status_code::success;
+        if constexpr (MaterializeNonContiguousPayload && !IsContiguous<typename Self::input_buffer_type>) {
+            std::vector<std::byte> raw_payload;
+            status = cbor::tags::detail::decode_extension_bstring_payload_into(dec, payload_size_u64, raw_payload);
+            if (status != status_code::success) {
+                return status;
+            }
+            std::forward<Consume>(consume)(std::move(raw_payload), payload_size);
+            return status_code::success;
+        } else {
+            return cbor::tags::detail::consume_extension_bstring_payload(dec, payload_size_u64, [&](auto &&raw_payload) {
+                std::forward<Consume>(consume)(std::forward<decltype(raw_payload)>(raw_payload), payload_size);
+                return status_code::success;
+            });
+        }
     }
 
     template <OwnedTypedArrayTarget Array>
@@ -1171,7 +1189,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         using array_type = std::remove_cvref_t<Array>;
         using value_type = typename array_type::value_type;
 
-        return decode_bounded_typed_array_bytes<value_type, array_type::byte_order>(
+        return decode_bounded_typed_array_bytes<value_type, array_type::byte_order, true>(
             payload_major, payload_info, min, max, [&](auto &&raw_payload, std::size_t payload_size) {
                 array.values() = detail::materialize_values<value_type, array_type::byte_order>(
                     std::forward<decltype(raw_payload)>(raw_payload), payload_size);
@@ -1189,7 +1207,7 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
         if constexpr (std::ranges::contiguous_range<const byte_range> && !IsContiguous<typename Self::input_buffer_type>) {
             return status_code::contiguous_view_on_non_contiguous_data;
         } else {
-            return decode_bounded_typed_array_bytes<value_type, array_type::byte_order>(
+            return decode_bounded_typed_array_bytes<value_type, array_type::byte_order, false>(
                 payload_major, payload_info, min, max, [&](auto &&raw_payload, std::size_t payload_size) {
                     view = array_type{byte_range{std::forward<decltype(raw_payload)>(raw_payload)}, payload_size};
                 });
@@ -1215,17 +1233,15 @@ template <typename Self> struct typed_array_codec : cbor_codec_mixin_base<Self> 
                 return status;
             }
 
-            status = cbor::tags::detail::require_extension_payload_bytes(dec, payload_size_u64);
-            if (status != status_code::success) {
-                return status;
-            }
-            auto       raw_payload  = dec.decode_bstring_payload(payload_size_u64);
             const auto payload_size = static_cast<std::size_t>(payload_size_u64);
-            if ((payload_size % sizeof(value_type)) != 0U) {
-                return status_code::unexpected_group_size;
-            }
-            view = typed_array_view<value_type, ByteRange, ByteOrder>{ByteRange{std::move(raw_payload)}, payload_size};
-            return status_code::success;
+            return cbor::tags::detail::consume_extension_bstring_payload(dec, payload_size_u64, [&](auto &&raw_payload) {
+                if ((payload_size % sizeof(value_type)) != 0U) {
+                    return status_code::unexpected_group_size;
+                }
+                view = typed_array_view<value_type, ByteRange, ByteOrder>{ByteRange{std::forward<decltype(raw_payload)>(raw_payload)},
+                                                                          payload_size};
+                return status_code::success;
+            });
         }
     }
 

--- a/test/test_extension_payload_regressions.cpp
+++ b/test/test_extension_payload_regressions.cpp
@@ -1,0 +1,171 @@
+#include "test_util.h"
+
+#include <cbor_tags/cbor_decoder.h>
+#include <cbor_tags/extensions/custom_codec_1.h>
+#include <cbor_tags/extensions/rfc8746_typed_arrays.h>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <vector>
+
+using namespace cbor::tags;
+using namespace cbor::tags::ext::rfc8746;
+
+namespace {
+
+struct CountingUnsizedByteRange {
+    using value_type = std::byte;
+
+    struct iterator {
+        using value_type        = std::byte;
+        using difference_type   = std::ptrdiff_t;
+        using iterator_concept  = std::bidirectional_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        std::list<std::byte>::const_iterator current{};
+        std::size_t                         *increments{};
+
+        [[nodiscard]] const std::byte &operator*() const noexcept { return *current; }
+        [[nodiscard]] const std::byte *operator->() const noexcept { return std::addressof(*current); }
+
+        iterator &operator++() noexcept {
+            ++current;
+            ++*increments;
+            return *this;
+        }
+        iterator operator++(int) noexcept {
+            auto copy = *this;
+            ++*this;
+            return copy;
+        }
+        iterator &operator--() noexcept {
+            --current;
+            return *this;
+        }
+        iterator operator--(int) noexcept {
+            auto copy = *this;
+            --*this;
+            return copy;
+        }
+
+        friend bool operator==(const iterator &, const iterator &) = default;
+    };
+
+    std::list<std::byte> bytes;
+    mutable std::size_t  increments{};
+
+    [[nodiscard]] iterator begin() const noexcept { return {bytes.cbegin(), &increments}; }
+    [[nodiscard]] iterator end() const noexcept { return {bytes.cend(), &increments}; }
+};
+
+} // namespace
+
+TEST_CASE("extension payloads consume unsized non-contiguous input once") {
+    SUBCASE("owned typed arrays") {
+        CountingUnsizedByteRange  input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02},
+                                         std::byte{0x03}, std::byte{0x04}, std::byte{0x05}}};
+        typed_array<std::uint8_t> decoded;
+        auto                      dec = make_decoder<typed_array_codec>(input);
+
+        REQUIRE(dec(decoded));
+        CHECK_EQ(decoded.values(), (std::vector<std::uint8_t>{1, 2, 3, 4, 5}));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+
+    SUBCASE("typed array views") {
+        CountingUnsizedByteRange input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02},
+                                        std::byte{0x03}, std::byte{0x04}, std::byte{0x05}}};
+        auto                     dec = make_decoder<typed_array_codec>(input);
+        using view_type              = typed_array_view_for<std::uint8_t, decltype(dec)>;
+        view_type decoded;
+
+        REQUIRE(dec(decoded));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+        CHECK_EQ(decoded.copy_values(), (std::vector<std::uint8_t>{1, 2, 3, 4, 5}));
+    }
+
+    SUBCASE("bounded owned typed arrays") {
+        CountingUnsizedByteRange input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02},
+                                        std::byte{0x03}, std::byte{0x04}, std::byte{0x05}}};
+        bounded_size<typed_array<std::uint8_t>, 1, 5> decoded;
+        auto                                          dec = make_decoder<typed_array_codec>(input);
+
+        REQUIRE(dec(decoded));
+        CHECK_EQ(decoded.value().values(), (std::vector<std::uint8_t>{1, 2, 3, 4, 5}));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+
+    SUBCASE("bounded typed array views") {
+        CountingUnsizedByteRange input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02},
+                                        std::byte{0x03}, std::byte{0x04}, std::byte{0x05}}};
+        auto                     dec = make_decoder<typed_array_codec>(input);
+        using view_type              = typed_array_view_for<std::uint8_t, decltype(dec)>;
+        bounded_size<view_type, 1, 5> decoded;
+
+        REQUIRE(dec(decoded));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+        CHECK_EQ(decoded.value().copy_values(), (std::vector<std::uint8_t>{1, 2, 3, 4, 5}));
+    }
+
+    SUBCASE("owning custom_codec_1 values") {
+        CountingUnsizedByteRange input{
+            {std::byte{0xC1}, std::byte{0x44}, std::byte{0x03}, std::byte{0x11}, std::byte{0x22}, std::byte{0x33}}};
+        std::vector<std::uint8_t> decoded;
+        auto                      dec = make_decoder<cbor::tags::ext::custom_codec_1::custom_codec_1>(input);
+
+        REQUIRE(dec(cbor::tags::ext::custom_codec_1::as_custom_codec_1(static_tag<1>{}, decoded)));
+        CHECK_EQ(decoded, (std::vector<std::uint8_t>{0x11, 0x22, 0x33}));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+}
+
+TEST_CASE("extension payloads retain terminal incomplete behavior for unsized input") {
+    SUBCASE("owned typed arrays") {
+        CountingUnsizedByteRange  input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02}}};
+        typed_array<std::uint8_t> decoded{{0xAA}};
+        auto                      dec = make_decoder<typed_array_codec>(input);
+
+        const auto result = dec(decoded);
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_EQ(decoded.values(), (std::vector<std::uint8_t>{0xAA}));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+
+    SUBCASE("typed array views report incomplete from direct extension dispatch") {
+        CountingUnsizedByteRange input{{std::byte{0xD8}, std::byte{0x40}, std::byte{0x45}, std::byte{0x01}, std::byte{0x02}}};
+        auto                     dec = make_decoder<typed_array_codec>(input);
+        using view_type              = typed_array_view_for<std::uint8_t, decltype(dec)>;
+        view_type decoded;
+        const auto [major, additional_info] = dec.read_initial_byte();
+        auto status                         = status_code::success;
+
+        CHECK_NOTHROW(status = dec.decode(decoded, major, additional_info));
+        CHECK_EQ(status, status_code::incomplete);
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+
+    SUBCASE("owning custom_codec_1 values") {
+        CountingUnsizedByteRange  input{{std::byte{0xC1}, std::byte{0x44}, std::byte{0x03}, std::byte{0x11}}};
+        std::vector<std::uint8_t> decoded{0xAA};
+        auto                      dec = make_decoder<cbor::tags::ext::custom_codec_1::custom_codec_1>(input);
+
+        const auto result = dec(cbor::tags::ext::custom_codec_1::as_custom_codec_1(static_tag<1>{}, decoded));
+
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::incomplete);
+        CHECK_EQ(decoded, (std::vector<std::uint8_t>{0xAA}));
+        CHECK_EQ(input.increments, input.bytes.size());
+        CHECK(dec.tell() == input.end());
+    }
+}


### PR DESCRIPTION
Closes #86

Stacked on #84 (`agent/one-pass-unsized-decoder`).

## Measured behavior

The regression test uses an unsized `std::list<std::byte>` range whose iterator counts source advances:

```cpp
typed_array<std::uint8_t> decoded;
auto dec = make_decoder<typed_array_codec>(input);
REQUIRE(dec(decoded));
CHECK_EQ(input.increments, input.bytes.size()); // 8, not a prewalk plus rewalks
```

It covers owned/view/bounded RFC 8746 typed arrays and owning `custom_codec_1` values. The truncated cases also prove terminal `incomplete` behavior.

## Change

- Make extension availability checks O(1) only for contiguous or sized input; unsized non-contiguous input is not prewalked.
- Route extension bstr payload consumption through shared helpers that preserve `status_code::incomplete` for direct extension dispatch.
- For owning RFC 8746 and `custom_codec_1` targets on non-contiguous input, use the core decoder's one-pass byte-string append path, then materialize from the local contiguous buffer.
- Keep the contiguous fast paths and borrowed non-contiguous typed-array views intact.

## Validation

- `cmake --build /tmp/cbor-tags-extension-payloads-build --parallel`
- `ctest --test-dir /tmp/cbor-tags-extension-payloads-build --output-on-failure` (45/45)
- Focused traversal test: 34 assertions across all owned/view/bounded/custom and incomplete cases.