### PR TITLE
perf(smart-ptr): coallocate shared decode ownership

### DIFF
--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -647,10 +647,19 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
         requires std::default_initializable<typename std::remove_cvref_t<Pointer>::element_type>
     [[nodiscard]] status_code decode_shareable(Pointer &value) {
         using pointer_type = std::remove_cvref_t<Pointer>;
-        detail::reset_pointer_to_new(value);
+        using element_type = typename pointer_type::element_type;
+
+        std::shared_ptr<void> stored;
+        if constexpr (std::constructible_from<pointer_type, std::shared_ptr<element_type>>) {
+            auto owner = std::make_shared<element_type>();
+            value      = pointer_type{owner};
+            stored     = std::move(owner);
+        } else {
+            detail::reset_pointer_to_new(value);
+            stored = std::make_shared<pointer_type>(value);
+        }
 
         auto scope    = current_decode_scope();
-        auto stored   = std::make_shared<pointer_type>(value);
         auto inserted = scope.insert(
             shared_ptr_decode_entry{std::move(stored), detail::graph_type_id<pointer_type>(), shared_ptr_entry_state::encoding});
         if (!inserted) {
@@ -684,7 +693,11 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
             return status_code::error;
         }
 
-        value = *std::static_pointer_cast<pointer_type>(resolved->pointer);
+        if constexpr (std::constructible_from<pointer_type, std::shared_ptr<typename pointer_type::element_type>>) {
+            value = pointer_type{std::static_pointer_cast<typename pointer_type::element_type>(resolved->pointer)};
+        } else {
+            value = *std::static_pointer_cast<pointer_type>(resolved->pointer);
+        }
         return status_code::success;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -630,10 +630,14 @@ set_tests_properties(test_decode_stack_floor PROPERTIES LABELS resource TIMEOUT 
 
 check_cxx_compiler_flag("-funsigned-char" CBOR_TAGS_HAS_FUNSIGNED_CHAR)
 if(CBOR_TAGS_HAS_FUNSIGNED_CHAR)
-  add_executable(test_unsigned_char test_unsigned_char.cc)
+add_executable(test_unsigned_char test_unsigned_char.cc)
   target_compile_options(test_unsigned_char PRIVATE -funsigned-char)
   target_link_libraries(test_unsigned_char PRIVATE cbor::tags)
-  add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+add_test(NAME test_unsigned_char COMMAND test_unsigned_char)
+
+add_executable(test_smart_ptr_decode_allocations test_smart_ptr_decode_allocations.cc)
+target_link_libraries(test_smart_ptr_decode_allocations PRIVATE cbor::tags)
+add_test(NAME test_smart_ptr_decode_allocations COMMAND test_smart_ptr_decode_allocations)
 endif()
 
 if(TARGET cbor_tags_cli)

--- a/test/test_smart_ptr_decode_allocations.cc
+++ b/test/test_smart_ptr_decode_allocations.cc
@@ -1,0 +1,63 @@
+#include "cbor_tags/cbor_decoder.h"
+#include "cbor_tags/extensions/smart_ptr.h"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <new>
+
+namespace {
+
+std::atomic_bool         track_allocations{};
+std::atomic<std::size_t> allocation_count{};
+
+} // namespace
+
+void *operator new(std::size_t size) {
+    if (track_allocations.load(std::memory_order_relaxed)) {
+        allocation_count.fetch_add(1U, std::memory_order_relaxed);
+    }
+    if (void *pointer = std::malloc(size)) {
+        return pointer;
+    }
+    throw std::bad_alloc{};
+}
+
+void operator delete(void *pointer) noexcept { std::free(pointer); }
+void operator delete(void *pointer, std::size_t) noexcept { std::free(pointer); }
+
+int main() {
+    using namespace cbor::tags;
+    using namespace cbor::tags::ext::smart_ptr;
+
+    const std::array bytes{
+        std::byte{0xD8}, std::byte{0x1C}, std::byte{0x01}, std::byte{0xD8}, std::byte{0x1D}, std::byte{0x00},
+    };
+
+    shared_ptr_decode_scope table;
+    table.reserve(1U);
+    auto dec = make_decoder<shared_ptr_codec>(bytes);
+    dec.set_shared_ptr_scope(table);
+
+    std::shared_ptr<std::uint64_t> first;
+    allocation_count.store(0U, std::memory_order_relaxed);
+    track_allocations.store(true, std::memory_order_relaxed);
+    const auto first_result = dec(first);
+    track_allocations.store(false, std::memory_order_relaxed);
+    if (!first_result || !first || *first != 1U || allocation_count.load(std::memory_order_relaxed) != 1U) {
+        return 1;
+    }
+
+    std::shared_ptr<std::uint64_t> second;
+    allocation_count.store(0U, std::memory_order_relaxed);
+    track_allocations.store(true, std::memory_order_relaxed);
+    const auto second_result = dec(second);
+    track_allocations.store(false, std::memory_order_relaxed);
+    if (!second_result || first != second || allocation_count.load(std::memory_order_relaxed) != 0U) {
+        return 2;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

- coallocate a decoded pointee and its shared ownership block when the structural pointer accepts a standard shared owner
- store that owner directly in the type-erased decode table instead of allocating a boxed pointer copy
- retain the generic fallback for other user-defined shared pointer types

## Red / green commits

1. `test(smart-ptr): reproduce shared decode allocations` adds a dedicated allocation-count executable. With a pre-reserved table, #93 performs 3 allocations for the first tag-28 decode.
2. `perf(smart-ptr): coallocate shared decode ownership` reduces the first decode to 1 allocation and keeps tag-29 resolution at 0 allocations.

## Validation

- allocation contract: first shareable = 1, shared reference = 0
- `ctest --test-dir build --output-on-failure` (55/55 passed)
- existing standard and user-defined shared-pointer roundtrips passed
- `scripts/format-cxx.sh --check`

This PR overlaps the pointer-construction area in #97. The optimized path is allocation-safe by construction; #97 still owns the generic fallback's exception-safety fix.

Stacked on #93 for focused review.
