### PR TITLE
docs: fix reviewed contracts and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,6 @@ Should the need arise for overloading, or encoding private members, you have two
 
 #include <cassert>
 #include <cstdint>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ The library design is inspired by [zpp_bits](https://github.com/eyalz800/zpp_bit
   - [Version Handling with Variants](#version-handling-with-variants)
   - [Manual Tag Parsing](#manual-tag-parsing)
   - [Private class members or explicit overloading](#private-class-members-or-explicit-overloading)
-- [✨ Advanced Features](#-advanced-features)
 - [🎨 Custom Tag Handling](#-custom-tag-handling)
 - [🔄 Automatic Reflection](#-automatic-reflection)
 - [🏷️ Annotating buffers and Diagnostic notation](#️-annotating-cbor-buffers)
@@ -40,7 +39,6 @@ The library design is inspired by [zpp_bits](https://github.com/eyalz800/zpp_bit
 - [Project Status](#project-status)
 - [📚 Documentation](#-documentation)
   - [IANA Tag Registry](#iana-tag-registry)
-- [🌟 Practical Use Cases](#-practical-use-cases)
 - [ Testing Performance and Benchmarks](#testing-performance-and-benchmarks)
 - [📄 License](#-license)
 
@@ -326,9 +324,9 @@ int main() {
     // Encoding
     auto data          = std::vector<std::byte>{};
     auto enc           = make_encoder(data);
-    auto status = enc(v2::UserProfile{.name = "John Doe", .age = 30, .role = roles::admin});
-    if (!status) {
-        std::cerr << "Encoding status: " << status_message(status.error()) << std::endl;
+    auto encode_status = enc(v2::UserProfile{.name = "John Doe", .age = 30, .role = roles::admin});
+    if (!encode_status) {
+        std::cerr << "Encoding status: " << status_message(encode_status.error()) << std::endl;
         return 1;
     }
     // ...
@@ -336,10 +334,10 @@ int main() {
     // Decoding - supporting multiple versions
     using variant = std::variant<v1::UserProfile, v2::UserProfile>;
     variant user;
-    auto    dec = make_decoder(data);
-    auto    status = dec(user);
-    if (!status) {
-        std::cerr << "Decoding status: " << status_message(status.error()) << std::endl;
+    auto dec           = make_decoder(data);
+    auto decode_status = dec(user);
+    if (!decode_status) {
+        std::cerr << "Decoding status: " << status_message(decode_status.error()) << std::endl;
         return 1;
     }
     // should now hold a v2::UserProfile
@@ -432,8 +430,13 @@ Should the need arise for overloading, or encoding private members, you have two
 ```cpp
 #include "cbor_tags/cbor_decoder.h"
 #include "cbor_tags/cbor_encoder.h"
-#include <vector>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 using namespace cbor::tags;
 
@@ -481,7 +484,7 @@ int main() {
     PrivateDataClass obj{123, "Private Data"};
     
     // Encode the object
-    std::vector<uint8_t> buffer;
+    std::vector<std::uint8_t> buffer;
     auto                 enc = make_encoder(buffer);
     { [[maybe_unused]] auto _ = enc(obj); }
 
@@ -502,8 +505,13 @@ Method 2 is to use an overload of encode or decode as free functions. This appro
 ```cpp
 #include "cbor_tags/cbor_decoder.h"
 #include "cbor_tags/cbor_encoder.h"
-#include <vector>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 using namespace cbor::tags;
 
@@ -567,7 +575,7 @@ int main() {
     ExternalClass obj{456, "External Data"};
     
     // Encode the object
-    std::vector<uint8_t> buffer;
+    std::vector<std::uint8_t> buffer;
     auto enc = make_encoder(buffer);
     auto result = enc(obj);
     
@@ -1111,14 +1119,15 @@ ctest --test-dir build/interop-tests --output-on-failure
 ```
 
 The benchmarks can be run by configuring with `-DCBOR_TAGS_BUILD_BENCHMARKS=ON`.
-This creates targets for the encoder, decoder, ranges, and the
-`custom_codec_1` comparison suite.
+This creates targets for the encoder, decoder, ranges, RFC 8746 typed arrays,
+and the `custom_codec_1` comparison suite.
 
 ```bash
 cmake -S . -B build-bench -G Ninja -DCMAKE_BUILD_TYPE=Release -DCBOR_TAGS_BUILD_BENCHMARKS=ON
 cmake --build build-bench --target bench_encoder
 cmake --build build-bench --target bench_decoder
 cmake --build build-bench --target bench_ranges
+cmake --build build-bench --target bench_typed_arrays
 cmake --build build-bench --target bench_custom_codec_1
 ./build-bench/benchmarks/custom_codec_1/bench_custom_codec_1
 ```

--- a/doc/codec_extensions.md
+++ b/doc/codec_extensions.md
@@ -117,6 +117,8 @@ my_root<T> as_my_root(my_session&, const T&&) = delete;
 
 Current public extension headers:
 
+- `cbor_tags/extensions/custom_codec_1.h`: schema-bound `tag(bstr)` payload
+  codec. See [Custom Codec 1](custom_codec_1.md).
 - `cbor_tags/extensions/smart_ptr.h`: nullable `unique_ptr`/`shared_ptr` values
   and shared `shared_ptr` identity sessions.
 - `cbor_tags/extensions/std_expected.h`: opt-in `std::expected` return type
@@ -125,3 +127,5 @@ Current public extension headers:
   See [RFC 8746 Typed Arrays](rfc8746_typed_arrays.md).
 - `cbor_tags/extensions/cbor_visualization.h`: CDDL, annotation, and diagnostic
   rendering helpers.
+- `cbor_tags/extensions/cddl_traits.h`: traits for describing custom extension
+  types in generated CDDL.

--- a/doc/custom_codec_1.md
+++ b/doc/custom_codec_1.md
@@ -79,6 +79,9 @@ if (it != matches.end()) {
     auto    ok          = it->decode<cc1::custom_codec_1>(payload_ref);
 }
 
+// Exhaust the scanner before using failed() for the complete input segment.
+for (; it != matches.end(); ++it) {}
+
 if (matches.failed()) {
     auto status = matches.status();
 }

--- a/doc/custom_codec_1.md
+++ b/doc/custom_codec_1.md
@@ -68,6 +68,8 @@ auto result = enc(cc1::as_custom_codec_1(static_tag<1001>{}, message));
 `find_tags` matches the outer CBOR tag and exposes only the tag payload. For
 `custom_codec_1` values, that payload is the definite-length byte string, not the
 whole `#6.<tag>(bstr)` envelope. Decode it with `as_custom_codec_1_payload`.
+The payload decoder object also accepts the wrapper directly, so either form can
+decode the current match:
 
 ```cpp
 auto matches = find_tags<1001>(out);
@@ -77,6 +79,12 @@ if (it != matches.end()) {
     Message decoded_from_match{};
     auto    payload_ref = cc1::as_custom_codec_1_payload(decoded_from_match);
     auto    ok          = it->decode<cc1::custom_codec_1>(payload_ref);
+}
+
+if (it != matches.end()) {
+    Message decoded_from_payload{};
+    auto    payload_decoder = it->make_decoder<cc1::custom_codec_1>();
+    auto    ok = payload_decoder(cc1::as_custom_codec_1_payload(decoded_from_payload));
 }
 
 // Exhaust the scanner before using failed() for the complete input segment.
@@ -92,16 +100,6 @@ if (matches.failed()) {
 first match leaves later malformed or deeply nested data unscanned. Its current
 fixed nesting boundary and terminal scanner contract are documented under
 [Lazy Tag Scanning](experimental_ranges.md#lazy-tag-scanning).
-
-The payload decoder object also accepts the wrapper directly:
-
-```cpp
-if (it != matches.end()) {
-    Message decoded_from_payload{};
-    auto    payload_decoder = it->make_decoder<cc1::custom_codec_1>();
-    auto    ok = payload_decoder(cc1::as_custom_codec_1_payload(decoded_from_payload));
-}
-```
 
 Use `as_custom_codec_1(...)` for full buffers that still contain the outer tag. Use
 `as_custom_codec_1_payload(...)` only when the decoder starts at the tag payload bstr,

--- a/doc/custom_codec_1.md
+++ b/doc/custom_codec_1.md
@@ -84,6 +84,12 @@ if (matches.failed()) {
 }
 ```
 
+`find_tags` scans incrementally. Advance to `matches.end()` before treating
+`failed()` as the status for the complete input segment; stopping after the
+first match leaves later malformed or deeply nested data unscanned. Its current
+fixed nesting boundary and terminal scanner contract are documented under
+[Lazy Tag Scanning](experimental_ranges.md#lazy-tag-scanning).
+
 The payload decoder object also accepts the wrapper directly:
 
 ```cpp

--- a/doc/decoder_resource_limits.md
+++ b/doc/decoder_resource_limits.md
@@ -93,7 +93,7 @@ These controls are complementary:
 #include <string>
 #include <vector>
 
-#include <cbor_tags/cbor.h>
+#include <cbor_tags/cbor_decoder.h>
 
 namespace ct = cbor::tags;
 

--- a/doc/experimental_ranges.md
+++ b/doc/experimental_ranges.md
@@ -363,8 +363,10 @@ Scanning is incremental, not whole-buffer validation. `failed()` reports only
 work the iterator has already performed, so advance through `matches.end()`
 before treating its status as the result for the complete input segment. If a
 caller stops after the first match, malformed or deeply nested trailing data
-has not been scanned yet. The scanner currently has a fixed nesting boundary:
-depth 255 succeeds, while depth 256 returns `status_code::error`. This is a
+has not been scanned yet. The current scanner permits at most 256
+simultaneously open array, map, or tag frames. It returns `status_code::error`
+when scanning or locating a matched payload boundary would require another
+frame; that payload scan shares the same frame budget. This is a
 scanner-specific terminal limit, not a core decoder rollback or resumability
 guarantee.
 

--- a/doc/experimental_ranges.md
+++ b/doc/experimental_ranges.md
@@ -359,6 +359,15 @@ if (matches.failed()) {
 }
 ```
 
+Scanning is incremental, not whole-buffer validation. `failed()` reports only
+work the iterator has already performed, so advance through `matches.end()`
+before treating its status as the result for the complete input segment. If a
+caller stops after the first match, malformed or deeply nested trailing data
+has not been scanned yet. The scanner currently has a fixed nesting boundary:
+depth 255 succeeds, while depth 256 returns `status_code::error`. This is a
+scanner-specific terminal limit, not a core decoder rollback or resumability
+guarantee.
+
 Runtime filters are also supported:
 
 ```cpp

--- a/doc/rfc8746_typed_arrays.md
+++ b/doc/rfc8746_typed_arrays.md
@@ -147,6 +147,11 @@ for (double value : view.values()) {
 }
 ```
 
+`typed_array_view<T>` borrows the encoded payload from the decoder input. Keep
+that input alive and do not mutate, reallocate, or otherwise invalidate it while
+the view is used. Decode into `typed_array<T>` for owning storage, or call
+`view.copy_values()` before releasing the input when values must outlive it.
+
 For big-endian payload views, use `typed_array_view_be<T>`:
 
 ```cpp
@@ -246,9 +251,10 @@ The structural wrappers are shape wrappers, not full semantic validators.
 `homogeneous_array<T>` requires `T` to encode as a CBOR array, and
 `multi_dimensional_array<Dimensions, T>` requires unsigned-integer array
 dimensions plus an array, typed-array, or homogeneous-array payload.
-Multi-dimensional encode/decode rejects zero dimensions and checks
+Multi-dimensional encode/decode rejects zero-valued dimensions and checks
 dimension/product consistency when the payload element count is available from
-the C++ type.
+the C++ type. An empty dimension sequence is accepted as rank zero when the
+payload element count is one.
 
 The generated scalar typed-array CDDL uses the RFC data-model spelling
 `#6.N(bstr)`. The decoder accepts definite-length byte strings for typed-array


### PR DESCRIPTION
repair README navigation and make its versioning and customization examples standalone
document lazy tag scanning's incremental, terminal depth boundary and typed-array view borrowing rules
correct rank-zero typed-array semantics, the decoder resource include, and extension/benchmark listings
