### PR TITLE
fix(smart-ptr): prioritize exact simple variant matches

### DIFF
--- a/doc/smart_pointers.md
+++ b/doc/smart_pointers.md
@@ -387,6 +387,10 @@ outer wire shape to be independent of an installed custom codec. If a codec
 changes an alternative's outer tag or major type, define an explicit codec for
 the whole variant so it can apply that protocol-specific discriminator.
 
+For major type 7, exact alternatives such as `bool`, `nullptr_t`, and
+pointer-null are selected before the `simple` catch-all, regardless of variant
+order.
+
 An ordinary `std::optional` cannot directly contain a smart pointer. Both the
 empty optional and the empty pointer would encode as CBOR `null`. A named-map
 field can still distinguish an omitted optional field from a present field

--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -394,17 +394,17 @@ template <typename Decoder, typename T> consteval bool unique_variant_alternativ
     }
 }
 
-template <typename Decoder, typename T>
+template <typename Decoder, bool CatchAllPass, typename T>
 [[nodiscard]] constexpr bool unique_variant_matches(major_type major, std::byte additional_info, const std::optional<std::uint64_t> &tag) {
     using type = std::remove_cvref_t<T>;
     if constexpr (UniquePointer<type>) {
         if (major == major_type::Simple && additional_info == static_cast<std::byte>(SimpleType::Null)) {
             return true;
         }
-        return unique_variant_matches<Decoder, pointer_element_t<type>>(major, additional_info, tag);
+        return unique_variant_matches<Decoder, CatchAllPass, pointer_element_t<type>>(major, additional_info, tag);
     } else if constexpr (IsVariant<type>) {
         return cbor::tags::detail::with_variant_alternatives<type>(
-            [&]<typename... Ts>() { return (unique_variant_matches<Decoder, Ts>(major, additional_info, tag) || ...); });
+            [&]<typename... Ts>() { return (unique_variant_matches<Decoder, CatchAllPass, Ts>(major, additional_info, tag) || ...); });
     } else if (major == major_type::Tag) {
         if (!tag.has_value()) {
             return false;
@@ -422,7 +422,8 @@ template <typename Decoder, typename T>
         if constexpr (item_count > 1U && Decoder::options::wrap_groups) {
             return major == major_type::Array;
         } else if constexpr (item_count == 1U) {
-            return unique_variant_matches<Decoder, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>(major, additional_info, tag);
+            return unique_variant_matches<Decoder, CatchAllPass, std::tuple_element_t<0U, std::remove_cvref_t<tuple_type>>>(
+                major, additional_info, tag);
         } else {
             return false;
         }
@@ -431,8 +432,7 @@ template <typename Decoder, typename T>
             return false;
         }
         if (major == major_type::Simple) {
-            return cbor::tags::detail::matches_simple_dispatch<false, type>(additional_info) ||
-                   cbor::tags::detail::matches_simple_dispatch<true, type>(additional_info);
+            return cbor::tags::detail::matches_simple_dispatch<CatchAllPass, type>(additional_info);
         }
         return true;
     }
@@ -483,19 +483,26 @@ template <typename Decoder, IsVariant Variant>
     status_code result   = status_code::no_match_in_variant_on_buffer;
     bool        selected = false;
 
-    cbor::tags::detail::with_variant_alternative_indices<variant_type>([&]<std::size_t... Is>() {
-        auto select = [&]<std::size_t I>() {
-            using alternative_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
-            if (selected || !unique_variant_matches<Decoder, alternative_type>(major, additional_info, tag)) {
-                return;
-            }
-            selected = true;
-            cbor::tags::detail::variant_assign<I>(value, alternative_type{});
-            auto &alternative = cbor::tags::detail::variant_get<I>(value);
-            result            = decode_unique_variant_alternative(dec, alternative, major, additional_info, tag);
-        };
-        (select.template operator()<Is>(), ...);
-    });
+    auto select_pass = [&]<bool CatchAllPass>() {
+        cbor::tags::detail::with_variant_alternative_indices<variant_type>([&]<std::size_t... Is>() {
+            auto select = [&]<std::size_t I>() {
+                using alternative_type = cbor::tags::detail::variant_alternative_t<I, variant_type>;
+                if (selected || !unique_variant_matches<Decoder, CatchAllPass, alternative_type>(major, additional_info, tag)) {
+                    return;
+                }
+                selected = true;
+                cbor::tags::detail::variant_assign<I>(value, alternative_type{});
+                auto &alternative = cbor::tags::detail::variant_get<I>(value);
+                result            = decode_unique_variant_alternative(dec, alternative, major, additional_info, tag);
+            };
+            (select.template operator()<Is>(), ...);
+        });
+    };
+
+    select_pass.template operator()<false>();
+    if (!selected && major == major_type::Simple) {
+        select_pass.template operator()<true>();
+    }
 
     return result;
 }

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -840,6 +840,13 @@ TEST_CASE("unique pointer variant prefers exact simple values over simple catch-
     const auto &pointer = std::get<1>(decoded);
     REQUIRE(pointer);
     CHECK(*pointer);
+
+    const auto null_bytes = to_bytes("f6");
+    choice     decoded_null;
+    auto       null_dec = make_decoder<unique_ptr_codec>(null_bytes);
+    REQUIRE(null_dec(decoded_null));
+    REQUIRE_EQ(decoded_null.index(), 1U);
+    CHECK_FALSE(std::get<1>(decoded_null));
 }
 
 TEST_CASE("unique_ptr decode keeps terminal partial pointee state") {

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -824,6 +824,24 @@ TEST_CASE("unique pointer codec supports nested variants") {
     CHECK_EQ(*pointer, 7U);
 }
 
+TEST_CASE("unique pointer variant prefers exact simple values over simple catch-all") {
+    using choice = std::variant<simple, std::unique_ptr<bool>>;
+    choice sent  = std::make_unique<bool>(true);
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<unique_ptr_codec>(bytes);
+    REQUIRE(enc(sent));
+    CHECK_EQ(to_hex(bytes), "f5");
+
+    choice decoded;
+    auto   dec = make_decoder<unique_ptr_codec>(bytes);
+    REQUIRE(dec(decoded));
+    REQUIRE_EQ(decoded.index(), 1U);
+    const auto &pointer = std::get<1>(decoded);
+    REQUIRE(pointer);
+    CHECK(*pointer);
+}
+
 TEST_CASE("unique_ptr decode keeps terminal partial pointee state") {
     const auto value = std::make_unique<smart_ptr_test::partial_record>(smart_ptr_test::partial_record{.first = 7U, .second = "Ada"});
     auto       bytes = smart_ptr_test::encode_unique(value);


### PR DESCRIPTION
## Summary

- dispatch exact major-type-7 alternatives before the `simple` catch-all
- preserve variant-order independence for `bool` and pointer-null wire values
- mirror the core decoder's existing two-pass simple dispatch

## Red / green commits

1. `test(smart-ptr): reproduce simple catch-all priority` shows `f5` selecting the first `simple` alternative instead of `unique_ptr<bool>`.
2. `fix(smart-ptr): prioritize exact simple variant matches` adds exact and catch-all passes, plus null-pointer edge coverage.

## Validation

- focused exact/catch-all test: 9/9 assertions passed
- related unique-pointer variant tests passed
- `ctest --test-dir build --output-on-failure` (54/54 passed)
- `scripts/format-cxx.sh --check`

Stacked on #93 for focused review.
