### PR TITLE
fix(smart-ptr): avoid optimized scope reset crash

### DIFF
--- a/include/cbor_tags/extensions/smart_ptr.h
+++ b/include/cbor_tags/extensions/smart_ptr.h
@@ -585,16 +585,25 @@ template <typename Self> struct shared_ptr_codec : cbor_codec_mixin_base<Self> {
         external_decode_scope_.reset();
     }
 
+    // MSVC 19.50 miscompiles reset through the temporary erased wrapper returned by current_*_scope() in optimized builds.
     template <typename S = Self>
         requires detail::EncoderSelf<S>
     void reset_shared_ptr_scope() {
-        current_encode_scope().reset();
+        if (external_encode_scope_) {
+            external_encode_scope_->reset();
+        } else {
+            default_encode_scope_.reset();
+        }
     }
 
     template <typename S = Self>
         requires detail::DecoderSelf<S>
     void reset_shared_ptr_scope() {
-        current_decode_scope().reset();
+        if (external_decode_scope_) {
+            external_decode_scope_->reset();
+        } else {
+            default_decode_scope_.reset();
+        }
     }
 
     template <typename S = Self>

--- a/test/test_smart_ptr.cpp
+++ b/test/test_smart_ptr.cpp
@@ -1087,6 +1087,34 @@ TEST_CASE("default shared_ptr scope persists until explicitly reset") {
     CHECK(first != second);
 }
 
+TEST_CASE("external shared_ptr scope resets through the codec") {
+    auto value = std::make_shared<std::uint64_t>(1U);
+
+    smart_ptr_test::encode_table encode_table;
+    std::vector<std::byte>       bytes;
+    auto                         enc = make_encoder<shared_ptr_codec>(bytes);
+    enc.set_shared_ptr_scope(encode_table);
+    REQUIRE(enc(value));
+    enc.reset_shared_ptr_scope();
+    *value = 2U;
+    REQUIRE(enc(value));
+    CHECK_EQ(to_hex(bytes), "d81c01d81c02");
+
+    smart_ptr_test::decode_table   decode_table;
+    std::shared_ptr<std::uint64_t> first;
+    std::shared_ptr<std::uint64_t> second;
+    auto                           dec = make_decoder<shared_ptr_codec>(bytes);
+    dec.set_shared_ptr_scope(decode_table);
+    REQUIRE(dec(first));
+    dec.reset_shared_ptr_scope();
+    REQUIRE(dec(second));
+    REQUIRE(first);
+    REQUIRE(second);
+    CHECK_EQ(*first, 1U);
+    CHECK_EQ(*second, 2U);
+    CHECK(first != second);
+}
+
 TEST_CASE("shared_ptr use needs no root wrapper") {
     auto value = std::make_shared<std::uint64_t>(1U);
 


### PR DESCRIPTION
## What changed

- Reset codec-owned shared-pointer scopes directly instead of routing them through a temporary type-erased scope reference.
- Keep caller-owned scopes on the persistent erased-reference path.
- Add round-trip coverage for resetting caller-owned encode and decode scopes through the codec.

## Why

Master's optimized MSVC 19.50 builds with magic_enum crashed at dec.reset_shared_ptr_scope(). The test passed all assertions before the reset and also passed under ASan, identifying an optimizer-sensitive failure in the temporary erased-wrapper call. Directly resetting the owned scope avoids that call shape while preserving external scope behavior.

Failing master run: https://github.com/jkammerland/cbor_tags/actions/runs/30767483711

## Validation

- Visual Studio 2026 MSVC 19.50, Release, C++20, magic_enum: 59/59 tests passed.
- GCC 16 Debug: 60/60 tests passed.
- scripts/format-cxx.sh --check
- scripts/lint-cxx.sh
