### PR TITLE
docs: streamline decoder guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ The library design is inspired by [zpp_bits](https://github.com/eyalz800/zpp_bit
 - [✅ Requirements](#-requirements)
 - [📦 Installation](#-installation)
 - [💡 CMake Integration](#-cmake-integration)
-- [Decoder Resource Limits](#decoder-resource-limits)
 - [Project Status](#project-status)
 - [📚 Documentation](#-documentation)
   - [IANA Tag Registry](#iana-tag-registry)
@@ -48,7 +47,7 @@ The library design is inspired by [zpp_bits](https://github.com/eyalz800/zpp_bit
 ## 🎯 Key Features
 
 - Support for both contiguous and non-contiguous buffers.
-- Buffer-backed decode views for contiguous and non-contiguous inputs.
+- Buffer-backed decode views (zero-copy) for contiguous and non-contiguous inputs.
 - Flexible tag handling for structs and tuples, can be completely non-invasive on your code.
 - Support for many (almost arbitrary) containers and nesting.
 - noexcept API (encode/decode), with status return values using `tl::expected<void, status_code>` by default or `std::expected<void, status_code>` with C++23 opt-in.
@@ -121,70 +120,11 @@ Tagged tagged{.a = 2, .b = 3.14, .c = "Hello, World!"};
 enc(tagged);
 ```
 
-> [!NOTE]
-> The definition of a tag is a CBOR major type 6 encoded uint, with a concise data definition format of #6.321(any). This allows generic parsers to decode tags without knowing their semantic meaning or the exact order of internal items. It also means the struct implicitly define a cbor array of exact types following the tag, i.e #6.321([int, float64, tstr]). See tuning options for more details.
-
-The core CBOR decoder accumulates into mutable owning sequence destinations. Arrays,
-maps, byte strings, and text strings are appended to or inserted into; it does not
-clear an existing destination. Initialize the destination empty when replacement
-semantics are wanted. Codec extensions can define a different destination contract.
-
-```cpp
-std::string source = "payload";
-std::vector<std::byte> buffer;
-auto enc = make_encoder(buffer);
-enc(source);
-
-std::string destination = "prefix:";
-auto dec = make_decoder(buffer);
-dec(destination);
-assert(destination == "prefix:payload");
-```
-
-A failed encoder or decoder call is terminal for that encoder or decoder
-instance. The destination or output buffer may be partially modified; discard
-it after failure unless its type documents a stronger guarantee. In particular,
-`status_code::incomplete` reports that the fixed input does not contain a
-complete value and does not make the decoder resumable. The caller owns the
-input buffer (including its lifetime, admission limit, and C++ range extent
-promise); the library owns parsing the next requested CBOR item(s) from it. On
-an unsized input, the core decoder consumes incrementally rather than first
-walking a declared payload length: completed elements and string bytes may
-remain in the destination, and no reservation is made solely from an
-unverified header. A contiguous input or `std::ranges::sized_range` uses a
-range-provided extent check before reserving, rather than a decoder prewalk;
-for definite arrays/maps this is a one-byte-per-item lower bound (two bytes per
-map pair), not a full structural validation. See
-[Decoder Resource Limits](doc/decoder_resource_limits.md#input-buffer-and-segment-parsing)
-for the complete ownership and one-shot contract.
-Definite views are formed only after their complete payload is available, which
-prevents out-of-bounds views without adding a second traversal.
-
-Mutable owning text- and byte-string destinations whose exposed contiguous
-storage overlaps the decoder input are rejected with `status_code::error`; use
-separate input and output storage. Other mutable output types must not alias
-the decoder input: the runtime check is not general alias analysis. Input range
-adaptors and views that hide shared storage are unsupported and must also use
-separate storage. Fixed-size destinations and borrowed views retain their
-exact-size or assignment semantics. Advanced callers that can guarantee
-separate storage can disable the runtime check through
-`unchecked_aliasing_decoder_options`; see [encoder and decoder
-options](doc/options.md#unchecked-inputoutput-aliasing).
-
-While encoding, input values must not alias an appendable output buffer. A
-fixed output span may share its backing allocation with a source span only when
-their byte regions do not overlap; see [encoder source/output
-aliasing](doc/options.md#encoder-sourceoutput-aliasing).
-
-Equivalent to manually encoding the struct in the following example:
-```cpp
-Tagged tagged{.a = 2, .b = 3.14, .c = "Hello, World!"};
-enc(static_tag<Tagged::cbor_tag>{}, as_array{3}, tagged.a, tagged.b, tagged.c); // same as enc(tagged);
-// Also equivalent to:
-// enc(static_tag<Tagged::cbor_tag>{}, wrap_as_array{tagged.a, tagged.b, tagged.c});
-// Now the buffer contains the tag(321) followed by a single array with 3 elements
-
-```
+The default wire shape is `#6.321([int, float64, tstr])`: tag 321 identifies
+the application-defined payload, followed by the reflected struct fields. See
+[custom tag handling](#-custom-tag-handling) for other tag forms, and the
+[decoder contract](doc/decoder_resource_limits.md#decoder-contract) for
+destination, failure, input, and aliasing rules.
 
 ### Advanced Type Support
 This can be taken further to any number of members or nesting, e.g a struct with all CBOR major types (and more):
@@ -1008,24 +948,8 @@ find_package(cbor_tags REQUIRED)
 target_link_libraries(your_target PRIVATE cbor::tags)
 ```
 
-## Decoder Resource Limits
-
-Bound untrusted input at the transport or framing layer before decoding:
-
-```cpp
-if (input.size() > max_message_bytes)
-    return input_too_large;
-
-return cbor::tags::make_decoder(input)(value);
-```
-
-Use `bounded_size` or `as_bounded_size` for protocol limits and a bounded
-`std::pmr::memory_resource` for allocation containment. These controls address
-different layers: a PMR arena does not limit accepted input, and a field bound
-does not constrain unwrapped nested containers.
-
-See [Decoder Resource Limits](doc/decoder_resource_limits.md) for complete PMR
-examples, size-bound behavior, single-pass decoding, and recursive decode paths.
+For bounded object fields, PMR allocation containment, and their CDDL, see
+[resource-limited decoding](doc/decoder_resource_limits.md#bounded-objects-pmr-and-cddl).
 
 ## Project Status
 
@@ -1047,7 +971,8 @@ Additional docs:
 - [Codec Extensions](doc/codec_extensions.md)
 - [RFC 8746 Typed Arrays](doc/rfc8746_typed_arrays.md)
 - [Smart Pointer Codecs](doc/smart_pointers.md)
-- [Decoder Resource Limits](doc/decoder_resource_limits.md)
+- [Decoder contract](doc/decoder_resource_limits.md#decoder-contract)
+- [Resource-limited decoding: PMR, `bounded_size`, and CDDL](doc/decoder_resource_limits.md#bounded-objects-pmr-and-cddl)
 - [Experimental Range And Segment APIs](doc/experimental_ranges.md)
 - [Testing](doc/testing.md)
 

--- a/doc/decoder_resource_limits.md
+++ b/doc/decoder_resource_limits.md
@@ -12,6 +12,52 @@ return cbor::tags::make_decoder(input)(value);
 
 For streaming or resumable parsing, enforce the same policy against the cumulative bytes received.
 
+## Decoder Contract
+
+The core CBOR decoder accumulates into mutable owning sequence destinations.
+Arrays, maps, byte strings, and text strings are appended to or inserted into;
+they are not cleared first. Initialize a destination empty when replacement
+semantics are wanted. Codec extensions can define a different destination
+contract.
+
+```cpp
+std::string source = "payload";
+std::vector<std::byte> buffer;
+auto enc = make_encoder(buffer);
+enc(source);
+
+std::string destination = "prefix:";
+auto dec = make_decoder(buffer);
+dec(destination);
+assert(destination == "prefix:payload");
+```
+
+A failed encoder or decoder call is terminal for that instance. Its destination
+or output buffer may be partially modified; discard it after failure unless its
+type documents a stronger guarantee. In particular, `status_code::incomplete`
+means that the fixed input does not contain a complete value and does not make
+the decoder resumable. The caller owns the input buffer; the next section
+defines the input and segment contract.
+
+Definite borrowed views are formed only after their complete payload is
+available, preventing out-of-bounds views without a second traversal.
+
+Mutable owning text- and byte-string destinations whose exposed contiguous
+storage overlaps the decoder input are rejected with `status_code::error`; use
+separate input and output storage. Other mutable output types must not alias
+the decoder input: the runtime check is not general alias analysis. Input range
+adaptors and views that hide shared storage are unsupported and must also use
+separate storage. Fixed-size destinations and borrowed views retain their
+exact-size or assignment semantics. Advanced callers that can guarantee
+separate storage can disable the runtime check through
+`unchecked_aliasing_decoder_options`; see [encoder and decoder
+options](options.md#unchecked-inputoutput-aliasing).
+
+While encoding, input values must not alias an appendable output buffer. A fixed
+output span may share its backing allocation with a source span only when their
+byte regions do not overlap; see [encoder source/output
+aliasing](options.md#encoder-sourceoutput-aliasing).
+
 ## Input Buffer And Segment Parsing
 
 The ownership split is deliberately simple:
@@ -67,7 +113,7 @@ lazy-tag discovery), not a generic extension escape hatch. Such a feature
 needs its own documentation and tests, returns an explicit terminal status,
 and does not make prewalking or rollback valid in the core decoder.
 
-## Container And Allocation Limits
+## Bounded Objects, PMR, And CDDL
 
 Plain owning containers do not impose protocol limits. A transport-level byte
 limit does not express per-field limits for arrays, maps, text strings, or byte
@@ -132,6 +178,40 @@ std::pmr::vector<std::optional<std::pmr::string>>
 The arena must use a bounded upstream resource such as
 `std::pmr::null_memory_resource()`. PMR contains allocations; it does not perform
 schema validation or limit how much input the application accepts.
+
+### CDDL For Bounded Objects
+
+A PMR allocator is runtime state, so it does not change the CBOR or CDDL shape.
+When a bound belongs to the protocol, put a static `bounded_size` member in the
+object type. The same type then validates the field and describes it in CDDL:
+
+```cpp
+#include <cbor_tags/extensions/cbor_visualization.h>
+
+#include <cstdint>
+#include <memory_resource>
+#include <string>
+#include <vector>
+
+namespace ct = cbor::tags;
+
+struct bounded_request {
+    ct::bounded_size<std::pmr::string, 1, 64> name;
+    ct::bounded_size<std::pmr::vector<std::uint64_t>, 0, 8> samples;
+};
+
+fmt::memory_buffer schema;
+ct::cddl_schema_to<bounded_request>(
+    schema,
+    {.row_options = {.format_by_rows = false}});
+// bounded_request = [tstr .size (1..64), [0*8 uint]]
+```
+
+Use `dynamic_bounded_size` or `as_bounded_size(value, min, max)` when limits
+come from application configuration. Those limits are instance data, so they
+cannot generate type-based CDDL. See [CDDL Size-Bounded
+Containers](cddl_handling.md#size-bounded-containers) for nested fields and
+range-wrapper examples.
 
 ### Size-Bound Behavior
 

--- a/test/test_cddl.cpp
+++ b/test/test_cddl.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <memory_resource>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -702,8 +703,10 @@ TEST_CASE("CDDL emits typed containers and registers nested definitions once") {
 
 TEST_CASE("CDDL emits bounded sizes for strings containers and range wrappers") {
     CHECK_EQ(cddl_schema_inline<bounded_size<std::string, 1, 64>>(), "root = tstr .size (1..64)");
+    CHECK_EQ(cddl_schema_inline<bounded_size<std::pmr::string, 1, 64>>(), "root = tstr .size (1..64)");
     CHECK_EQ(cddl_schema_inline<bounded_size<std::vector<std::byte>, 0, 16>>(), "root = bstr .size (0..16)");
     CHECK_EQ(cddl_schema_inline<bounded_size<std::vector<int>, 1, 3>>(), "root = [1*3 int]");
+    CHECK_EQ(cddl_schema_inline<bounded_size<std::pmr::vector<std::uint64_t>, 0, 8>>(), "root = [0*8 uint]");
     CHECK_EQ(cddl_schema_inline<bounded_size<std::map<std::string, std::uint64_t>, 0, 2>>(), "root = {0*2 tstr => uint}");
     CHECK_EQ(cddl_schema_inline<exact_size<std::string, 4>>(), "root = tstr .size 4");
     CHECK_EQ(cddl_schema_inline<max_size<std::string, 64>>(), "root = tstr .size (0..64)");


### PR DESCRIPTION
## Summary

- streamline the README tagged-struct example and link detailed decoder semantics
- move the full decoder contract into the resource guide
- add a focused PMR, `bounded_size`, and CDDL section with a bounded-object example
- cover generated CDDL for PMR bounded string and vector fields

## Why

The README mixed the quick-start tag example with detailed mutation, terminal-failure, input ownership, and aliasing rules. The complete contract now lives beside the resource-limit guidance, while the README remains easy to scan.

## Validation

- `./scripts/format-cxx.sh --check`
- `./build/test/tests --test-case='CDDL emits bounded sizes for strings containers and range wrappers,Decode bounded pmr array reserve failure returns out_of_memory,Decode bounded pmr strings return out_of_memory' --reporter=console`
- `ctest --test-dir build --quiet`