### PR TITLE
fix(smart-ptr): classify unique variant wire shapes

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -364,6 +364,11 @@ an application tag. The library does not guess how tag 28/29 should compete
 with the other alternatives. Unique-pointer variants remain supported when
 their wire shapes do not overlap.
 
+Automatic unique-pointer variant dispatch also requires every alternative's
+outer wire shape to be independent of an installed custom codec. If a codec
+changes an alternative's outer tag or major type, define an explicit codec for
+the whole variant so it can apply that protocol-specific discriminator.
+
 An ordinary `std::optional` cannot directly contain a smart pointer. Both the
 empty optional and the empty pointer would encode as CBOR `null`. A named-map
 field can still distinguish an omitted optional field from a present field

--- a/include/cbor_tags/detail/smart_ptr_traits.h
+++ b/include/cbor_tags/detail/smart_ptr_traits.h
@@ -223,17 +223,55 @@ template <typename T, std::uint64_t Tag> consteval bool wire_matches_tag() {
     }
 }
 
-template <typename A, typename B> consteval bool wire_shapes_overlap() {
+template <typename Options, typename T> consteval bool wire_matches_array() {
+    using type = std::remove_cvref_t<T>;
+    if constexpr (UniquePointer<type>) {
+        return wire_matches_array<Options, pointer_element_t<type>>();
+    } else if constexpr (SharedPointer<type>) {
+        return false;
+    } else if constexpr (IsVariant<type>) {
+        return cbor::tags::detail::with_variant_alternatives<type>(
+            []<typename... Ts>() { return (wire_matches_array<Options, Ts>() || ...); });
+    } else if constexpr ((IsAggregate<type> || IsUntaggedTuple<type>) && !IsTag<type>) {
+        using tuple_type          = pointer_tuple_t<type>;
+        constexpr auto item_count = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
+        if constexpr (item_count == 0U) {
+            return false;
+        } else if constexpr (item_count == 1U) {
+            return wire_matches_array<Options, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>();
+        } else {
+            return Options::wrap_groups;
+        }
+    } else {
+        using one_type_variant = std::variant<type>;
+        constexpr auto mapping = valid_concept_mapping_array_v<one_type_variant>;
+        return mapping[cbor::tags::detail::MajorIndex::Array] != 0U;
+    }
+}
+
+template <typename Options, typename A, typename B> consteval bool wire_shapes_overlap() {
     using a_type = std::remove_cvref_t<A>;
     using b_type = std::remove_cvref_t<B>;
     if constexpr (UniquePointer<a_type>) {
-        return wire_matches_null<b_type>() || wire_shapes_overlap<pointer_element_t<a_type>, b_type>();
+        return wire_matches_null<b_type>() || wire_shapes_overlap<Options, pointer_element_t<a_type>, b_type>();
     } else if constexpr (UniquePointer<b_type>) {
-        return wire_matches_null<a_type>() || wire_shapes_overlap<a_type, pointer_element_t<b_type>>();
+        return wire_matches_null<a_type>() || wire_shapes_overlap<Options, a_type, pointer_element_t<b_type>>();
     } else if constexpr (SharedPointer<a_type>) {
         return wire_matches_null<b_type>() || wire_matches_tag<b_type, shareable_tag>() || wire_matches_tag<b_type, sharedref_tag>();
     } else if constexpr (SharedPointer<b_type>) {
         return wire_matches_null<a_type>() || wire_matches_tag<a_type, shareable_tag>() || wire_matches_tag<a_type, sharedref_tag>();
+    } else if constexpr ((IsAggregate<a_type> || IsUntaggedTuple<a_type>) && !IsTag<a_type>) {
+        using tuple_type          = pointer_tuple_t<a_type>;
+        constexpr auto item_count = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
+        if constexpr (item_count == 0U) {
+            return false;
+        } else if constexpr (item_count == 1U) {
+            return wire_shapes_overlap<Options, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>, b_type>();
+        } else {
+            return Options::wrap_groups && wire_matches_array<Options, b_type>();
+        }
+    } else if constexpr ((IsAggregate<b_type> || IsUntaggedTuple<b_type>) && !IsTag<b_type>) {
+        return wire_shapes_overlap<Options, b_type, a_type>();
     } else {
         using pair_variant          = std::variant<a_type, b_type>;
         constexpr auto mapping      = valid_concept_mapping_array_v<pair_variant>;
@@ -247,16 +285,17 @@ template <typename A, typename B> consteval bool wire_shapes_overlap() {
     }
 }
 
-template <typename Variant, std::size_t I = 0U, std::size_t J = 1U> consteval bool pointer_variant_is_unambiguous() {
+template <typename Variant, typename Options = default_options, std::size_t I = 0U, std::size_t J = 1U>
+consteval bool pointer_variant_is_unambiguous() {
     constexpr auto count = cbor::tags::detail::variant_size_v<Variant>;
     if constexpr (I >= count) {
         return true;
     } else if constexpr (J >= count) {
-        return pointer_variant_is_unambiguous<Variant, I + 1U, I + 2U>();
+        return pointer_variant_is_unambiguous<Variant, Options, I + 1U, I + 2U>();
     } else {
         using left  = cbor::tags::detail::variant_alternative_t<I, Variant>;
         using right = cbor::tags::detail::variant_alternative_t<J, Variant>;
-        return !wire_shapes_overlap<left, right>() && pointer_variant_is_unambiguous<Variant, I, J + 1U>();
+        return !wire_shapes_overlap<Options, left, right>() && pointer_variant_is_unambiguous<Variant, Options, I, J + 1U>();
     }
 }
 

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -349,11 +349,11 @@ template <typename Decoder, typename T> consteval bool unique_variant_alternativ
     if constexpr (UniquePointer<type>) {
         return std::default_initializable<type> && std::default_initializable<pointer_element_t<type>> &&
                !known_null_wire_v<pointer_element_t<type>> && unique_variant_alternative_supported<Decoder, pointer_element_t<type>>();
-    } else if constexpr (IsClassWithDecodingOverload<Decoder, type> || extension_decodes_with_major_v<type, Decoder>) {
-        return false;
     } else if constexpr (IsVariant<type>) {
         return cbor::tags::detail::with_variant_alternatives<type>(
             []<typename... Ts>() { return (unique_variant_alternative_supported<Decoder, Ts>() && ...); });
+    } else if constexpr (IsClassWithDecodingOverload<Decoder, type> || extension_decodes_with_major_v<type, Decoder>) {
+        return false;
     } else if constexpr ((IsAggregate<type> || IsUntaggedTuple<type>) && !IsTag<type>) {
         using tuple_type          = pointer_tuple_t<type>;
         constexpr auto item_count = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
@@ -440,7 +440,7 @@ template <typename Decoder, IsVariant Variant>
                       []<typename... Ts>() { return (unique_variant_alternative_supported<Decoder, Ts>() && ...); }),
                   "unique pointer variant alternatives must have codec-independent CBOR wire shapes; add an explicit codec for the "
                   "whole variant");
-    static_assert(pointer_variant_is_unambiguous<variant_type>(),
+    static_assert(pointer_variant_is_unambiguous<variant_type, typename Decoder::options>(),
                   "Pointer variant alternatives overlap on the CBOR wire; add an application tag or choose a different decode type");
     static_assert(cbor::tags::detail::with_variant_alternatives<variant_type>(
                       []<typename... Ts>() { return (std::default_initializable<Ts> && ...); }),

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -343,30 +343,43 @@ template <typename Decoder, UniquePointer Pointer>
     }
 }
 
-template <typename T> consteval bool unique_variant_alternative_supported() {
+template <typename Decoder, typename T> consteval bool unique_variant_alternative_supported() {
     using type = std::remove_cvref_t<T>;
+
     if constexpr (UniquePointer<type>) {
         return std::default_initializable<type> && std::default_initializable<pointer_element_t<type>> &&
-               !known_null_wire_v<pointer_element_t<type>>;
+               !known_null_wire_v<pointer_element_t<type>> && unique_variant_alternative_supported<Decoder, pointer_element_t<type>>();
+    } else if constexpr (IsClassWithDecodingOverload<Decoder, type> || extension_decodes_with_major_v<type, Decoder>) {
+        return false;
     } else if constexpr (IsVariant<type>) {
         return cbor::tags::detail::with_variant_alternatives<type>(
-            []<typename... Ts>() { return (unique_variant_alternative_supported<Ts>() && ...); });
+            []<typename... Ts>() { return (unique_variant_alternative_supported<Decoder, Ts>() && ...); });
+    } else if constexpr ((IsAggregate<type> || IsUntaggedTuple<type>) && !IsTag<type>) {
+        using tuple_type          = pointer_tuple_t<type>;
+        constexpr auto item_count = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
+        if constexpr (item_count == 0U) {
+            return false;
+        } else if constexpr (item_count > 1U) {
+            return Decoder::options::wrap_groups;
+        } else {
+            return unique_variant_alternative_supported<Decoder, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>();
+        }
     } else {
         return IsCborMajor<type> || IsArray<type> || IsMap<type>;
     }
 }
 
-template <typename T>
+template <typename Decoder, typename T>
 [[nodiscard]] constexpr bool unique_variant_matches(major_type major, std::byte additional_info, const std::optional<std::uint64_t> &tag) {
     using type = std::remove_cvref_t<T>;
     if constexpr (UniquePointer<type>) {
         if (major == major_type::Simple && additional_info == static_cast<std::byte>(SimpleType::Null)) {
             return true;
         }
-        return unique_variant_matches<pointer_element_t<type>>(major, additional_info, tag);
+        return unique_variant_matches<Decoder, pointer_element_t<type>>(major, additional_info, tag);
     } else if constexpr (IsVariant<type>) {
         return cbor::tags::detail::with_variant_alternatives<type>(
-            [&]<typename... Ts>() { return (unique_variant_matches<Ts>(major, additional_info, tag) || ...); });
+            [&]<typename... Ts>() { return (unique_variant_matches<Decoder, Ts>(major, additional_info, tag) || ...); });
     } else if (major == major_type::Tag) {
         if (!tag.has_value()) {
             return false;
@@ -375,6 +388,16 @@ template <typename T>
             return true;
         } else if constexpr (IsTag<type>) {
             return static_cast<std::uint64_t>(cbor::tags::detail::get_tag_from_any<type>()) == *tag;
+        } else {
+            return false;
+        }
+    } else if constexpr ((IsAggregate<type> || IsUntaggedTuple<type>) && !IsTag<type>) {
+        using tuple_type          = pointer_tuple_t<type>;
+        constexpr auto item_count = std::tuple_size_v<std::remove_cvref_t<tuple_type>>;
+        if constexpr (item_count > 1U && Decoder::options::wrap_groups) {
+            return major == major_type::Array;
+        } else if constexpr (item_count == 1U) {
+            return unique_variant_matches<Decoder, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>(major, additional_info, tag);
         } else {
             return false;
         }
@@ -414,8 +437,9 @@ template <typename Decoder, IsVariant Variant>
     using variant_type = std::remove_cvref_t<Variant>;
 
     static_assert(cbor::tags::detail::with_variant_alternatives<variant_type>(
-                      []<typename... Ts>() { return (unique_variant_alternative_supported<Ts>() && ...); }),
-                  "unique pointer variant alternatives must have supported CBOR wire shapes");
+                      []<typename... Ts>() { return (unique_variant_alternative_supported<Decoder, Ts>() && ...); }),
+                  "unique pointer variant alternatives must have codec-independent CBOR wire shapes; add an explicit codec for the "
+                  "whole variant");
     static_assert(pointer_variant_is_unambiguous<variant_type>(),
                   "Pointer variant alternatives overlap on the CBOR wire; add an application tag or choose a different decode type");
     static_assert(cbor::tags::detail::with_variant_alternatives<variant_type>(
@@ -437,7 +461,7 @@ template <typename Decoder, IsVariant Variant>
     cbor::tags::detail::with_variant_alternative_indices<variant_type>([&]<std::size_t... Is>() {
         auto select = [&]<std::size_t I>() {
             using alternative_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
-            if (selected || !unique_variant_matches<alternative_type>(major, additional_info, tag)) {
+            if (selected || !unique_variant_matches<Decoder, alternative_type>(major, additional_info, tag)) {
                 return;
             }
             selected = true;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -411,6 +411,22 @@ add_test(
     -P
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
+add_executable(
+  smart_ptr_variant_composed_codec_compile_fails
+  EXCLUDE_FROM_ALL
+  smart_ptr_variant_composed_codec_compile_fail.cc)
+target_link_libraries(smart_ptr_variant_composed_codec_compile_fails PRIVATE cbor::tags)
+add_test(
+  NAME smart_ptr_variant_composed_codec_compile_fails
+  COMMAND
+    ${CMAKE_COMMAND}
+    "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+    "-DTEST_TARGET=smart_ptr_variant_composed_codec_compile_fails"
+    "-DCONFIG=$<CONFIG>"
+    "-DPASS_REGEX=unique pointer variant alternatives must have codec-independent CBOR wire shapes"
+    -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+
 add_executable(smart_ptr_nested_null_compile_fails EXCLUDE_FROM_ALL smart_ptr_nested_null_compile_fail.cc)
 target_link_libraries(smart_ptr_nested_null_compile_fails PRIVATE cbor::tags)
 add_test(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -383,6 +383,22 @@ add_test(
     "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
 
 add_executable(
+  smart_ptr_variant_aggregate_array_compile_fails
+  EXCLUDE_FROM_ALL
+  smart_ptr_variant_aggregate_array_compile_fail.cc)
+target_link_libraries(smart_ptr_variant_aggregate_array_compile_fails PRIVATE cbor::tags)
+add_test(
+  NAME smart_ptr_variant_aggregate_array_compile_fails
+  COMMAND
+    ${CMAKE_COMMAND}
+    "-DBUILD_DIR=${CMAKE_BINARY_DIR}"
+    "-DTEST_TARGET=smart_ptr_variant_aggregate_array_compile_fails"
+    "-DCONFIG=$<CONFIG>"
+    "-DPASS_REGEX=Pointer variant alternatives overlap on the CBOR wire"
+    -P
+    "${CMAKE_CURRENT_SOURCE_DIR}/expect_compile_failure.cmake")
+
+add_executable(
   smart_ptr_variant_shared_ptr_vector_array_compile_fails
   EXCLUDE_FROM_ALL
   smart_ptr_variant_shared_ptr_vector_array_compile_fail.cc)

--- a/test/smart_ptr_variant_aggregate_array_compile_fail.cc
+++ b/test/smart_ptr_variant_aggregate_array_compile_fail.cc
@@ -1,0 +1,21 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <variant>
+#include <vector>
+
+struct record {
+    std::uint64_t first{};
+    std::uint64_t second{};
+};
+
+int main() {
+    std::vector<std::byte> bytes;
+    auto                   dec = cbor::tags::make_decoder<cbor::tags::ext::smart_ptr::unique_ptr_codec>(bytes);
+
+    std::variant<std::unique_ptr<record>, std::vector<std::uint64_t>> decoded;
+    return dec(decoded).has_value() ? 0 : 1;
+}

--- a/test/smart_ptr_variant_composed_codec_compile_fail.cc
+++ b/test/smart_ptr_variant_composed_codec_compile_fail.cc
@@ -1,0 +1,49 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/cbor_extensions.h"
+#include "cbor_tags/detail/cbor_extension_decode.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+
+struct record {
+    static constexpr std::uint64_t cbor_tag = 42U;
+    std::uint64_t                  value{};
+};
+
+template <typename Self> struct record_codec : cbor::tags::cbor_codec_mixin_base<Self> {
+    using cbor::tags::cbor_codec_mixin_base<Self>::decode;
+    using cbor::tags::cbor_codec_mixin_base<Self>::encode;
+
+    void encode(const record &value) {
+        auto &enc = static_cast<Self &>(*this);
+        enc.encode(cbor::tags::static_tag<100>{});
+        enc.encode(value.value);
+    }
+
+    [[nodiscard]] cbor::tags::status_code decode(record &value, cbor::tags::major_type major, std::byte additional_info) {
+        if (major != cbor::tags::major_type::Tag) {
+            return cbor::tags::status_code::no_match_for_tag_on_buffer;
+        }
+        auto         &dec = static_cast<Self &>(*this);
+        std::uint64_t tag{};
+        const auto    status = cbor::tags::detail::decode_unsigned_argument(dec, additional_info, tag);
+        if (status != cbor::tags::status_code::success || tag != 100U) {
+            return status == cbor::tags::status_code::success ? cbor::tags::status_code::no_match_for_tag : status;
+        }
+        return dec.decode(value.value);
+    }
+};
+
+int main() {
+    using choice = std::variant<std::unique_ptr<std::string>, record>;
+    const std::vector<std::byte> bytes{std::byte{0xD8}, std::byte{0x64}, std::byte{0x01}};
+    auto                         dec = cbor::tags::make_decoder<cbor::tags::ext::smart_ptr::unique_ptr_codec, record_codec>(bytes);
+    choice                       value;
+    return dec(value).has_value() ? 0 : 1;
+}

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -740,6 +740,25 @@ TEST_CASE("unique_ptr codec delegates aggregate pointees to composed codecs") {
     CHECK_EQ(decoded->value, 42U);
 }
 
+TEST_CASE("unique pointer variant matches an array-wrapped aggregate pointee") {
+    using choice = std::variant<std::unique_ptr<smart_ptr_test::partial_record>, std::string>;
+    choice sent  = std::make_unique<smart_ptr_test::partial_record>(smart_ptr_test::partial_record{.first = 7U, .second = "Ada"});
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
+    REQUIRE(enc(sent));
+    CHECK_EQ(to_hex(bytes), "820763416461");
+
+    choice decoded;
+    auto   dec = make_decoder<unique_ptr_codec>(bytes);
+    REQUIRE(dec(decoded));
+    REQUIRE_EQ(decoded.index(), 0U);
+    const auto &pointer = std::get<0>(decoded);
+    REQUIRE(pointer);
+    CHECK_EQ(pointer->first, 7U);
+    CHECK_EQ(pointer->second, "Ada");
+}
+
 TEST_CASE("unique_ptr decode keeps terminal partial pointee state") {
     const auto value = std::make_unique<smart_ptr_test::partial_record>(smart_ptr_test::partial_record{.first = 7U, .second = "Ada"});
     auto       bytes = smart_ptr_test::encode_unique(value);

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -759,6 +759,28 @@ TEST_CASE("unique pointer variant matches an array-wrapped aggregate pointee") {
     CHECK_EQ(pointer->second, "Ada");
 }
 
+TEST_CASE("unique pointer codec supports nested variants") {
+    using nested = std::variant<std::unique_ptr<std::uint64_t>, std::string>;
+    using choice = std::variant<nested, bool>;
+
+    choice sent{std::in_place_index<0>, nested{std::in_place_index<0>, std::make_unique<std::uint64_t>(7U)}};
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
+    REQUIRE(enc(sent));
+    REQUIRE_EQ(to_hex(bytes), "07");
+
+    choice decoded;
+    auto   dec = make_decoder<unique_ptr_codec>(bytes);
+    REQUIRE(dec(decoded));
+    REQUIRE_EQ(decoded.index(), 0U);
+    const auto &decoded_nested = std::get<0>(decoded);
+    REQUIRE_EQ(decoded_nested.index(), 0U);
+    const auto &pointer = std::get<0>(decoded_nested);
+    REQUIRE(pointer);
+    CHECK_EQ(*pointer, 7U);
+}
+
 TEST_CASE("unique_ptr decode keeps terminal partial pointee state") {
     const auto value = std::make_unique<smart_ptr_test::partial_record>(smart_ptr_test::partial_record{.first = 7U, .second = "Ada"});
     auto       bytes = smart_ptr_test::encode_unique(value);


### PR DESCRIPTION
## Summary

- match array-wrapped aggregate pointees by their actual outer CBOR array shape
- reject automatic unique-pointer variant dispatch when an installed codec changes an alternative's outer wire shape
- direct protocol-specific variants to an explicit whole-variant codec

## Red / green commits

1. `test(smart-ptr): reproduce variant wire-shape gaps` adds a failing aggregate roundtrip and a compile-fail expectation that fails on #93 because the unsafe custom-codec variant compiles.
2. `fix(smart-ptr): classify unique variant wire shapes` derives reflected aggregate shapes from decoder options and adds codec-awareness to the support gate.

## Validation

- aggregate repro: 7/7 assertions passed after the fix
- custom-codec contract CTest passed after the fix
- `ctest --test-dir build --output-on-failure` (55/55 passed)
- `scripts/format-cxx.sh --check`

The decoder does not trial-decode or roll back alternatives. A custom codec may choose any wire policy, so the only sound generic behavior is a compile-time rejection and an explicit whole-variant codec.

Stacked on #93 for focused review.
