### PR TITLE
fix(concepts): require optional reset semantics

### DIFF
--- a/include/cbor_tags/cbor_concepts.h
+++ b/include/cbor_tags/cbor_concepts.h
@@ -656,10 +656,11 @@ concept IsTag = HasDynamicTag<T> || HasStaticTag<T> || HasInlineTag<T> || IsTagg
 
 template <typename T>
 concept IsOptional = requires(T t) {
-    typename T::value_type; // Must have a value_type
-    t.has_value();          // Must have has_value() method
-    t.value();              // Must have value() method
-    T{};                    // Must be default constructible (nullopt)
+    typename T::value_type;              // Must have a value_type
+    t.has_value();                       // Must have has_value() method
+    t.value();                           // Must have value() method
+    { t.reset() } -> std::same_as<void>; // Must support an explicit empty state
+    T{};                                 // Must be default constructible (nullopt)
 };
 
 template <typename T> struct is_variant : std::bool_constant<detail::VariantLike<std::remove_cvref_t<T>>> {};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -680,10 +680,19 @@ set_tests_properties(test_decode_stack_floor PROPERTIES LABELS resource TIMEOUT 
 
 check_cxx_compiler_flag("-funsigned-char" CBOR_TAGS_HAS_FUNSIGNED_CHAR)
 if(CBOR_TAGS_HAS_FUNSIGNED_CHAR)
-  add_executable(test_unsigned_char test_unsigned_char.cc)
+add_executable(test_unsigned_char test_unsigned_char.cc)
   target_compile_options(test_unsigned_char PRIVATE -funsigned-char)
   target_link_libraries(test_unsigned_char PRIVATE cbor::tags)
-  add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+
+add_executable(test_smart_ptr_expected_classification test_smart_ptr_expected_classification.cc)
+target_link_libraries(test_smart_ptr_expected_classification PRIVATE cbor::tags)
+set_target_properties(
+  test_smart_ptr_expected_classification
+  PROPERTIES CXX_STANDARD 23
+             CXX_STANDARD_REQUIRED ON
+             CXX_EXTENSIONS OFF)
+add_test(NAME test_smart_ptr_expected_classification COMMAND test_smart_ptr_expected_classification)
 endif()
 
 add_executable(test_smart_ptr_decode_allocations test_smart_ptr_decode_allocations.cc)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -680,10 +680,11 @@ set_tests_properties(test_decode_stack_floor PROPERTIES LABELS resource TIMEOUT 
 
 check_cxx_compiler_flag("-funsigned-char" CBOR_TAGS_HAS_FUNSIGNED_CHAR)
 if(CBOR_TAGS_HAS_FUNSIGNED_CHAR)
-add_executable(test_unsigned_char test_unsigned_char.cc)
+  add_executable(test_unsigned_char test_unsigned_char.cc)
   target_compile_options(test_unsigned_char PRIVATE -funsigned-char)
   target_link_libraries(test_unsigned_char PRIVATE cbor::tags)
-add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+  add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+endif()
 
 add_executable(test_smart_ptr_expected_classification test_smart_ptr_expected_classification.cc)
 target_link_libraries(test_smart_ptr_expected_classification PRIVATE cbor::tags)
@@ -693,7 +694,7 @@ set_target_properties(
              CXX_STANDARD_REQUIRED ON
              CXX_EXTENSIONS OFF)
 add_test(NAME test_smart_ptr_expected_classification COMMAND test_smart_ptr_expected_classification)
-endif()
+add_dependencies(tests test_smart_ptr_expected_classification)
 
 add_executable(test_smart_ptr_decode_allocations test_smart_ptr_decode_allocations.cc)
 target_link_libraries(test_smart_ptr_decode_allocations PRIVATE cbor::tags)

--- a/test/test_smart_ptr_expected_classification.cc
+++ b/test/test_smart_ptr_expected_classification.cc
@@ -1,0 +1,44 @@
+#include <version>
+
+#if __has_include(<expected>) && defined(__cpp_lib_expected) && __cpp_lib_expected >= 202202L
+
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/cbor_encoder.h"
+#include "cbor_tags/detail/cbor_pointer_traits.h"
+#include "cbor_tags/extensions/std_expected.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <vector>
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::std_expected;
+
+    using result_type = std::expected<std::uint64_t, std::string>;
+    static_assert(!IsOptional<result_type>);
+    static_assert(!cbor::tags::detail::has_known_null_wire_v<result_type>);
+
+    const result_type sent{std::unexpected<std::string>{"bad"}};
+
+    std::vector<std::byte> bytes;
+    auto                   enc = make_encoder<std_expected_codec>(bytes);
+    if (!enc(sent)) {
+        return 1;
+    }
+
+    result_type decoded;
+    auto        dec = make_decoder<std_expected_codec>(bytes);
+    if (!dec(decoded) || decoded.has_value() || decoded.error() != "bad") {
+        return 2;
+    }
+    return 0;
+}
+
+#else
+
+int main() { return 0; }
+
+#endif


### PR DESCRIPTION
## Summary

- require an optional-like type to expose `reset()` as an explicit empty-state operation
- stop classifying `std::expected<T,E>` as optional/null-capable
- add a C++23 regression target that verifies classification and the expected error roundtrip

## Red / green commits

1. `test(smart-ptr): reproduce expected optional misclassification` fails on #93 because `IsOptional<std::expected<...>>` and the pointer null-wire trait are both incorrectly true.
2. `fix(concepts): require optional reset semantics` distinguishes an empty optional state from expected's success/error states using method signatures only.

## Validation

- red target failed its two classification assertions on #93
- green C++23 target builds and passes
- `ctest --test-dir build --output-on-failure` (55/55 passed)
- `scripts/format-cxx.sh --check`

The target compiles as C++23 and becomes a no-op when the standard library does not provide `std::expected`.

Stacked on #93 for focused review.
