### PR TITLE
docs: clarify smart pointer codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,9 +798,22 @@ Standards coverage is tracked in [`doc/cddl_standard_coverage.md`](doc/cddl_stan
 
 ### Smart Pointer Codecs
 Smart pointer support is opt-in through `cbor_tags/extensions/smart_ptr.h`.
-Use `nullable_ptr_codec` for nullable ownership values, or `shared_graph_codec`
-when repeated `std::shared_ptr<T>` identity must be preserved across one logical
-graph session:
+There are two choices because “a pointer may be empty” and “two pointers mean
+the same object” are different jobs:
+
+| If you need... | Use | In plain words |
+|---|---|---|
+| A pointer that may be empty | `nullable_ptr_codec` | “Nullable” means it may be `nullptr`. |
+| Repeated `std::shared_ptr`s to stay attached to one object after decoding | `shared_graph_codec` | “Shared” means several pointers refer to that one object. |
+
+`nullable_ptr_codec` works with `std::unique_ptr<T>` and ordinary
+`std::shared_ptr<T>`. It writes an empty pointer as `[0]` and a pointer with an
+object as `[1, value]`. It does not remember that two `shared_ptr`s once pointed
+to the same object.
+
+Use `shared_graph_codec` only when that relationship matters. Its
+`...session` objects are small “already seen” lists: use the same one while
+reading or writing one message, then reset or replace it for the next message.
 
 ```cpp
 #include "cbor_tags/cbor_decoder.h"
@@ -814,30 +827,23 @@ using namespace cbor::tags::ext::smart_ptr;
 
 std::vector<std::byte> buffer;
 
-auto shared = std::make_shared<int>(42);
-shared_graph_encode_session encode_graph;
+auto item = std::make_shared<int>(42);
+std::vector<std::shared_ptr<int>> sent{item, item};
+
+shared_graph_encode_session write_state;
 auto enc = make_encoder<shared_graph_codec>(buffer);
+enc(as_shared_graph(write_state, sent));
 
-enc(as_shared_graph(encode_graph, shared));
-enc(as_shared_graph(encode_graph, shared));
-
-std::shared_ptr<int> first;
-std::shared_ptr<int> second;
-
+std::vector<std::shared_ptr<int>> received;
 auto dec = make_decoder<shared_graph_codec>(buffer);
-shared_graph_decode_session decode_graph;
+shared_graph_decode_session read_state;
+dec(as_shared_graph(read_state, received));
 
-dec(as_shared_graph(decode_graph, first));
-dec(as_shared_graph(decode_graph, second));
+// received[0].get() == received[1].get(): both point to the same int.
 ```
 
-`nullable_ptr_codec` encodes null pointers as `[0]` and values as `[1, value]`.
-`shared_graph_codec` uses CBOR value-sharing tags 28/29 inside
-`as_shared_graph(...)` roots. Use `shared_graph_cddl<T>` when generated CDDL
-should describe that graph shape, rendering `std::shared_ptr<T>` as
-`[0] / #6.28(T) / #6.29(uint)`. See
-[Smart Pointer Codecs](doc/smart_pointers.md) for wire shapes, limitations,
-value-sharing spec links, CDDL examples, and variant behavior.
+See [Smart Pointer Codecs](doc/smart_pointers.md) for the exact CBOR form,
+CDDL, unsupported cycles, and variant rules.
 See [Codec Extensions](doc/codec_extensions.md) for the general opt-in extension
 pattern.
 

--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -1,7 +1,7 @@
 # Smart Pointer Codecs
 
 Smart pointer support is explicit. Include `cbor_tags/extensions/smart_ptr.h`
-and install the codec mixins you want:
+and choose how pointers should be stored:
 
 ```cpp
 #include "cbor_tags/cbor_decoder.h"
@@ -14,10 +14,22 @@ using namespace cbor::tags;
 using namespace cbor::tags::ext::smart_ptr;
 ```
 
-## Nullable Pointers
+## Why There Are Two Codecs
 
-`nullable_ptr_codec` supports `std::unique_ptr<T>` and `std::shared_ptr<T>` when
-`T` is a default-initializable, non-const, non-void, non-array object type.
+The codecs solve different problems:
+
+| If you need... | Use | Meaning |
+|---|---|---|
+| A pointer that may be empty | `nullable_ptr_codec` | “Nullable” means it may be `nullptr`. |
+| Several `std::shared_ptr`s to keep pointing to one object after decoding | `shared_graph_codec` | “Shared” means one object has more than one pointer. |
+
+Use the first codec unless keeping that “same object” relationship matters.
+
+## Pointers That May Be Empty
+
+`nullable_ptr_codec` stores whether a `std::unique_ptr<T>` or
+`std::shared_ptr<T>` is empty. It supports ordinary object types that the
+decoder can create with `T{}`.
 
 ```cpp
 std::vector<std::byte> bytes;
@@ -38,52 +50,52 @@ nullable<T> = [0] / [1, T]
 ```
 
 Null pointers encode as `[0]`. Non-null pointers encode as `[1, value]`, where
-`value` is the pointed-to object. This codec preserves nullable ownership state,
-not `shared_ptr` identity.
+`value` is the pointed-to object.
 
-## Shared Pointer Identity
+If the same `shared_ptr` appears twice, this codec writes two values. After
+decoding they have the same contents, but they are two separate objects. Use
+`shared_graph_codec` when both pointers must still point to one object.
 
-`shared_graph_codec` preserves repeated `std::shared_ptr<T>` identity inside
-explicit `as_shared_graph(...)` roots. The graph state is held in a reusable
-session object so identities can span multiple roots in one logical message.
+## Keep Repeated `shared_ptr`s Pointing To One Object
+
+`shared_graph_codec` is for that second case. Wrap the value in
+`as_shared_graph(...)` so the library knows to keep track of repeated
+`std::shared_ptr`s. The classes named `...session` are small “already seen”
+lists: one for writing and one for reading.
 
 ```cpp
 std::vector<std::byte> bytes;
+
+auto item = std::make_shared<int>(42);
+std::vector<std::shared_ptr<int>> sent{item, item};
+
+shared_graph_encode_session write_state;
 auto enc = make_encoder<shared_graph_codec>(bytes);
+enc(as_shared_graph(write_state, sent));
 
-auto shared = std::make_shared<int>(42);
-shared_graph_encode_session encode_graph;
-
-enc(as_shared_graph(encode_graph, shared)); // #6.28(42)
-enc(as_shared_graph(encode_graph, shared)); // #6.29(0)
-
-std::shared_ptr<int> first;
-std::shared_ptr<int> second;
-
+std::vector<std::shared_ptr<int>> received;
 auto dec = make_decoder<shared_graph_codec>(bytes);
-shared_graph_decode_session decode_graph;
+shared_graph_decode_session read_state;
+dec(as_shared_graph(read_state, received));
 
-dec(as_shared_graph(decode_graph, first));
-dec(as_shared_graph(decode_graph, second));
+// received[0].get() == received[1].get()
 ```
 
-Inside a graph session:
+While one message is being written or read:
 
 - Null `shared_ptr<T>` values encode as `[0]`.
-- First-seen non-null values encode as CBOR tag 28, `#6.28(value)`.
-- Later references encode as CBOR tag 29, `#6.29(id)`.
-- `id` is the zero-based index of the previously decoded tag-28 shareable value
-  in that session.
+- The first pointer to an object uses CBOR tag 28, `#6.28(value)`.
+- A later pointer to that object uses CBOR tag 29, `#6.29(id)`.
+- `id` is the number assigned to the first object in that tracker.
 
 Tags 28 and 29 are the CBOR value-sharing tags registered in the
 [IANA CBOR Tags registry](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml)
 and specified by the linked
 [value-sharing tag definition](http://cbor.schmorp.de/value-sharing).
 
-## Session Boundaries
+## One Tracker Per Message
 
-Reuse the same session to share identities across multiple roots in one logical
-message:
+Reuse the same tracker if one message is written or read as several CBOR values:
 
 ```cpp
 auto shared = std::make_shared<int>(42);
@@ -93,20 +105,17 @@ enc(as_shared_graph(graph, shared));
 enc(as_shared_graph(graph, std::vector{shared, shared}));
 ```
 
-Call `reset()` between independent messages or streams. Tags 28/29 do not carry
-an in-band reset marker, so an encoder reset inside one CBOR stream requires the
-decoder to perform the same out-of-band reset at the same boundary.
+Call `reset()` or make a new tracker for the next independent message. CBOR does
+not write a reset marker, so the writer and reader must agree on that message
+boundary.
 
-Graph sessions are stream state, not transactional recovery checkpoints. If an
-`as_shared_graph(...)` encode or decode operation fails, discard or reset the
-session before continuing with another logical graph. Fine-grained rollback is
-reserved for a future checkpoint-oriented API.
+If `as_shared_graph(...)` fails, discard or reset the tracker before using it
+again. It may already contain part of the failed message.
 
-## Lookup Policy
+## Choosing The Tracker
 
-Encode-side lookup defaults to `shared_graph_encode_lookup::unordered_map` for
-larger graphs. For small graphs or allocation-sensitive scopes, construct the
-session with `shared_graph_encode_lookup::linear_scan`:
+The default is suitable for most messages. For a small message or when you need
+to control memory use, choose `shared_graph_encode_lookup::linear_scan`:
 
 ```cpp
 shared_graph_encode_session graph{shared_graph_encode_lookup::linear_scan};
@@ -114,10 +123,10 @@ graph.reserve_unique(32);
 enc(as_shared_graph(graph, shared));
 ```
 
-`reserve_unique(n)` reserves space for `n` distinct non-null `shared_ptr`
-definitions. It must be called outside active encode operations.
+`reserve_unique(n)` prepares room for `n` different non-empty `shared_ptr`s.
+Call it before encoding.
 
-## Composition With Nullable Pointers
+## Using Both Codecs
 
 `nullable_ptr_codec` and `shared_graph_codec` can be installed together:
 
@@ -126,9 +135,10 @@ auto enc = make_encoder<nullable_ptr_codec, shared_graph_codec>(bytes);
 auto dec = make_decoder<nullable_ptr_codec, shared_graph_codec>(bytes);
 ```
 
-Outside `as_shared_graph(...)`, `std::shared_ptr<T>` uses the nullable
-`[0]` / `[1, value]` shape only when `nullable_ptr_codec` is installed. Inside
-`as_shared_graph(...)`, `std::shared_ptr<T>` uses graph identity encoding.
+Install both only when a message has both kinds of use. Outside
+`as_shared_graph(...)`, `std::shared_ptr<T>` uses the simple empty-or-value
+form. Inside `as_shared_graph(...)`, repeated pointers keep pointing to the
+same object.
 
 ## Variants
 


### PR DESCRIPTION
## Summary

- explain why the library has two smart-pointer codecs in plain terms
- define “nullable” as “may be `nullptr`”
- define shared-pointer preservation as keeping repeated pointers attached to one object
- rename and simplify the session guidance as a per-message “already seen” tracker
- replace the README example with a direct same-object round trip

## Why

The previous wording led with internal terms such as identity, graph session, and value sharing. It did not first explain the user decision: whether a pointer may be empty, or whether repeated `std::shared_ptr` values must remain pointers to one object after decoding.

## Impact

No wire format or code behavior changes. This makes the opt-in choice and the lifetime of `shared_graph_*_session` clear before the detailed CBOR, CDDL, and variant reference material.

## Validation

- `./scripts/format-cxx.sh --check`
- `./build/test/tests --test-case='nullable pointer codec does not preserve repeated shared_ptr identity,shared graph codec decodes duplicate references to the same object,shared graph codec decodes nested shareables after table growth' --reporter=console`
- `git diff --check`