### PR TITLE
fix(smart-ptr): keep sharedref indices global

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -84,11 +84,8 @@ The first non-null pointer is written with tag 28. Later occurrences are tag
 ]
 ```
 
-Indices count every tag 28 item decoded through the typed codec, including tag
-28 on an ordinary or nested non-pointer value. The table records those items as
-untracked positions so later pointer indices stay aligned. Opaque encoded-item
-views are not walked; a reference namespace must not cross an opaque item whose
-contents may contain tag 28.
+Every tag 28 in the active reference scope consumes an index, including tags not
+produced by `shared_ptr_codec`.
 
 An empty pointer is ordinary CBOR `null`.
 

--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -84,6 +84,12 @@ The first non-null pointer is written with tag 28. Later occurrences are tag
 ]
 ```
 
+Indices count every tag 28 item decoded through the typed codec, including tag
+28 on an ordinary or nested non-pointer value. The table records those items as
+untracked positions so later pointer indices stay aligned. Opaque encoded-item
+views are not walked; a reference namespace must not cross an opaque item whose
+contents may contain tag 28.
+
 An empty pointer is ordinary CBOR `null`.
 
 ### Polymorphic base pointers
@@ -309,6 +315,8 @@ dec(second_output);
 expected<shared_ptr_observation, status_code>
 observe(const shared_ptr_encode_key&);
 
+expected<void, status_code> observe_untracked();
+
 void mark_complete(std::size_t index);
 void reset();
 ```
@@ -318,6 +326,8 @@ void reset();
 ```cpp
 expected<std::size_t, status_code>
 insert(const shared_ptr_decode_entry&);
+
+expected<void, status_code> insert_untracked();
 
 expected<shared_ptr_decode_entry, status_code>
 resolve(std::size_t index);

--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -69,6 +69,16 @@ concept CodecStatusResult = requires(T result) {
     { result.error() } -> std::convertible_to<status_code>;
 };
 
+template <typename T>
+concept HasEncodedCborTagObserver = requires(T &observer, std::uint64_t tag) {
+    { observer.observe_encoded_cbor_tag(tag) } -> std::same_as<void>;
+};
+
+template <typename T>
+concept HasDecodedCborTagObserver = requires(T &observer, std::uint64_t tag) {
+    { observer.observe_decoded_cbor_tag(tag) } -> std::same_as<status_code>;
+};
+
 } // namespace detail
 
 template <typename T>

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -575,7 +575,12 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         if (major != major_type::Tag) {
             return status_code::no_match_for_tag_on_buffer;
         }
-        if (decode_unsigned(additionalInfo) != N) {
+        std::uint64_t tag{};
+        const auto    status = decode_tag_argument(additionalInfo, tag);
+        if (status != status_code::success) {
+            return status;
+        }
+        if (tag != N) {
             return status_code::no_match_for_tag;
         }
         return status_code::success;
@@ -598,7 +603,12 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return status_code::no_match_for_tag_on_buffer;
         }
 
-        if (decode_unsigned(additionalInfo) != static_cast<std::uint64_t>(value.cbor_tag)) {
+        std::uint64_t tag{};
+        const auto    status = decode_tag_argument(additionalInfo, tag);
+        if (status != status_code::success) {
+            return status;
+        }
+        if (tag != static_cast<std::uint64_t>(value.cbor_tag)) {
             return status_code::no_match_for_tag;
         }
 
@@ -615,7 +625,11 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return status_code::no_match_for_tag_on_buffer;
         }
 
-        auto tag = decode_unsigned(additionalInfo);
+        std::uint64_t tag{};
+        const auto    tag_status = decode_tag_argument(additionalInfo, tag);
+        if (tag_status != status_code::success) {
+            return tag_status;
+        }
         if (tag != std::get<0>(t)) {
             return status_code::no_match_for_tag;
         }
@@ -684,8 +698,12 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return status_code::no_match_for_tag_on_buffer;
         }
 
-        auto &&tuple = to_tuple(value);
-        auto   tag   = decode_unsigned(additionalInfo);
+        auto        &&tuple = to_tuple(value);
+        std::uint64_t tag{};
+        const auto    status = decode_tag_argument(additionalInfo, tag);
+        if (status != status_code::success) {
+            return status;
+        }
         return this->decode_tagged_aggregate(value, tag, tuple);
     }
 
@@ -993,8 +1011,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
         if (major != major_type::Tag) {
             return status_code::no_match_for_tag_on_buffer;
         }
-        value.tag = decode_unsigned(additionalInfo);
-        return status_code::success;
+        return decode_tag_argument(additionalInfo, value.tag);
     }
     constexpr status_code decode(as_tag_any &value, std::uint64_t tag) {
         value.tag = tag;
@@ -1322,6 +1339,16 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
             return static_cast<uint64_t>(additionalInfo);
         }
         return read_unsigned(additionalInfo);
+    }
+
+    constexpr status_code decode_tag_argument(byte additionalInfo, std::uint64_t &tag) {
+        tag = decode_unsigned(additionalInfo);
+        if constexpr (requires(self_t &self) {
+                          { self.observe_decoded_cbor_tag(tag) } -> std::same_as<status_code>;
+                      }) {
+            return static_cast<self_t &>(*this).observe_decoded_cbor_tag(tag);
+        }
+        return status_code::success;
     }
 
     constexpr int64_t decode_integer(byte additionalInfo) {
@@ -1815,7 +1842,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 result = this->decode_variant(decoded_value, major, additionalInfo, tag);
             } else if constexpr (IsTag<raw_type>) {
                 if (!tag) {
-                    tag = decode_unsigned(additionalInfo);
+                    std::uint64_t decoded_tag{};
+                    const auto    tag_status = decode_tag_argument(additionalInfo, decoded_tag);
+                    if (tag_status != status_code::success) {
+                        hard_error = tag_status;
+                        return false;
+                    }
+                    tag = decoded_tag;
                 }
                 result = this->decode(decoded_value, *tag);
             } else {
@@ -1904,7 +1937,13 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
                 result = this->decode_variant(decoded_value, major, additionalInfo, tag);
             } else if constexpr (IsTag<raw_type>) {
                 if (!tag) {
-                    tag = decode_unsigned(additionalInfo);
+                    std::uint64_t decoded_tag{};
+                    const auto    tag_status = decode_tag_argument(additionalInfo, decoded_tag);
+                    if (tag_status != status_code::success) {
+                        hard_error = tag_status;
+                        return false;
+                    }
+                    tag = decoded_tag;
                 }
                 result = this->decode(decoded_value, *tag);
             } else {

--- a/include/cbor_tags/cbor_decoder.h
+++ b/include/cbor_tags/cbor_decoder.h
@@ -1343,9 +1343,7 @@ struct decoder : public Decoders<decoder<InputBuffer, Options, Decoders...>>... 
 
     constexpr status_code decode_tag_argument(byte additionalInfo, std::uint64_t &tag) {
         tag = decode_unsigned(additionalInfo);
-        if constexpr (requires(self_t &self) {
-                          { self.observe_decoded_cbor_tag(tag) } -> std::same_as<status_code>;
-                      }) {
+        if constexpr (detail::HasDecodedCborTagObserver<self_t>) {
             return static_cast<self_t &>(*this).observe_decoded_cbor_tag(tag);
         }
         return status_code::success;

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -54,12 +54,14 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
     }
 
     constexpr void encode_major_and_size(std::uint64_t value, byte_type majorType) {
-        if (majorType == static_cast<byte_type>(0xC0)) {
-            if constexpr (requires(self_t &self) { self.observe_encoded_cbor_tag(value); }) {
-                static_cast<self_t &>(*this).observe_encoded_cbor_tag(value);
-            }
-        }
         detail::append_cbor_major_argument(appender_, data_, value, majorType);
+    }
+
+    constexpr void encode_tag_argument(std::uint64_t value) {
+        if constexpr (detail::HasEncodedCborTagObserver<self_t>) {
+            static_cast<self_t &>(*this).observe_encoded_cbor_tag(value);
+        }
+        encode_major_and_size(value, static_cast<byte_type>(0xC0));
     }
 
     template <IsUnsigned T> constexpr void encode(T value) { encode_major_and_size(value, static_cast<byte_type>(0x00)); }
@@ -84,10 +86,8 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
         }
     }
 
-    template <std::uint64_t N> constexpr void encode(static_tag<N>) { encode_major_and_size(N, static_cast<byte_type>(0xC0)); }
-    template <IsUnsigned T> constexpr void    encode(dynamic_tag<T> value) {
-        encode_major_and_size(value.cbor_tag, static_cast<byte_type>(0xC0));
-    }
+    template <std::uint64_t N> constexpr void encode(static_tag<N>) { encode_tag_argument(N); }
+    template <IsUnsigned T> constexpr void    encode(dynamic_tag<T> value) { encode_tag_argument(value.cbor_tag); }
 
     template <IsString T, std::size_t Min, std::size_t Max> constexpr void encode(const bounded_size<T, Min, Max> &value) {
         encode_bounded_size(value);
@@ -160,7 +160,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
     constexpr void encode(const T &value) {
         if constexpr (HasInlineTag<T>) {
             const auto &&tuple = to_tuple(value);
-            encode_major_and_size(T::cbor_tag, static_cast<byte_type>(0xC0));
+            encode_tag_argument(T::cbor_tag);
             std::apply(
                 [this](const auto &...args) {
                     constexpr auto   size_        = sizeof...(args);
@@ -175,7 +175,7 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
         } else if constexpr (IsTag<T>) {
             const auto &&tuple = to_tuple(value);
             static_assert(IsTag<std::remove_cvref_t<decltype(std::get<0>(tuple))>>, "Tag must be first element of tuple");
-            encode_major_and_size(std::get<0>(tuple), static_cast<byte_type>(0xC0));
+            encode_tag_argument(std::get<0>(tuple));
             aggregate_encode(detail::tuple_tail(tuple));
         } else {
             const auto &&tuple = to_tuple(value);

--- a/include/cbor_tags/cbor_encoder.h
+++ b/include/cbor_tags/cbor_encoder.h
@@ -54,6 +54,11 @@ struct encoder : Encoders<encoder<OutputBuffer, Options, Encoders...>>... {
     }
 
     constexpr void encode_major_and_size(std::uint64_t value, byte_type majorType) {
+        if (majorType == static_cast<byte_type>(0xC0)) {
+            if constexpr (requires(self_t &self) { self.observe_encoded_cbor_tag(value); }) {
+                static_cast<self_t &>(*this).observe_encoded_cbor_tag(value);
+            }
+        }
         detail::append_cbor_major_argument(appender_, data_, value, majorType);
     }
 

--- a/include/cbor_tags/detail/cbor_extension_decode.h
+++ b/include/cbor_tags/detail/cbor_extension_decode.h
@@ -27,6 +27,8 @@ template <typename Decoder>
     return status_code::success;
 }
 
+// This is a raw CBOR argument parser and does not notify tag observers. Use
+// decode_tag_argument() for a tag header unless the codec registers that tag itself.
 template <typename Decoder>
 [[nodiscard]] constexpr status_code decode_unsigned_argument(Decoder &dec, std::byte additional_info, std::uint64_t &value) {
     const auto info = std::to_integer<std::uint8_t>(additional_info);
@@ -38,6 +40,18 @@ template <typename Decoder>
         value = dec.decode_unsigned(additional_info);
     } catch (const parse_incomplete_exception &) { return status_code::incomplete; }
     return status_code::success;
+}
+
+template <typename Decoder>
+[[nodiscard]] constexpr status_code decode_tag_argument(Decoder &dec, std::byte additional_info, std::uint64_t &value) {
+    const auto info = std::to_integer<std::uint8_t>(additional_info);
+    if (!is_valid_cbor_argument_info(info)) {
+        return status_code::error;
+    }
+
+    try {
+        return dec.decode_tag_argument(additional_info, value);
+    } catch (const parse_incomplete_exception &) { return status_code::incomplete; }
 }
 
 template <typename Decoder>
@@ -118,7 +132,7 @@ template <typename Decoder, typename Fn>
     }
 
     std::uint64_t actual_tag{};
-    auto          status = decode_unsigned_argument(dec, additional_info, actual_tag);
+    auto          status = decode_tag_argument(dec, additional_info, actual_tag);
     if (status != status_code::success) {
         return status;
     }
@@ -151,7 +165,7 @@ template <typename Decoder, typename Fn>
     }
 
     std::uint64_t actual_tag{};
-    auto          status = decode_unsigned_argument(dec, additional_info, actual_tag);
+    auto          status = decode_tag_argument(dec, additional_info, actual_tag);
     if (status != status_code::success) {
         return status;
     }
@@ -182,7 +196,7 @@ template <typename Decoder, typename Fn>
     }
 
     std::uint64_t actual_tag{};
-    auto          status = decode_unsigned_argument(dec, additional_info, actual_tag);
+    auto          status = decode_tag_argument(dec, additional_info, actual_tag);
     if (status != status_code::success) {
         return status;
     }

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -565,10 +565,6 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
         if (tag != detail::shareable_tag) {
             return;
         }
-        if (encoding_tracked_shareable_) {
-            encoding_tracked_shareable_ = false;
-            return;
-        }
         auto observed = current_encode_scope().observe_untracked();
         if (!observed) {
             throw cbor::tags::detail::encode_status_exception{observed.error()};
@@ -657,8 +653,8 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
             return;
         }
 
-        encoding_tracked_shareable_ = true;
-        enc.encode(static_tag<detail::shareable_tag>{});
+        // observe() already reserved this tag 28 index.
+        enc.encode_major_and_size(detail::shareable_tag, static_cast<typename Self::byte_type>(0xC0));
         enc.encode(*value);
         scope.mark_complete(observation->index);
     }
@@ -751,7 +747,6 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
     shared_ptr_decode_scope                 default_decode_scope_{};
     std::optional<detail::encode_scope_ref> external_encode_scope_{};
     std::optional<detail::decode_scope_ref> external_decode_scope_{};
-    bool                                    encoding_tracked_shareable_{};
 };
 
 } // namespace cbor::tags::ext::smart_ptr

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -54,6 +54,7 @@ struct shared_ptr_decode_entry {
 template <typename Scope>
 concept SharedPtrEncodeScope = requires(Scope &scope, const shared_ptr_encode_key &key, std::size_t index) {
     { scope.observe(key) } -> std::same_as<expected<shared_ptr_observation, status_code>>;
+    { scope.observe_untracked() } -> std::same_as<expected<void, status_code>>;
     { scope.mark_complete(index) } -> std::same_as<void>;
     { scope.reset() } -> std::same_as<void>;
 };
@@ -61,6 +62,7 @@ concept SharedPtrEncodeScope = requires(Scope &scope, const shared_ptr_encode_ke
 template <typename Scope>
 concept SharedPtrDecodeScope = requires(Scope &scope, const shared_ptr_decode_entry &entry, std::size_t index) {
     { scope.insert(entry) } -> std::same_as<expected<std::size_t, status_code>>;
+    { scope.insert_untracked() } -> std::same_as<expected<void, status_code>>;
     { scope.resolve(index) } -> std::same_as<expected<shared_ptr_decode_entry, status_code>>;
     { scope.mark_complete(index) } -> std::same_as<void>;
     { scope.reset() } -> std::same_as<void>;
@@ -102,6 +104,11 @@ class shared_ptr_encode_scope {
         return shared_ptr_observation{.kind = shared_ptr_observation_kind::first, .index = index};
     }
 
+    [[nodiscard]] expected<void, status_code> observe_untracked() {
+        entries_.push_back({});
+        return {};
+    }
+
     void mark_complete(std::size_t index) {
         if (index < entries_.size()) {
             entries_[index].state = shared_ptr_entry_state::complete;
@@ -131,6 +138,11 @@ class shared_ptr_decode_scope {
         const auto index = entries_.size();
         entries_.push_back(entry);
         return index;
+    }
+
+    [[nodiscard]] expected<void, status_code> insert_untracked() {
+        entries_.push_back({});
+        return {};
     }
 
     [[nodiscard]] expected<shared_ptr_decode_entry, status_code> resolve(std::size_t index) {
@@ -197,18 +209,21 @@ class encode_scope_ref {
     explicit encode_scope_ref(Scope &scope)
         : scope_(std::addressof(scope)),
           observe_([](void *raw, const shared_ptr_encode_key &key) { return static_cast<Scope *>(raw)->observe(key); }),
+          observe_untracked_([](void *raw) { return static_cast<Scope *>(raw)->observe_untracked(); }),
           mark_complete_([](void *raw, std::size_t index) { static_cast<Scope *>(raw)->mark_complete(index); }),
           reset_([](void *raw) { static_cast<Scope *>(raw)->reset(); }) {}
 
     [[nodiscard]] expected<shared_ptr_observation, status_code> observe(const shared_ptr_encode_key &key) const {
         return observe_(scope_, key);
     }
-    void mark_complete(std::size_t index) const { mark_complete_(scope_, index); }
-    void reset() const { reset_(scope_); }
+    [[nodiscard]] expected<void, status_code> observe_untracked() const { return observe_untracked_(scope_); }
+    void                                      mark_complete(std::size_t index) const { mark_complete_(scope_, index); }
+    void                                      reset() const { reset_(scope_); }
 
   private:
     void *scope_{};
     expected<shared_ptr_observation, status_code> (*observe_)(void *, const shared_ptr_encode_key &){};
+    expected<void, status_code> (*observe_untracked_)(void *){};
     void (*mark_complete_)(void *, std::size_t){};
     void (*reset_)(void *){};
 };
@@ -219,11 +234,13 @@ class decode_scope_ref {
     explicit decode_scope_ref(Scope &scope)
         : scope_(std::addressof(scope)),
           insert_([](void *raw, const shared_ptr_decode_entry &entry) { return static_cast<Scope *>(raw)->insert(entry); }),
+          insert_untracked_([](void *raw) { return static_cast<Scope *>(raw)->insert_untracked(); }),
           resolve_([](void *raw, std::size_t index) { return static_cast<Scope *>(raw)->resolve(index); }),
           mark_complete_([](void *raw, std::size_t index) { static_cast<Scope *>(raw)->mark_complete(index); }),
           reset_([](void *raw) { static_cast<Scope *>(raw)->reset(); }) {}
 
     [[nodiscard]] expected<std::size_t, status_code> insert(const shared_ptr_decode_entry &entry) const { return insert_(scope_, entry); }
+    [[nodiscard]] expected<void, status_code>        insert_untracked() const { return insert_untracked_(scope_); }
     [[nodiscard]] expected<shared_ptr_decode_entry, status_code> resolve(std::size_t index) const { return resolve_(scope_, index); }
     void                                                         mark_complete(std::size_t index) const { mark_complete_(scope_, index); }
     void                                                         reset() const { reset_(scope_); }
@@ -231,6 +248,7 @@ class decode_scope_ref {
   private:
     void *scope_{};
     expected<std::size_t, status_code> (*insert_)(void *, const shared_ptr_decode_entry &){};
+    expected<void, status_code> (*insert_untracked_)(void *){};
     expected<shared_ptr_decode_entry, status_code> (*resolve_)(void *, std::size_t){};
     void (*mark_complete_)(void *, std::size_t){};
     void (*reset_)(void *){};
@@ -541,6 +559,32 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
         current_decode_scope().reset();
     }
 
+    template <typename S = Self>
+        requires detail::EncoderSelf<S>
+    void observe_encoded_cbor_tag(std::uint64_t tag) {
+        if (tag != detail::shareable_tag) {
+            return;
+        }
+        if (encoding_tracked_shareable_) {
+            encoding_tracked_shareable_ = false;
+            return;
+        }
+        auto observed = current_encode_scope().observe_untracked();
+        if (!observed) {
+            throw cbor::tags::detail::encode_status_exception{observed.error()};
+        }
+    }
+
+    template <typename S = Self>
+        requires detail::DecoderSelf<S>
+    [[nodiscard]] status_code observe_decoded_cbor_tag(std::uint64_t tag) {
+        if (tag != detail::shareable_tag) {
+            return status_code::success;
+        }
+        auto inserted = current_decode_scope().insert_untracked();
+        return inserted ? status_code::success : inserted.error();
+    }
+
     template <IsSharedPointer Pointer> void encode(const Pointer &value) { encode_shared_pointer(value); }
 
     template <IsSharedPointer Pointer> void encode(const scoped_shared_ptr<Pointer> &value) { encode_shared_pointer(value.value()); }
@@ -613,6 +657,7 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
             return;
         }
 
+        encoding_tracked_shareable_ = true;
         enc.encode(static_tag<detail::shareable_tag>{});
         enc.encode(*value);
         scope.mark_complete(observation->index);
@@ -706,6 +751,7 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
     shared_ptr_decode_scope                 default_decode_scope_{};
     std::optional<detail::encode_scope_ref> external_encode_scope_{};
     std::optional<detail::decode_scope_ref> external_decode_scope_{};
+    bool                                    encoding_tracked_shareable_{};
 };
 
 } // namespace cbor::tags::ext::smart_ptr

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -290,7 +290,7 @@ template <typename Decoder, typename T>
         }
 
         std::uint64_t tag{};
-        const auto    status = cbor::tags::detail::decode_unsigned_argument(dec, additional_info, tag);
+        const auto    status = cbor::tags::detail::decode_tag_argument(dec, additional_info, tag);
         return status == status_code::success ? dec.decode(value, tag) : status;
     } else if constexpr (IsAggregate<T> || IsUntaggedTuple<T>) {
         auto &&tuple = [&]() -> decltype(auto) {
@@ -442,7 +442,7 @@ template <typename Decoder, IsVariant Variant>
 
     if (major == major_type::Tag && !tag.has_value()) {
         std::uint64_t decoded_tag{};
-        const auto    status = cbor::tags::detail::decode_unsigned_argument(dec, additional_info, decoded_tag);
+        const auto    status = cbor::tags::detail::decode_tag_argument(dec, additional_info, decoded_tag);
         if (status != status_code::success) {
             return status;
         }
@@ -671,7 +671,9 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
         }
 
         std::uint64_t tag{};
-        const auto    status = cbor::tags::detail::decode_unsigned_argument(static_cast<Self &>(*this), additional_info, tag);
+        // Tag 28 is registered by decode_shareable() with the pointer entry itself.
+        // Observing it here would also insert an untracked entry and shift every reference index.
+        const auto status = cbor::tags::detail::decode_unsigned_argument(static_cast<Self &>(*this), additional_info, tag);
         if (status != status_code::success) {
             return status;
         }

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -110,6 +110,11 @@ struct tagged_record {
     std::uint64_t  value{};
 };
 
+struct ordinary_shareable {
+    static_tag<28> cbor_tag;
+    std::uint64_t  value{};
+};
+
 struct custom_record {
     std::uint64_t value{};
 };
@@ -874,6 +879,25 @@ TEST_CASE("shared_ptr codec uses IANA reference tags") {
     REQUIRE(decoded[1]);
     CHECK_EQ(*decoded[0], 42U);
     CHECK(decoded[0] == decoded[1]);
+}
+
+TEST_CASE("sharedref indices count ordinary tag 28 items") {
+    const auto pointer = std::make_shared<std::uint64_t>(2U);
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<shared_ptr_codec>(bytes);
+    REQUIRE(enc(wrap_as_array{smart_ptr_test::ordinary_shareable{.value = 1U}, pointer, pointer}));
+    CHECK_EQ(to_hex(bytes), "83d81c01d81c02d81d01");
+
+    const auto                         standard_bytes = to_bytes("83d81c01d81c02d81d01");
+    smart_ptr_test::ordinary_shareable first;
+    std::shared_ptr<std::uint64_t>     decoded_pointer;
+    std::shared_ptr<std::uint64_t>     decoded_reference;
+    auto                               dec = make_decoder<shared_ptr_codec>(standard_bytes);
+    REQUIRE(dec(wrap_as_array{first, decoded_pointer, decoded_reference}));
+    CHECK_EQ(first.value, 1U);
+    REQUIRE(decoded_pointer);
+    CHECK(decoded_pointer == decoded_reference);
 }
 
 TEST_CASE("shared_ptr null uses native CBOR null") {

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -56,6 +56,14 @@ class encode_table {
         return shared_ptr_observation{shared_ptr_observation_kind::first, index};
     }
 
+    [[nodiscard]] expected<void, status_code> observe_untracked() {
+        if (entries_.size() >= limit_) {
+            return cbor::tags::unexpected<status_code>{status_code::size_limit_exceeded};
+        }
+        entries_.push_back({});
+        return {};
+    }
+
     void mark_complete(std::size_t index) { entries_.at(index).state = shared_ptr_entry_state::complete; }
 
   private:
@@ -77,6 +85,14 @@ class decode_table {
         const auto index = entries_.size();
         entries_.push_back(entry);
         return index;
+    }
+
+    [[nodiscard]] expected<void, status_code> insert_untracked() {
+        if (entries_.size() >= limit_) {
+            return cbor::tags::unexpected<status_code>{status_code::size_limit_exceeded};
+        }
+        entries_.push_back({});
+        return {};
     }
 
     [[nodiscard]] expected<shared_ptr_decode_entry, status_code> resolve(std::size_t index) {

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -131,6 +131,28 @@ struct ordinary_shareable {
     std::uint64_t  value{};
 };
 
+struct extension_shareable {
+    explicit extension_shareable(std::uint64_t initial_value = 0U) : value(initial_value) {}
+
+    std::uint64_t value{};
+};
+
+template <typename Self> struct extension_shareable_codec : cbor_codec_mixin_base<Self> {
+    using cbor_codec_mixin_base<Self>::decode;
+    using cbor_codec_mixin_base<Self>::encode;
+
+    void encode(const extension_shareable &value) {
+        auto &enc = static_cast<Self &>(*this);
+        enc.encode(static_tag<28>{});
+        enc.encode(value.value);
+    }
+
+    [[nodiscard]] status_code decode(extension_shareable &value, major_type major, std::byte additional_info) {
+        auto &dec = static_cast<Self &>(*this);
+        return cbor::tags::detail::decode_tagged_payload(dec, 28U, major, additional_info, [&] { return dec.decode(value.value); });
+    }
+};
+
 struct custom_record {
     std::uint64_t value{};
 };
@@ -911,6 +933,44 @@ TEST_CASE("sharedref indices count ordinary tag 28 items") {
     auto                               dec = make_decoder<shared_ptr_codec>(bytes);
     REQUIRE(dec(wrap_as_array{first, decoded_pointer, decoded_reference}));
     CHECK_EQ(first.value, 1U);
+    REQUIRE(decoded_pointer);
+    CHECK(decoded_pointer == decoded_reference);
+}
+
+TEST_CASE("sharedref indices count tag 28 pointees decoded through unique_ptr codec") {
+    const auto first   = std::make_unique<smart_ptr_test::ordinary_shareable>(smart_ptr_test::ordinary_shareable{.value = 1U});
+    const auto pointer = std::make_shared<std::uint64_t>(2U);
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec, shared_ptr_codec>(bytes);
+    REQUIRE(enc(wrap_as_array{first, pointer, pointer}));
+    REQUIRE_EQ(to_hex(bytes), "83d81c01d81c02d81d01");
+
+    std::unique_ptr<smart_ptr_test::ordinary_shareable> decoded_first;
+    std::shared_ptr<std::uint64_t>                      decoded_pointer;
+    std::shared_ptr<std::uint64_t>                      decoded_reference;
+    auto                                                dec = make_decoder<unique_ptr_codec, shared_ptr_codec>(bytes);
+    REQUIRE(dec(wrap_as_array{decoded_first, decoded_pointer, decoded_reference}));
+    REQUIRE(decoded_first);
+    CHECK_EQ(decoded_first->value, 1U);
+    REQUIRE(decoded_pointer);
+    CHECK(decoded_pointer == decoded_reference);
+}
+
+TEST_CASE("sharedref indices count tag 28 values decoded through extension helpers") {
+    const auto pointer = std::make_shared<std::uint64_t>(2U);
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<shared_ptr_codec, smart_ptr_test::extension_shareable_codec>(bytes);
+    REQUIRE(enc(wrap_as_array{smart_ptr_test::extension_shareable{1U}, pointer, pointer}));
+    REQUIRE_EQ(to_hex(bytes), "83d81c01d81c02d81d01");
+
+    smart_ptr_test::extension_shareable decoded_first;
+    std::shared_ptr<std::uint64_t>      decoded_pointer;
+    std::shared_ptr<std::uint64_t>      decoded_reference;
+    auto                                dec = make_decoder<shared_ptr_codec, smart_ptr_test::extension_shareable_codec>(bytes);
+    REQUIRE(dec(wrap_as_array{decoded_first, decoded_pointer, decoded_reference}));
+    CHECK_EQ(decoded_first.value, 1U);
     REQUIRE(decoded_pointer);
     CHECK(decoded_pointer == decoded_reference);
 }

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -174,7 +174,7 @@ template <typename Self> struct custom_record_codec : cbor_codec_mixin_base<Self
 
         auto         &dec = static_cast<Self &>(*this);
         std::uint64_t tag{};
-        const auto    status = cbor::tags::detail::decode_unsigned_argument(dec, additional_info, tag);
+        const auto    status = cbor::tags::detail::decode_tag_argument(dec, additional_info, tag);
         if (status != status_code::success) {
             return status;
         }

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -903,13 +903,12 @@ TEST_CASE("sharedref indices count ordinary tag 28 items") {
     std::vector<std::byte> bytes;
     auto                   enc = make_encoder<shared_ptr_codec>(bytes);
     REQUIRE(enc(wrap_as_array{smart_ptr_test::ordinary_shareable{.value = 1U}, pointer, pointer}));
-    CHECK_EQ(to_hex(bytes), "83d81c01d81c02d81d01");
+    REQUIRE_EQ(to_hex(bytes), "83d81c01d81c02d81d01");
 
-    const auto                         standard_bytes = to_bytes("83d81c01d81c02d81d01");
     smart_ptr_test::ordinary_shareable first;
     std::shared_ptr<std::uint64_t>     decoded_pointer;
     std::shared_ptr<std::uint64_t>     decoded_reference;
-    auto                               dec = make_decoder<shared_ptr_codec>(standard_bytes);
+    auto                               dec = make_decoder<shared_ptr_codec>(bytes);
     REQUIRE(dec(wrap_as_array{first, decoded_pointer, decoded_reference}));
     CHECK_EQ(first.value, 1U);
     REQUIRE(decoded_pointer);


### PR DESCRIPTION
## Summary

- count ordinary and nested typed tag 28 items in the shared-reference namespace
- keep tag 29 indices aligned on encode and decode without scanning payloads
- extend user-owned scope concepts with untracked tag-28 insertion
- document the opaque encoded-view boundary explicitly

## Red / green commits

1. `test(smart-ptr): reproduce global sharedref index drift` demonstrates encoding reference 0 instead of 1 and failure to decode the standards-correct reference 1.
2. `fix(smart-ptr): keep sharedref indices global` observes typed tag boundaries and records unrelated tag 28 positions without retaining their values.

## Validation

- focused repro: 6/6 assertions passed after the fix
- `cmake --build build --parallel 4`
- `ctest --test-dir build --output-on-failure` (54/54 passed)
- `scripts/format-cxx.sh --check`

No input walker or prewalk is introduced. Opaque encoded-item views remain opaque and are documented as a reference-namespace boundary.

Stacked on #93 for focused review.
