### PR TITLE
fix(smart-ptr): enforce single-item pointee framing

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -351,6 +351,20 @@ An empty aggregate encodes no item and is rejected. A multi-field aggregate is
 also rejected when group wrapping is disabled, because it would encode several
 items under one tag 28.
 
+The codec cannot inspect the body of a member/free `encode` or `transcode`
+customization. Such pointees are rejected unless the application explicitly
+declares that the customization always emits one complete item:
+
+```cpp
+template <>
+inline constexpr bool
+    cbor::tags::ext::smart_ptr::enable_custom_pointee_single_item<record> = true;
+```
+
+This declaration is a wire-format promise. For example,
+`return enc(wrap_as_array{a, b});` satisfies it, while `return enc(a, b);` does
+not.
+
 A shared pointer inside `std::variant` requires an application codec:
 
 ```cpp

--- a/include/cbor_tags/detail/smart_ptr_traits.h
+++ b/include/cbor_tags/detail/smart_ptr_traits.h
@@ -13,7 +13,14 @@
 #include <utility>
 #include <variant>
 
-namespace cbor::tags::ext::smart_ptr::detail {
+namespace cbor::tags::ext::smart_ptr {
+
+// Custom class encoders are opaque to structural wire-shape inspection. Users
+// may opt in only when every encoding customization for T emits one complete
+// CBOR item.
+template <typename T> inline constexpr bool enable_custom_pointee_single_item = false;
+
+namespace detail {
 
 inline constexpr std::uint64_t shareable_tag = 28U;
 inline constexpr std::uint64_t sharedref_tag = 29U;
@@ -37,7 +44,13 @@ template <typename T> inline constexpr bool known_null_wire_v = cbor::tags::deta
 template <typename T> inline constexpr char graph_type_token{};
 template <typename T> constexpr const void *graph_type_id() noexcept { return &graph_type_token<std::remove_cvref_t<T>>; }
 
-template <typename Options, typename T> consteval bool encodes_one_cbor_item();
+struct pointee_shape_probe_encoder {
+    using expected_type = expected<void, status_code>;
+
+    template <typename... Ts> constexpr expected_type operator()(Ts &&...) const { return {}; }
+};
+
+template <typename Options, typename T, bool CheckCustomization = true> consteval bool encodes_one_cbor_item();
 
 template <typename T, bool = IsAggregate<std::remove_cvref_t<T>>> struct pointer_tuple {
     using type = std::remove_cvref_t<T>;
@@ -52,7 +65,7 @@ template <typename T> using pointer_tuple_t = typename pointer_tuple<T>::type;
 template <typename Options, typename Tuple, std::size_t Offset, std::size_t... Is>
 consteval bool tuple_members_encode_one_item(std::index_sequence<Is...>) {
     using tuple_type = std::remove_cvref_t<Tuple>;
-    return (encodes_one_cbor_item<Options, std::tuple_element_t<Offset + Is, tuple_type>>() && ...);
+    return (encodes_one_cbor_item<Options, std::tuple_element_t<Offset + Is, tuple_type>, false>() && ...);
 }
 
 template <typename Options, typename Tuple, std::size_t Offset = 0U> consteval bool tuple_payload_encodes_one_item() {
@@ -70,9 +83,19 @@ template <typename Options, typename Tuple, std::size_t Offset = 0U> consteval b
     }
 }
 
-template <typename Options, typename T> consteval bool encodes_one_cbor_item() {
+template <typename Options, typename T, bool CheckCustomization> consteval bool encodes_one_cbor_item() {
     using type = std::remove_cvref_t<T>;
 
+    if constexpr (IsClassWithEncodingOverload<pointee_shape_probe_encoder, type>) {
+        if constexpr (CheckCustomization) {
+            return enable_custom_pointee_single_item<type>;
+        } else {
+            // A nested custom value remains one member of its containing
+            // aggregate. Only a customization on the pointer's pointee can
+            // change the number of top-level items wrapped by tag 28.
+            return true;
+        }
+    }
     if constexpr (SmartPointer<type>) {
         return true;
     }
@@ -80,34 +103,45 @@ template <typename Options, typename T> consteval bool encodes_one_cbor_item() {
         return false;
     }
     if constexpr (IsOptional<type>) {
-        return encodes_one_cbor_item<Options, typename type::value_type>();
+        return encodes_one_cbor_item<Options, typename type::value_type, false>();
     }
     if constexpr (IsVariant<type>) {
         return cbor::tags::detail::with_variant_alternatives<type>(
-            []<typename... Ts>() { return (encodes_one_cbor_item<Options, Ts>() && ...); });
+            []<typename... Ts>() { return (encodes_one_cbor_item<Options, Ts, false>() && ...); });
     }
     if constexpr (IsMap<type> && requires {
                       typename type::key_type;
                       typename type::mapped_type;
                   }) {
-        return encodes_one_cbor_item<Options, typename type::key_type>() && encodes_one_cbor_item<Options, typename type::mapped_type>();
+        return encodes_one_cbor_item<Options, typename type::key_type, false>() &&
+               encodes_one_cbor_item<Options, typename type::mapped_type, false>();
     }
     if constexpr (IsArray<type> && requires { typename type::value_type; }) {
-        return encodes_one_cbor_item<Options, typename type::value_type>();
+        return encodes_one_cbor_item<Options, typename type::value_type, false>();
     }
     if constexpr (IsTaggedTuple<type>) {
         return tuple_payload_encodes_one_item<Options, type, 1U>();
     }
-    if constexpr (IsClassWithTagOverload<type>) {
-        return true;
-    }
     if constexpr (IsAggregate<type> || IsUntaggedTuple<type>) {
         using tuple_type = pointer_tuple_t<type>;
-        if constexpr (IsTag<type> && !HasInlineTag<type>) {
-            return tuple_payload_encodes_one_item<Options, tuple_type, 1U>();
+        if constexpr (IsClassWithTagOverload<type>) {
+            constexpr auto total = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
+            if constexpr (total == 0U) {
+                return false;
+            } else {
+                using first_type          = std::remove_cvref_t<std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>;
+                constexpr bool stored_tag = is_static_tag_t<first_type>::value || is_dynamic_tag_t<first_type>;
+                return tuple_payload_encodes_one_item<Options, tuple_type, stored_tag ? 1U : 0U>();
+            }
         } else {
             return tuple_payload_encodes_one_item<Options, tuple_type>();
         }
+    }
+    if constexpr (IsClassWithTagOverload<type>) {
+        // Non-aggregate tagged types are emitted by an explicit codec. The tag
+        // and that codec's payload form one item; aggregate tag-only and
+        // unwrapped multi-item cases were handled above.
+        return true;
     }
     if constexpr (IsCborMajor<type>) {
         return true;
@@ -260,4 +294,5 @@ template <typename Variant, std::size_t I = 0U, std::size_t J = 1U> consteval bo
     }
 }
 
-} // namespace cbor::tags::ext::smart_ptr::detail
+} // namespace detail
+} // namespace cbor::tags::ext::smart_ptr

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -524,6 +524,31 @@ add_test(
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
+function(add_smart_ptr_single_item_compile_fail_test TEST_NAME SOURCE_FILE)
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${SOURCE_FILE})
+  target_link_libraries(${TEST_NAME} PRIVATE cbor::tags)
+  add_test(
+    NAME ${TEST_NAME}
+    COMMAND
+      ${CMAKE_COMMAND}
+      "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+      "-DTEST_TARGET=${TEST_NAME}"
+      "-DCONFIG=$<CONFIG>"
+      "-DPASS_REGEX=smart pointer pointee must encode exactly one CBOR item"
+      -P
+      "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+endfunction()
+
+add_smart_ptr_single_item_compile_fail_test(
+  smart_ptr_tag_only_class_pointee_compile_fails
+  smart_ptr_tag_only_class_pointee_compile_fail.cc)
+add_smart_ptr_single_item_compile_fail_test(
+  smart_ptr_unwrapped_tagged_class_pointee_compile_fails
+  smart_ptr_unwrapped_tagged_class_pointee_compile_fail.cc)
+add_smart_ptr_single_item_compile_fail_test(
+  smart_ptr_custom_multi_item_pointee_compile_fails
+  smart_ptr_custom_multi_item_pointee_compile_fail.cc)
+
 function(add_typed_array_variant_compile_fail_test TEST_NAME SOURCE_FILE)
   add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${SOURCE_FILE})
   target_link_libraries(${TEST_NAME} PRIVATE cbor::tags)

--- a/test/smart_ptr_custom_multi_item_pointee_compile_fail.cc
+++ b/test/smart_ptr_custom_multi_item_pointee_compile_fail.cc
@@ -1,0 +1,23 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+struct custom_record {
+    std::uint64_t first{};
+    std::uint64_t second{};
+
+    template <typename Encoder> constexpr auto encode(Encoder &enc) const { return enc(first, second); }
+};
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<shared_ptr_codec>(bytes);
+    return enc(std::make_shared<custom_record>()).has_value() ? 0 : 1;
+}

--- a/test/smart_ptr_tag_only_class_pointee_compile_fail.cc
+++ b/test/smart_ptr_tag_only_class_pointee_compile_fail.cc
@@ -1,0 +1,19 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+struct tag_only_record {
+    cbor::tags::static_tag<42> cbor_tag;
+};
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<shared_ptr_codec>(bytes);
+    return enc(std::make_shared<tag_only_record>()).has_value() ? 0 : 1;
+}

--- a/test/smart_ptr_unwrapped_tagged_class_pointee_compile_fail.cc
+++ b/test/smart_ptr_unwrapped_tagged_class_pointee_compile_fail.cc
@@ -1,0 +1,24 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+struct tagged_record {
+    cbor::tags::static_tag<42> cbor_tag;
+    std::uint64_t              first{};
+    std::uint64_t              second{};
+};
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    std::vector<std::byte> bytes;
+    encoder<std::vector<std::byte>, Options<default_expected>, cbor_header_encoder, cbor_indefinite_encoder, cbor_optional_encoder,
+            cbor_variant_encoder, shared_ptr_codec>
+        enc{bytes};
+    return enc(std::make_shared<tagged_record>()).has_value() ? 0 : 1;
+}

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -114,6 +114,14 @@ struct custom_record {
     std::uint64_t value{};
 };
 
+struct custom_single_item_record {
+    std::uint64_t first{};
+    std::uint64_t second{};
+
+    template <typename Encoder> constexpr auto encode(Encoder &enc) const { return enc(wrap_as_array{first, second}); }
+    template <typename Decoder> constexpr auto decode(Decoder &dec) { return dec(wrap_as_array{first, second}); }
+};
+
 template <typename Self> struct custom_record_codec : cbor_codec_mixin_base<Self> {
     using cbor_codec_mixin_base<Self>::decode;
     using cbor_codec_mixin_base<Self>::encode;
@@ -438,6 +446,9 @@ template <typename T> std::vector<std::byte> encode_unique(const std::unique_ptr
 }
 
 } // namespace smart_ptr_test
+
+template <>
+inline constexpr bool cbor::tags::ext::smart_ptr::enable_custom_pointee_single_item<smart_ptr_test::custom_single_item_record> = true;
 
 TEST_CASE("application shared pointer overload selects derived types with RTTI") {
     using namespace smart_ptr_test::rtti_polymorphism;
@@ -825,6 +836,23 @@ TEST_CASE("shared pointer pointees may be one-field and tagged aggregates") {
     REQUIRE(decoded_tagged);
     CHECK_EQ(decoded_one_field->value, 7U);
     CHECK_EQ(decoded_tagged->value, 9U);
+}
+
+TEST_CASE("custom pointee may explicitly promise one complete CBOR item") {
+    auto sent =
+        std::make_shared<smart_ptr_test::custom_single_item_record>(smart_ptr_test::custom_single_item_record{.first = 3U, .second = 4U});
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<shared_ptr_codec>(bytes);
+    REQUIRE(enc(sent));
+    CHECK_EQ(to_hex(bytes), "d81c820304");
+
+    std::shared_ptr<smart_ptr_test::custom_single_item_record> decoded;
+    auto                                                       dec = make_decoder<shared_ptr_codec>(bytes);
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded);
+    CHECK_EQ(decoded->first, 3U);
+    CHECK_EQ(decoded->second, 4U);
 }
 
 TEST_CASE("shared pointer identity includes the exact pointer type") {


### PR DESCRIPTION
## Summary

- reject tag-only aggregate pointees that do not encode a payload item
- reject tagged aggregates that emit multiple unwrapped payload items
- reject opaque custom pointee encoders unless the application explicitly promises one complete CBOR item
- retain composed nested extension codecs such as RFC 8746 typed arrays

## Red / green commits

1. `test(smart-ptr): reproduce multi-item pointee framing` adds three compile repros. On the PR #93 head, all three CTests fail because the invalid programs compile.
2. `fix(smart-ptr): enforce single-item pointee framing` makes those repros fail compilation at the smart-pointer item boundary and adds a positive custom-codec opt-in roundtrip.

## Validation

- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure` (57/57 passed)
- focused runtime and three compile-fail tests after formatting (4/4 passed)
- `scripts/format-cxx.sh --check`

Stacked on #93 for focused review.
