### PR TITLE
docs(smart-ptr): show application-owned polymorphism

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -156,9 +156,44 @@ encode(Encoder& enc, const std::shared_ptr<animal>& value) {
 }
 ```
 
-Keep this alternative in the same application namespace. Decoding does not
-need RTTI in either version. Read `null` or the application tag once, allocate
-the final object, then decode its body directly into that object:
+A third option is to support one exact encoder type and make `encode` virtual:
+
+```cpp
+using buffer_type = std::vector<std::byte>;
+using app_encoder = decltype(make_encoder(std::declval<buffer_type&>()));
+using result_type = app_encoder::expected_type;
+
+struct cbor_encodable {
+    virtual ~cbor_encodable() = default;
+    virtual result_type encode(app_encoder&) const = 0;
+};
+struct animal : cbor_encodable { ~animal() override = default; };
+struct dog final : animal {
+    std::uint64_t age{};
+    result_type encode(app_encoder& enc) const final {
+        return enc(static_tag<dog_tag>{}, wrap_as_array{age});
+    }
+};
+struct cat final : animal {
+    std::string name;
+    result_type encode(app_encoder& enc) const final {
+        return enc(static_tag<cat_tag>{}, wrap_as_array{name});
+    }
+};
+
+inline result_type
+encode(app_encoder& enc, const std::shared_ptr<animal>& value) {
+    return value ? enc(*value) : enc(nullptr); // virtual dispatch
+}
+```
+
+This performs one virtual call without RTTI or casts. It intentionally supports
+only `app_encoder`; changing its buffer, options, or codec pack creates a
+different encoder type.
+
+Keep each alternative in the same application namespace. All three can use
+the same decoder policy: read `null` or the application tag once, allocate the
+final object, then decode its body directly into that object:
 
 ```cpp
 template <typename Decoder>
@@ -187,8 +222,17 @@ decode(Decoder& dec, std::shared_ptr<animal>&& value) {
 }
 
 std::vector<std::byte> bytes;
+auto dog_value = std::make_shared<dog>();
+dog_value->age = 7;
+std::shared_ptr<animal> sent = dog_value;
+
 auto enc = make_encoder(bytes); // no shared_ptr_codec
+assert(enc(sent));
+
+std::shared_ptr<animal> received;
 auto dec = make_decoder(bytes);
+assert(dec(received));
+assert(static_cast<dog&>(*received).age == 7);
 ```
 
 The application wire choice is therefore:

--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -86,6 +86,122 @@ The first non-null pointer is written with tag 28. Later occurrences are tag
 
 An empty pointer is ordinary CBOR `null`.
 
+### Polymorphic base pointers
+
+The library does not choose which derived type a `std::shared_ptr<animal>`
+represents on the wire. Define that choice in the application. Put the overload
+in the same namespace as `animal` so the normal encoder and decoder find it,
+and do not install `shared_ptr_codec` for this value format.
+
+With RTTI, encoding can select the concrete type with `dynamic_cast`:
+
+```cpp
+namespace app {
+
+constexpr std::uint64_t dog_tag = 60010;
+constexpr std::uint64_t cat_tag = 60011;
+
+struct animal { virtual ~animal() = default; };
+struct dog final : animal { std::uint64_t age{}; };
+struct cat final : animal { std::string name; };
+
+template <typename Encoder>
+typename Encoder::expected_type
+encode(Encoder& enc, const std::shared_ptr<animal>& value) {
+    if (!value) return enc(nullptr);
+    if (auto* dog_value = dynamic_cast<const dog*>(value.get()))
+        return enc(static_tag<dog_tag>{}, wrap_as_array{dog_value->age});
+    if (auto* cat_value = dynamic_cast<const cat*>(value.get()))
+        return enc(static_tag<cat_tag>{}, wrap_as_array{cat_value->name});
+    return unexpected<status_code>{status_code::error};
+}
+
+} // namespace app
+```
+
+For a closed hierarchy without RTTI, replace the hierarchy and encoder above
+with a virtual discriminator. Each final class must return its own kind:
+
+```cpp
+enum class animal_kind { dog, cat };
+
+struct animal {
+    virtual ~animal() = default;
+    virtual animal_kind kind() const noexcept = 0;
+};
+struct dog final : animal {
+    std::uint64_t age{};
+    animal_kind kind() const noexcept final { return animal_kind::dog; }
+};
+struct cat final : animal {
+    std::string name;
+    animal_kind kind() const noexcept final { return animal_kind::cat; }
+};
+
+template <typename Encoder>
+typename Encoder::expected_type
+encode(Encoder& enc, const std::shared_ptr<animal>& value) {
+    if (!value) return enc(nullptr);
+    switch (value->kind()) {
+    case animal_kind::dog: {
+        auto& dog_value = static_cast<const dog&>(*value);
+        return enc(static_tag<dog_tag>{}, wrap_as_array{dog_value.age});
+    }
+    case animal_kind::cat: {
+        auto& cat_value = static_cast<const cat&>(*value);
+        return enc(static_tag<cat_tag>{}, wrap_as_array{cat_value.name});
+    }
+    }
+    return unexpected<status_code>{status_code::error};
+}
+```
+
+Keep this alternative in the same application namespace. Decoding does not
+need RTTI in either version. Read `null` or the application tag once, allocate
+the final object, then decode its body directly into that object:
+
+```cpp
+template <typename Decoder>
+typename Decoder::expected_type
+decode(Decoder& dec, std::shared_ptr<animal>&& value) {
+    value.reset();
+
+    std::optional<as_tag_any> tag;
+    auto result = dec(tag);
+    if (!result || !tag) return result; // error, or CBOR null
+
+    switch (tag->tag) {
+    case dog_tag: {
+        auto dog_value = std::make_shared<dog>();
+        value = dog_value; // keep it even if the body is incomplete
+        return dec(wrap_as_array{dog_value->age});
+    }
+    case cat_tag: {
+        auto cat_value = std::make_shared<cat>();
+        value = cat_value;
+        return dec(wrap_as_array{cat_value->name});
+    }
+    default:
+        return unexpected<status_code>{status_code::no_match_for_tag};
+    }
+}
+
+std::vector<std::byte> bytes;
+auto enc = make_encoder(bytes); // no shared_ptr_codec
+auto dec = make_decoder(bytes);
+```
+
+The application wire choice is therefore:
+
+```cddl
+animal = null / #6.60010([uint]) / #6.60011([tstr])
+```
+
+Use tags assigned by the application protocol. These overloads encode values,
+not shared identity: encoding the same pointer twice produces two complete
+items and decoding produces two objects. An application that needs both
+derived-type selection and tags 28/29 must implement those rules together.
+
 The encoder and decoder each keep one reference table. That table belongs to
 the codec object and remains across calls:
 

--- a/include/cbor_tags/cbor_detail.h
+++ b/include/cbor_tags/cbor_detail.h
@@ -392,7 +392,12 @@ template <typename T> static constexpr auto get_major_6_tag_from_class() {
     } else if constexpr (HasTagNonConstructible<T>) {
         return cbor::tags::cbor_tag<T>();
     } else if constexpr (HasTagFreeFunction<T>) {
-        return cbor_tag(T{});
+        using tag_type = std::remove_cvref_t<decltype(cbor_tag(std::declval<const T &>()))>;
+        if constexpr (is_static_tag_t<tag_type>::value) {
+            return tag_type{};
+        } else {
+            return cbor_tag(T{});
+        }
     } else {
         return -1;
         // return detail::FalseType{}; // This doesn't work so well across compilers

--- a/test/test_classes.cpp
+++ b/test/test_classes.cpp
@@ -69,6 +69,34 @@ struct Class4 {
     Class4(Class3 &&c, double d) : c0(std::move(c)), d_{d} {}
 };
 
+struct StaticTaggedNonDefault {
+    explicit StaticTaggedNonDefault(std::uint64_t initial_value) : value(initial_value) {}
+
+    std::uint64_t value{};
+
+    template <typename Encoder> constexpr auto encode(Encoder &enc) const { return enc(value); }
+    template <typename Decoder> constexpr auto decode(Decoder &dec) { return dec(value); }
+};
+
+constexpr auto cbor_tag(const StaticTaggedNonDefault &) { return static_tag<60000>{}; }
+
+static_assert(!std::is_default_constructible_v<StaticTaggedNonDefault>);
+
+TEST_CASE("free static tags do not require default construction") {
+    using value_type = std::variant<std::string, StaticTaggedNonDefault>;
+
+    value_type                value{std::in_place_type<StaticTaggedNonDefault>, 7U};
+    std::vector<std::uint8_t> buffer;
+    auto                      enc = make_encoder(buffer);
+    REQUIRE(enc(value));
+    CHECK_EQ(to_hex(buffer), "d9ea6007");
+
+    StaticTaggedNonDefault decoded{0U};
+    auto                   dec = make_decoder(buffer);
+    REQUIRE(dec(decoded));
+    CHECK_EQ(decoded.value, 7U);
+}
+
 // template <typename Encoder> constexpr auto encode(Encoder &enc, const Class4 &c) { return enc(wrap_as_array{c.c0, c.d_}); }
 
 template <typename Transcoder> constexpr auto transcode(Transcoder &tc, Class4 &&c) { return tc(wrap_as_array{c.c0, c.d_}); }

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -369,6 +369,67 @@ template <typename Decoder> typename Decoder::expected_type decode(Decoder &dec,
 
 } // namespace no_rtti_polymorphism
 
+namespace virtual_encoder_polymorphism {
+
+using buffer_type  = std::vector<std::byte>;
+using encoder_type = decltype(make_encoder(std::declval<buffer_type &>()));
+using result_type  = typename encoder_type::expected_type;
+
+inline constexpr std::uint64_t dog_tag = 60030U;
+inline constexpr std::uint64_t cat_tag = 60031U;
+
+struct cbor_encodable {
+    virtual ~cbor_encodable() = default;
+
+    virtual result_type encode(encoder_type &) const = 0;
+};
+
+struct animal : cbor_encodable {
+    ~animal() override = default;
+};
+
+struct dog final : animal {
+    std::uint64_t age{};
+    std::string   name;
+
+    result_type encode(encoder_type &enc) const final { return enc(static_tag<dog_tag>{}, wrap_as_array{age, name}); }
+};
+
+struct cat final : animal {
+    std::string   name;
+    std::uint64_t lives{};
+
+    result_type encode(encoder_type &enc) const final { return enc(static_tag<cat_tag>{}, wrap_as_array{name, lives}); }
+};
+
+inline result_type encode(encoder_type &enc, const std::shared_ptr<animal> &value) { return value ? enc(*value) : enc(nullptr); }
+
+template <typename Decoder> typename Decoder::expected_type decode(Decoder &dec, std::shared_ptr<animal> &&value) {
+    value.reset();
+
+    std::optional<as_tag_any> tag;
+    auto                      result = dec(tag);
+    if (!result || !tag) {
+        return result;
+    }
+
+    switch (tag->tag) {
+    case dog_tag: {
+        auto dog_value = std::make_shared<dog>();
+        value          = dog_value;
+        return dec(wrap_as_array{dog_value->age, dog_value->name});
+    }
+    case cat_tag: {
+        auto cat_value = std::make_shared<cat>();
+        value          = cat_value;
+        return dec(wrap_as_array{cat_value->name, cat_value->lives});
+    }
+    default: return typename Decoder::expected_type{cbor::tags::unexpected<status_code>{status_code::no_match_for_tag}};
+    }
+}
+
+} // namespace virtual_encoder_polymorphism
+
 template <typename T> std::vector<std::byte> encode_unique(const std::unique_ptr<T> &value) {
     std::vector<std::byte> bytes;
     auto                   enc = make_encoder<unique_ptr_codec>(bytes);
@@ -490,6 +551,62 @@ TEST_CASE("application shared pointer overload selects derived types without RTT
         auto dec     = make_decoder(bytes);
         REQUIRE(dec(decoded));
         CHECK_FALSE(decoded);
+    }
+}
+
+TEST_CASE("fixed virtual encoder interface roundtrips derived pointers") {
+    using namespace smart_ptr_test::virtual_encoder_polymorphism;
+
+    {
+        auto dog_value               = std::make_shared<dog>();
+        dog_value->age               = 4U;
+        dog_value->name              = "Fido";
+        std::shared_ptr<animal> sent = dog_value;
+
+        buffer_type  bytes;
+        encoder_type enc{bytes};
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> received;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(received));
+        REQUIRE(received);
+
+        const auto received_dog = std::static_pointer_cast<dog>(received);
+        CHECK_EQ(received_dog->age, 4U);
+        CHECK_EQ(received_dog->name, "Fido");
+    }
+
+    {
+        auto cat_value               = std::make_shared<cat>();
+        cat_value->name              = "Luna";
+        cat_value->lives             = 8U;
+        std::shared_ptr<animal> sent = cat_value;
+
+        buffer_type  bytes;
+        encoder_type enc{bytes};
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> received;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(received));
+        REQUIRE(received);
+
+        const auto received_cat = std::static_pointer_cast<cat>(received);
+        CHECK_EQ(received_cat->name, "Luna");
+        CHECK_EQ(received_cat->lives, 8U);
+    }
+
+    {
+        const std::shared_ptr<animal> sent;
+        buffer_type                   bytes;
+        encoder_type                  enc{bytes};
+        REQUIRE(enc(sent));
+
+        auto received = std::shared_ptr<animal>{std::make_shared<dog>()};
+        auto dec      = make_decoder(bytes);
+        REQUIRE(dec(received));
+        CHECK_FALSE(received);
     }
 }
 

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -233,6 +233,142 @@ static_assert(!IsUniquePointer<const std::unique_ptr<std::uint64_t[]> &>);
 static_assert(IsSmartPointer<shared_handle<std::uint64_t>>);
 static_assert(IsSmartPointer<unique_handle<std::uint64_t>>);
 
+namespace rtti_polymorphism {
+
+inline constexpr std::uint64_t dog_tag = 60010U;
+inline constexpr std::uint64_t cat_tag = 60011U;
+
+struct animal {
+    virtual ~animal() = default;
+};
+
+struct dog final : animal {
+    std::uint64_t age{};
+    std::string   name;
+};
+
+struct cat final : animal {
+    std::string   name;
+    std::uint64_t lives{};
+};
+
+struct unknown final : animal {};
+
+template <typename Encoder> typename Encoder::expected_type encode(Encoder &enc, const std::shared_ptr<animal> &value) {
+    if (!value) {
+        return enc(nullptr);
+    }
+    if (const auto *dog_value = dynamic_cast<const dog *>(value.get())) {
+        return enc(static_tag<dog_tag>{}, wrap_as_array{dog_value->age, dog_value->name});
+    }
+    if (const auto *cat_value = dynamic_cast<const cat *>(value.get())) {
+        return enc(static_tag<cat_tag>{}, wrap_as_array{cat_value->name, cat_value->lives});
+    }
+    return typename Encoder::expected_type{cbor::tags::unexpected<status_code>{status_code::error}};
+}
+
+template <typename Decoder> typename Decoder::expected_type decode(Decoder &dec, std::shared_ptr<animal> &&value) {
+    value.reset();
+
+    std::optional<as_tag_any> tag;
+    auto                      result = dec(tag);
+    if (!result || !tag) {
+        return result;
+    }
+
+    switch (tag->tag) {
+    case dog_tag: {
+        auto dog_value = std::make_shared<dog>();
+        value          = dog_value;
+        return dec(wrap_as_array{dog_value->age, dog_value->name});
+    }
+    case cat_tag: {
+        auto cat_value = std::make_shared<cat>();
+        value          = cat_value;
+        return dec(wrap_as_array{cat_value->name, cat_value->lives});
+    }
+    default: return typename Decoder::expected_type{cbor::tags::unexpected<status_code>{status_code::no_match_for_tag}};
+    }
+}
+
+} // namespace rtti_polymorphism
+
+namespace no_rtti_polymorphism {
+
+inline constexpr std::uint64_t dog_tag = 60020U;
+inline constexpr std::uint64_t cat_tag = 60021U;
+
+enum class animal_kind : std::uint8_t { dog, cat, unknown };
+
+struct animal {
+    virtual ~animal() = default;
+
+    [[nodiscard]] virtual animal_kind kind() const noexcept = 0;
+};
+
+struct dog final : animal {
+    std::uint64_t age{};
+    std::string   name;
+
+    [[nodiscard]] animal_kind kind() const noexcept final { return animal_kind::dog; }
+};
+
+struct cat final : animal {
+    std::string   name;
+    std::uint64_t lives{};
+
+    [[nodiscard]] animal_kind kind() const noexcept final { return animal_kind::cat; }
+};
+
+struct unknown final : animal {
+    [[nodiscard]] animal_kind kind() const noexcept final { return animal_kind::unknown; }
+};
+
+template <typename Encoder> typename Encoder::expected_type encode(Encoder &enc, const std::shared_ptr<animal> &value) {
+    if (!value) {
+        return enc(nullptr);
+    }
+
+    switch (value->kind()) {
+    case animal_kind::dog: {
+        const auto &dog_value = static_cast<const dog &>(*value);
+        return enc(static_tag<dog_tag>{}, wrap_as_array{dog_value.age, dog_value.name});
+    }
+    case animal_kind::cat: {
+        const auto &cat_value = static_cast<const cat &>(*value);
+        return enc(static_tag<cat_tag>{}, wrap_as_array{cat_value.name, cat_value.lives});
+    }
+    case animal_kind::unknown: return typename Encoder::expected_type{cbor::tags::unexpected<status_code>{status_code::error}};
+    }
+    return typename Encoder::expected_type{cbor::tags::unexpected<status_code>{status_code::error}};
+}
+
+template <typename Decoder> typename Decoder::expected_type decode(Decoder &dec, std::shared_ptr<animal> &&value) {
+    value.reset();
+
+    std::optional<as_tag_any> tag;
+    auto                      result = dec(tag);
+    if (!result || !tag) {
+        return result;
+    }
+
+    switch (tag->tag) {
+    case dog_tag: {
+        auto dog_value = std::make_shared<dog>();
+        value          = dog_value;
+        return dec(wrap_as_array{dog_value->age, dog_value->name});
+    }
+    case cat_tag: {
+        auto cat_value = std::make_shared<cat>();
+        value          = cat_value;
+        return dec(wrap_as_array{cat_value->name, cat_value->lives});
+    }
+    default: return typename Decoder::expected_type{cbor::tags::unexpected<status_code>{status_code::no_match_for_tag}};
+    }
+}
+
+} // namespace no_rtti_polymorphism
+
 template <typename T> std::vector<std::byte> encode_unique(const std::unique_ptr<T> &value) {
     std::vector<std::byte> bytes;
     auto                   enc = make_encoder<unique_ptr_codec>(bytes);
@@ -241,6 +377,200 @@ template <typename T> std::vector<std::byte> encode_unique(const std::unique_ptr
 }
 
 } // namespace smart_ptr_test
+
+TEST_CASE("application shared pointer overload selects derived types with RTTI") {
+    using namespace smart_ptr_test::rtti_polymorphism;
+
+    {
+        auto dog_value               = std::make_shared<dog>();
+        dog_value->age               = 7U;
+        dog_value->name              = "Rex";
+        std::shared_ptr<animal> sent = dog_value;
+
+        std::vector<std::byte> bytes;
+        auto                   enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> decoded;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+
+        const auto decoded_dog = std::dynamic_pointer_cast<dog>(decoded);
+        REQUIRE(decoded_dog);
+        CHECK_EQ(decoded_dog->age, 7U);
+        CHECK_EQ(decoded_dog->name, "Rex");
+    }
+
+    {
+        auto cat_value               = std::make_shared<cat>();
+        cat_value->name              = "Mog";
+        cat_value->lives             = 9U;
+        std::shared_ptr<animal> sent = cat_value;
+
+        std::vector<std::byte> bytes;
+        auto                   enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> decoded;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+
+        const auto decoded_cat = std::dynamic_pointer_cast<cat>(decoded);
+        REQUIRE(decoded_cat);
+        CHECK_EQ(decoded_cat->name, "Mog");
+        CHECK_EQ(decoded_cat->lives, 9U);
+    }
+
+    {
+        const std::shared_ptr<animal> sent;
+        std::vector<std::byte>        bytes;
+        auto                          enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+        CHECK_EQ(to_hex(bytes), "f6");
+
+        auto decoded = std::shared_ptr<animal>{std::make_shared<dog>()};
+        auto dec     = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+        CHECK_FALSE(decoded);
+    }
+}
+
+TEST_CASE("application shared pointer overload selects derived types without RTTI") {
+    using namespace smart_ptr_test::no_rtti_polymorphism;
+
+    {
+        auto dog_value               = std::make_shared<dog>();
+        dog_value->age               = 8U;
+        dog_value->name              = "Pip";
+        std::shared_ptr<animal> sent = dog_value;
+
+        std::vector<std::byte> bytes;
+        auto                   enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> decoded;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+        REQUIRE(decoded);
+        REQUIRE_EQ(decoded->kind(), animal_kind::dog);
+
+        const auto decoded_dog = std::static_pointer_cast<dog>(decoded);
+        CHECK_EQ(decoded_dog->age, 8U);
+        CHECK_EQ(decoded_dog->name, "Pip");
+    }
+
+    {
+        auto cat_value               = std::make_shared<cat>();
+        cat_value->name              = "Nox";
+        cat_value->lives             = 6U;
+        std::shared_ptr<animal> sent = cat_value;
+
+        std::vector<std::byte> bytes;
+        auto                   enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+
+        std::shared_ptr<animal> decoded;
+        auto                    dec = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+        REQUIRE(decoded);
+        REQUIRE_EQ(decoded->kind(), animal_kind::cat);
+
+        const auto decoded_cat = std::static_pointer_cast<cat>(decoded);
+        CHECK_EQ(decoded_cat->name, "Nox");
+        CHECK_EQ(decoded_cat->lives, 6U);
+    }
+
+    {
+        const std::shared_ptr<animal> sent;
+        std::vector<std::byte>        bytes;
+        auto                          enc = make_encoder(bytes);
+        REQUIRE(enc(sent));
+
+        auto decoded = std::shared_ptr<animal>{std::make_shared<cat>()};
+        auto dec     = make_decoder(bytes);
+        REQUIRE(dec(decoded));
+        CHECK_FALSE(decoded);
+    }
+}
+
+TEST_CASE("application shared pointer overload rejects unknown subtypes and tags") {
+    using namespace smart_ptr_test::rtti_polymorphism;
+
+    {
+        const std::shared_ptr<animal> sent = std::make_shared<unknown>();
+        std::vector<std::byte>        bytes;
+        auto                          enc    = make_encoder(bytes);
+        const auto                    result = enc(sent);
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::error);
+        CHECK(bytes.empty());
+    }
+
+    {
+        std::vector<std::byte> bytes;
+        auto                   enc = make_encoder(bytes);
+        REQUIRE(enc(static_tag<60012>{}, wrap_as_array{1U}));
+
+        auto       decoded = std::shared_ptr<animal>{std::make_shared<dog>()};
+        auto       dec     = make_decoder(bytes);
+        const auto result  = dec(decoded);
+        REQUIRE_FALSE(result);
+        CHECK_EQ(result.error(), status_code::no_match_for_tag);
+        CHECK_FALSE(decoded);
+    }
+}
+
+TEST_CASE("application shared pointer decode keeps terminal partial derived state") {
+    using namespace smart_ptr_test::rtti_polymorphism;
+
+    auto dog_value                     = std::make_shared<dog>();
+    dog_value->age                     = 7U;
+    dog_value->name                    = "Rex";
+    const std::shared_ptr<animal> sent = dog_value;
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder(bytes);
+    REQUIRE(enc(sent));
+    REQUIRE(bytes.size() > 1U);
+    bytes.pop_back();
+
+    std::shared_ptr<animal> decoded;
+    auto                    dec    = make_decoder(bytes);
+    const auto              result = dec(decoded);
+    REQUIRE_FALSE(result);
+    CHECK_EQ(result.error(), status_code::incomplete);
+
+    const auto decoded_dog = std::dynamic_pointer_cast<dog>(decoded);
+    REQUIRE(decoded_dog);
+    CHECK_EQ(decoded_dog->age, 7U);
+}
+
+TEST_CASE("application shared pointer overloads encode aliases as independent values") {
+    using namespace smart_ptr_test::rtti_polymorphism;
+
+    auto dog_value                     = std::make_shared<dog>();
+    dog_value->age                     = 5U;
+    dog_value->name                    = "Ada";
+    const std::shared_ptr<animal> sent = dog_value;
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder(bytes);
+    REQUIRE(enc(sent, sent));
+
+    std::shared_ptr<animal> first;
+    std::shared_ptr<animal> second;
+    auto                    dec = make_decoder(bytes);
+    REQUIRE(dec(first, second));
+    REQUIRE(first);
+    REQUIRE(second);
+    CHECK(first != second);
+    const auto first_dog  = std::dynamic_pointer_cast<dog>(first);
+    const auto second_dog = std::dynamic_pointer_cast<dog>(second);
+    REQUIRE(first_dog);
+    REQUIRE(second_dog);
+    CHECK_EQ(first_dog->name, "Ada");
+    CHECK_EQ(second_dog->name, "Ada");
+}
 
 TEST_CASE("unique_ptr codec uses native null or the pointee value") {
     const std::unique_ptr<std::uint64_t> empty;


### PR DESCRIPTION
## Summary

- document application-owned RTTI and non-RTTI overloads for polymorphic shared pointers
- decode `null` or the application tag once, allocate the concrete pointee immediately, and preserve terminal partial state
- state clearly that the normal overloads encode values rather than tags 28/29 shared identity
- avoid default-constructing a class when a free `cbor_tag(const T&)` returns `static_tag<N>`

## Relationship to #94

This is a focused sibling alternative to #94, stacked directly on #93. It does not add automatic subclass registration or shared-pointer variant support, and it does not modify #94.

## Validation

- `cmake --build --preset=debug-tests --parallel 4`
- `ctest --preset=debug-tests --output-on-failure` (54/54 passed)
- `scripts/format-cxx.sh --check`
- `scripts/lint-cxx.sh`
- C++23 `std::expected` test build plus the new focused cases
