### PR TITLE
fix(smart-ptr): reject simple null wire ambiguity

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -351,6 +351,11 @@ An empty aggregate encodes no item and is rejected. A multi-field aggregate is
 also rejected when group wrapping is disabled, because it would encode several
 items under one tag 28.
 
+`std::unique_ptr<simple>` is rejected because `simple{22}` and an empty unique
+pointer both encode as CBOR `null`; decoding cannot distinguish them. A shared
+pointer does not have that ambiguity because a non-null value is wrapped in tag
+28.
+
 A shared pointer inside `std::variant` requires an application codec:
 
 ```cpp

--- a/include/cbor_tags/detail/cbor_pointer_traits.h
+++ b/include/cbor_tags/detail/cbor_pointer_traits.h
@@ -74,7 +74,7 @@ template <typename Pointer> using smart_pointer_element_t = typename std::remove
 
 template <typename T> consteval bool has_known_null_wire_impl() {
     using type = std::remove_cvref_t<T>;
-    if constexpr (std::same_as<type, std::nullptr_t> || IsSmartPointer<type> || IsOptional<type>) {
+    if constexpr (std::same_as<type, std::nullptr_t> || std::same_as<type, simple> || IsSmartPointer<type> || IsOptional<type>) {
         return true;
     } else if constexpr (IsVariant<type>) {
         return with_variant_alternatives<type>([]<typename... Ts>() { return (has_known_null_wire_impl<Ts>() || ...); });

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -463,6 +463,19 @@ add_test(
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
+add_executable(smart_ptr_simple_null_compile_fails EXCLUDE_FROM_ALL smart_ptr_simple_null_compile_fail.cc)
+target_link_libraries(smart_ptr_simple_null_compile_fails PRIVATE cbor::tags)
+add_test(
+  NAME smart_ptr_simple_null_compile_fails
+  COMMAND
+    ${CMAKE_COMMAND}
+    "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+    "-DTEST_TARGET=smart_ptr_simple_null_compile_fails"
+    "-DCONFIG=$<CONFIG>"
+    "-DPASS_REGEX=unique pointer cannot encode a pointee that also has a CBOR null state"
+    -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+
 add_executable(
   cddl_smart_ptr_empty_pointee_compile_fails
   EXCLUDE_FROM_ALL

--- a/test/smart_ptr_simple_null_compile_fail.cc
+++ b/test/smart_ptr_simple_null_compile_fail.cc
@@ -1,0 +1,18 @@
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/cbor_simple.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    auto value = std::make_unique<simple>(static_cast<simple::value_type>(SimpleType::Null));
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
+    return enc(value).has_value() ? 0 : 1;
+}

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -890,6 +890,21 @@ TEST_CASE("shared_ptr null uses native CBOR null") {
     CHECK_FALSE(decoded);
 }
 
+TEST_CASE("unique pointer rejects simple values that use the null wire") {
+    auto value = std::make_unique<simple>(static_cast<simple::value_type>(SimpleType::Null));
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
+    REQUIRE(enc(value));
+    CHECK_EQ(to_hex(bytes), "f6");
+
+    std::unique_ptr<simple> decoded;
+    auto                    dec = make_decoder<unique_ptr_codec>(bytes);
+    REQUIRE(dec(decoded));
+    REQUIRE(decoded);
+    CHECK_EQ(decoded->value, static_cast<simple::value_type>(SimpleType::Null));
+}
+
 TEST_CASE("default shared_ptr scope persists until explicitly reset") {
     auto p = std::make_shared<std::uint64_t>(1U);
 

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -890,21 +890,6 @@ TEST_CASE("shared_ptr null uses native CBOR null") {
     CHECK_FALSE(decoded);
 }
 
-TEST_CASE("unique pointer rejects simple values that use the null wire") {
-    auto value = std::make_unique<simple>(static_cast<simple::value_type>(SimpleType::Null));
-
-    std::vector<std::byte> bytes;
-    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
-    REQUIRE(enc(value));
-    CHECK_EQ(to_hex(bytes), "f6");
-
-    std::unique_ptr<simple> decoded;
-    auto                    dec = make_decoder<unique_ptr_codec>(bytes);
-    REQUIRE(dec(decoded));
-    REQUIRE(decoded);
-    CHECK_EQ(decoded->value, static_cast<simple::value_type>(SimpleType::Null));
-}
-
 TEST_CASE("default shared_ptr scope persists until explicitly reset") {
     auto p = std::make_shared<std::uint64_t>(1U);
 


### PR DESCRIPTION
## Summary

- treat `simple` as a type that can use the CBOR null wire
- reject `unique_ptr<simple>` at compile time instead of silently decoding `simple{22}` as an empty pointer
- document why the same type remains safe behind a shared pointer

## Red / green commits

1. `test(smart-ptr): reproduce simple null wire loss` shows `unique_ptr<simple>{simple{22}}` encoding as `f6` and decoding as null.
2. `fix(smart-ptr): reject simple null wire ambiguity` converts the repro to a compile-fail contract test and extends the existing null-wire classification.

## Validation

- focused runtime repro failed on #93 because the destination pointer became empty
- focused green tests passed (runtime suite plus compile-fail contract)
- `ctest --test-dir build --output-on-failure` (55/55 passed)
- `scripts/format-cxx.sh --check`

A shared pointer remains supported: its non-null form is `#6.28(f6)`, so it cannot be confused with a null pointer encoded as bare `f6`.

Stacked on #93 for focused review.
