### PR TITLE
fix(smart-ptr): make pointer construction ownership-safe

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -43,8 +43,14 @@ empty pointer -> null
 pointer       -> T
 ```
 
-Custom deleters are supported. Decoding calls `reset(new T)`, so the
-destination pointer keeps its existing deleter.
+Custom deleters are supported when they can safely destroy a `T` allocated by
+`new T`. Decoding retains the destination pointer's deleter and transfers such
+an allocation through `reset(T*)`. This allocation/deleter compatibility is a
+semantic requirement and cannot be checked by the structural pointer concept.
+For a user-defined pointer, `reset(T*)` must take responsibility for either
+owning or deleting the supplied pointer even if it reports an error. Use an
+application codec for pointers whose deleter requires a pool or another
+allocation source.
 
 `T` must be default-initializable for decoding and must not itself accept CBOR
 `null`. For example, `std::unique_ptr<std::optional<int>>` is rejected because

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -308,9 +308,16 @@ template <typename Decoder, typename T>
 
 template <typename Pointer> void reset_pointer_to_new(Pointer &value) {
     using element_type = pointer_element_t<Pointer>;
-    auto allocation    = std::make_unique<element_type>();
-    value.reset(allocation.get());
-    (void)allocation.release();
+    if constexpr (SharedPointer<Pointer> && std::constructible_from<std::remove_cvref_t<Pointer>, std::shared_ptr<element_type>>) {
+        // Establish ownership before converting to the structural pointer.
+        // shared_ptr(raw) deletes raw if its control-block allocation fails.
+        auto allocation = std::shared_ptr<element_type>{new element_type{}};
+        value           = std::remove_cvref_t<Pointer>{std::move(allocation)};
+    } else {
+        auto  allocation = std::make_unique<element_type>();
+        auto *raw        = allocation.release();
+        value.reset(raw);
+    }
 }
 
 template <typename Decoder, UniquePointer Pointer>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,10 @@ endif()
 # add tests for ctest
 add_test(NAME tests COMMAND tests)
 
+add_executable(test_smart_ptr_allocation_failure test_smart_ptr_allocation_failure.cc)
+target_link_libraries(test_smart_ptr_allocation_failure PRIVATE cbor::tags)
+add_test(NAME test_smart_ptr_allocation_failure COMMAND test_smart_ptr_allocation_failure)
+
 function(add_incompatible_codec_result_compile_fail_test TEST_NAME COMPILE_DEFINITION PASS_REGEX)
   add_executable(${TEST_NAME} EXCLUDE_FROM_ALL incompatible_codec_result_compile_fail.cc)
   target_compile_definitions(${TEST_NAME} PRIVATE ${COMPILE_DEFINITION})

--- a/test/test_smart_ptr_allocation_failure.cc
+++ b/test/test_smart_ptr_allocation_failure.cc
@@ -1,0 +1,65 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <new>
+#include <vector>
+
+namespace {
+
+bool fail_next_global_allocation = false;
+
+struct tracked_value {
+    std::uint64_t value{};
+
+    static inline int destructor_calls{};
+    static inline int delete_calls{};
+
+    ~tracked_value() { ++destructor_calls; }
+
+    static void *operator new(std::size_t size) {
+        auto *storage = std::malloc(size);
+        if (storage == nullptr) {
+            throw std::bad_alloc{};
+        }
+        fail_next_global_allocation = true;
+        return storage;
+    }
+
+    static void operator delete(void *) noexcept {
+        // Keep the storage valid so a duplicate destruction is observable
+        // without relying on allocator-specific double-free behavior.
+        ++delete_calls;
+    }
+};
+
+} // namespace
+
+void *operator new(std::size_t size) {
+    if (fail_next_global_allocation) {
+        fail_next_global_allocation = false;
+        throw std::bad_alloc{};
+    }
+    if (auto *storage = std::malloc(size)) {
+        return storage;
+    }
+    throw std::bad_alloc{};
+}
+
+void operator delete(void *storage) noexcept { std::free(storage); }
+void operator delete(void *storage, std::size_t) noexcept { std::free(storage); }
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    const std::vector<std::byte>   encoded{std::byte{0xD8}, std::byte{0x1C}, std::byte{0x01}};
+    std::shared_ptr<tracked_value> decoded;
+    auto                           dec    = make_decoder<shared_ptr_codec>(encoded);
+    const auto                     result = dec(decoded);
+
+    const auto allocation_failed = !result && result.error() == status_code::out_of_memory;
+    return allocation_failed && !decoded && tracked_value::destructor_calls == 1 && tracked_value::delete_calls == 1 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes the allocation-handoff safety finding from the #93 review.

Red commit abb310f adds a fault-injection executable. On #93 it observes two destructor/delete calls when shared_ptr control-block allocation fails.

Green commit cacfd31 establishes shared ownership before converting to a structural shared pointer, transfers raw ownership before fallback reset, and documents the allocation/deleter semantic contract.

Validation:
- red: focused CTest failed on #93 behavior
- green: all 55 CTest entries passed
- scripts/format-cxx.sh --check passed

Base: #93